### PR TITLE
Miscellaneous fixups to our C++11 support

### DIFF
--- a/contrib/C++11/cpp11.h
+++ b/contrib/C++11/cpp11.h
@@ -21,6 +21,10 @@
 // If Boost.Thread is used, we want it to provide the new name for its <future> class
 #define BOOST_THREAD_PROVIDES_FUTURE
 
+#ifndef __has_feature
+  #define __has_feature(x) (AUTOWIRE_##x)
+#endif
+
 /*********************
  * __func__ function name support
  *********************/
@@ -144,8 +148,10 @@
  * noexcept support
  *********************/
 #ifdef _MSC_VER
+  #define AUTOWIRE_cxx_noexcept 0
   #define NOEXCEPT(x)
 #else
+  #define AUTOWIRE_cxx_noexcept 1
   #define NOEXCEPT(x) x noexcept
 #endif
 

--- a/src/autonet/stdafx.h
+++ b/src/autonet/stdafx.h
@@ -11,9 +11,4 @@
 // C++11 glue logic, for platforms that have incomplete C++11 support
 #include "C++11/cpp11.h"
 
-// Very unusual syntax -- function taking an array of fixed size, and returning
-// a character array of that same size
-template<class T, int n>
-const char (&ArraySize(const T (&vals)[n]))[n];
-
 #define ARRAYCOUNT(x) sizeof(ArraySize(x))


### PR DESCRIPTION
These fixups are required to get websocketpp building on Linux platforms, due to differences in how platform support for nothrow is detected.
