### PR TITLE
Switching EnclosedContextTestBase to be a filter rather than a base type

### DIFF
--- a/src/autowiring/test/AnySharedPointerTest.hpp
+++ b/src/autowiring/test/AnySharedPointerTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class AnySharedPointerTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/AutoAnchorTest.hpp
+++ b/src/autowiring/test/AutoAnchorTest.hpp
@@ -1,8 +1,7 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class AutoAnchorTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};
 

--- a/src/autowiring/test/AutoFilterTest.hpp
+++ b/src/autowiring/test/AutoFilterTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class AutoFilterTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/AutoInjectableTest.hpp
+++ b/src/autowiring/test/AutoInjectableTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class AutoInjectableTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/AutoPacketFactoryTest.hpp
+++ b/src/autowiring/test/AutoPacketFactoryTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class AutoPacketFactoryTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/AutowiringBenchmarkTest.hpp
+++ b/src/autowiring/test/AutowiringBenchmarkTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class AutowiringBenchmarkTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/AutowiringTest.cpp
+++ b/src/autowiring/test/AutowiringTest.cpp
@@ -8,7 +8,7 @@
 
 TEST_F(AutowiringTest, VerifyAutowiredFast) {
   // Add an object:
-  m_create->Inject<SimpleObject>();
+  AutoCurrentContext()->Inject<SimpleObject>();
 
   // Verify that AutowiredFast can find this object
   AutowiredFast<SimpleObject> sobj;

--- a/src/autowiring/test/AutowiringTest.hpp
+++ b/src/autowiring/test/AutowiringTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class AutowiringTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/AutowiringUtilitiesTest.hpp
+++ b/src/autowiring/test/AutowiringUtilitiesTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class AutowiringUtilitiesTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/BasicThreadTest.hpp
+++ b/src/autowiring/test/BasicThreadTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class BasicThreadTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/BoltTest.cpp
+++ b/src/autowiring/test/BoltTest.cpp
@@ -80,9 +80,10 @@ public:
 };
 
 TEST_F(BoltTest, VerifySimpleInjection) {
+  AutoCurrentContext ctxt;
   AutoEnable<InjectsIntoPipeline>();
 
-  auto created = m_create->Create<Pipeline>();
+  auto created = ctxt->Create<Pipeline>();
 
   // Verify that the SimpleObject didn't accidentally get injected out here:
   {
@@ -143,10 +144,11 @@ TEST_F(BoltTest, VerifyCreationBubbling) {
 }
 
 TEST_F(BoltTest, VerifyMultipleInjection) {
+  AutoCurrentContext ctxt;
   AutoEnable<InjectsIntoBoth>();
 
-  auto created = m_create->Create<Pipeline>();
-  auto created2 = m_create->Create<OtherContext>();
+  auto created = ctxt->Create<Pipeline>();
+  auto created2 = ctxt->Create<OtherContext>();
 
   // Verify that the SimpleObject didn't accidentally get injected out here:
   {
@@ -168,6 +170,7 @@ TEST_F(BoltTest, VerifyMultipleInjection) {
 }
 
 TEST_F(BoltTest, EmptyBolt) {
+  AutoCurrentContext ctxt;
   AutoEnable<InjectsIntoEverything>();
   Autowired<CountObject> so;
   EXPECT_FALSE(so.IsAutowired()) << "CountObject injected into outer context";
@@ -180,7 +183,7 @@ TEST_F(BoltTest, EmptyBolt) {
     ASSERT_EQ(1, innerSo->count) << "ContextCreated() called incorrect number of times";
   }
 
-  auto created2 = m_create->Create<Pipeline>();
+  auto created2 = ctxt->Create<Pipeline>();
   {
     CurrentContextPusher pshr(created2);
     Autowired<CountObject> innerSo;

--- a/src/autowiring/test/BoltTest.hpp
+++ b/src/autowiring/test/BoltTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class BoltTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -42,6 +42,7 @@ set(AutowiringTest_SRCS
   DtorCorrectnessTest.hpp
   DtorCorrectnessTest.cpp
   EnclosedContextTestBase.hpp
+  EnclosedContextTestBase.cpp
   ExceptionFilterTest.hpp
   ExceptionFilterTest.cpp
   EventReceiverTest.hpp

--- a/src/autowiring/test/ContextCleanupTest.cpp
+++ b/src/autowiring/test/ContextCleanupTest.cpp
@@ -137,7 +137,8 @@ public:
 };
 
 TEST_F(ContextCleanupTest, VerifyGracefulThreadCleanup) {
-  m_create->Initiate();
+  AutoCurrentContext ctxt;
+  ctxt->Initiate();
   AutoRequired<CoreThread> ct;
 
   // Just create a CoreThread directly and have it pend some lambdas that will take awhile to run:
@@ -148,12 +149,13 @@ TEST_F(ContextCleanupTest, VerifyGracefulThreadCleanup) {
   *ct += [called] { *called = true; };
 
   // Verify that a graceful shutdown ensures both lambdas are called:
-  m_create->SignalShutdown(true, ShutdownMode::Graceful);
+  ctxt->SignalShutdown(true, ShutdownMode::Graceful);
   ASSERT_TRUE(*called) << "Graceful shutdown did not correctly run down all lambdas";
 }
 
 TEST_F(ContextCleanupTest, VerifyImmediateThreadCleanup) {
-  m_create->Initiate();
+  AutoCurrentContext ctxt;
+  ctxt->Initiate();
   AutoRequired<CoreThread> ct;
 
   // Just create a CoreThread directly and have it pend some lambdas that will take awhile to run:
@@ -172,7 +174,7 @@ TEST_F(ContextCleanupTest, VerifyImmediateThreadCleanup) {
   *ct += [called] { *called = true; };
 
   // Verify that a graceful shutdown ensures both lambdas are called:
-  m_create->SignalTerminate(true);
+  ctxt->SignalTerminate(true);
   ASSERT_FALSE(*called) << "Immediate shutdown incorrectly ran down the dispatch queue";
 }
 
@@ -210,22 +212,23 @@ public:
 
 TEST_F(ContextCleanupTest, VerifyThreadShutdownInterleave) {
   // Record the initial use count:
-  auto initCount = m_create.use_count();
+  AutoCurrentContext ctxt;
+  auto initCount = ctxt.use_count();
 
   // Create a thread that will take awhile to stop:
   AutoRequired<TakesALongTimeToExit> longTime;
 
   // We want threads to run as soon as they are added:
-  m_create->Initiate();
+  ctxt->Initiate();
 
   // Make the thread exit before the enclosing context exits:
   longTime->Continue();
   longTime->Stop();
 
   // Now stop the context and perform an explicit wait
-  m_create->SignalShutdown(true);
+  ctxt->SignalShutdown(true);
 
   // At this point, the thread must have returned AND released its shared pointer to the enclosing context
-  EXPECT_EQ(initCount, m_create.use_count()) << "Context thread persisted even after it should have fallen out of scope";
+  EXPECT_EQ(initCount, ctxt.use_count()) << "Context thread persisted even after it should have fallen out of scope";
 }
 

--- a/src/autowiring/test/ContextCleanupTest.hpp
+++ b/src/autowiring/test/ContextCleanupTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class ContextCleanupTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/ContextCreatorTest.hpp
+++ b/src/autowiring/test/ContextCreatorTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class ContextCreatorTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/ContextEnumeratorTest.hpp
+++ b/src/autowiring/test/ContextEnumeratorTest.hpp
@@ -3,5 +3,5 @@
 #include "EnclosedContextTestBase.hpp"
 
 class ContextEnumeratorTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/ContextMapTest.hpp
+++ b/src/autowiring/test/ContextMapTest.hpp
@@ -1,11 +1,8 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
-#ifndef _CONTEXT_MAP_TEST_H
-#define _CONTEXT_MAP_TEST_H
-#include <gtest/gtest.h>
+#pragma once
 
 class ContextMapTest:
   public testing::Test
 {
 };
 
-#endif

--- a/src/autowiring/test/ContextMemberTest.hpp
+++ b/src/autowiring/test/ContextMemberTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class ContextMemberTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -12,6 +12,8 @@ class Bar{};
 class Baz{};
 
 TEST_F(CoreContextTest, TestEnumerateChildren) {
+  AutoCurrentContext ctxt;
+
   // Create a few anonymous children:
   AutoCreateContext child1;
   AutoCreateContext child2;
@@ -26,7 +28,7 @@ TEST_F(CoreContextTest, TestEnumerateChildren) {
   ASSERT_EQ(4UL, allChildren.size()) << "Failed to enumerate the correct number of child contexts";
 
   // Verify full membership:
-  ASSERT_EQ(1UL, allChildren.count(m_create)) << "Failed to find the root context in the returned context collection";
+  ASSERT_EQ(1UL, allChildren.count(ctxt)) << "Failed to find the root context in the returned context collection";
 
   const char* childMissing = "Failed to find a child context in the set of children";
   ASSERT_EQ(1UL, allChildren.count(child1)) << childMissing;
@@ -38,23 +40,25 @@ TEST_F(CoreContextTest, TestEnumerateChildren) {
   AutoCreateContextT<Bar> barCtxt;
   auto childFoo = barCtxt->Create<Foo>();
 
-  ContextEnumeratorT<Foo> enumerator1(m_create);
+  ContextEnumeratorT<Foo> enumerator1(ctxt);
   std::vector<std::shared_ptr<CoreContext>> onlyFoos(enumerator1.begin(), enumerator1.end());
   ASSERT_EQ(2UL, onlyFoos.size()) << "Didn't collect only contexts with 'Foo' sigil";
   ASSERT_NE(std::find(onlyFoos.begin(), onlyFoos.end(), fooCtxt), onlyFoos.end()) << "Context not enumerated";
   ASSERT_NE(std::find(onlyFoos.begin(), onlyFoos.end(), childFoo), onlyFoos.end()) << "Context not enumerated";
 
-  ContextEnumeratorT<Bar> enumerator2(m_create);
+  ContextEnumeratorT<Bar> enumerator2(ctxt);
   std::vector<std::shared_ptr<CoreContext>> onlyBars(enumerator2.begin(), enumerator2.end());
   ASSERT_EQ(1UL, onlyBars.size()) << "Didn't collect only contexts with 'Bar' sigil";
   ASSERT_NE(std::find(onlyBars.begin(), onlyBars.end(), barCtxt), onlyBars.end()) << "Context not enumerated";
 
-  ContextEnumeratorT<Baz> enumerator3(m_create);
+  ContextEnumeratorT<Baz> enumerator3(ctxt);
   std::vector<std::shared_ptr<CoreContext>> noBaz(enumerator3.begin(), enumerator3.end());
   ASSERT_TRUE(noBaz.empty()) << "Incorrectly collected contexts with 'Baz' sigil";
 }
 
 TEST_F(CoreContextTest, TestEarlyLambdaReturn) {
+  AutoCurrentContext ctxt;
+
   // Create three children:
   AutoCreateContext child1;
   AutoCreateContext child2;
@@ -72,7 +76,7 @@ TEST_F(CoreContextTest, TestEarlyLambdaReturn) {
   ASSERT_EQ(3UL, allChildren.size()) << "Enumeration routine failed to quit early";
 
   // Verify that the root context is the first one enumerated--needed to assure that we are executing a depth-first search
-  ASSERT_EQ(m_create, allChildren[0]) << "EnumerateChildContexts did not execute depth-first";
+  ASSERT_EQ(ctxt, allChildren[0]) << "EnumerateChildContexts did not execute depth-first";
 }
 
 /// <summary>

--- a/src/autowiring/test/CoreContextTest.hpp
+++ b/src/autowiring/test/CoreContextTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class CoreContextTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/CoreJobTest.cpp
+++ b/src/autowiring/test/CoreJobTest.cpp
@@ -7,25 +7,26 @@
 
 TEST_F(CoreJobTest, VerifySimpleProperties) {
   AutoRequired<CoreJob> jb;
+  AutoCurrentContext ctxt;
 
-  ASSERT_FALSE(m_create->IsInitiated()) << "CoreJob reported it could receive events before its enclosing context was created";
+  ASSERT_FALSE(ctxt->IsInitiated()) << "CoreJob reported it could receive events before its enclosing context was created";
 
   // Create a thread which will delay for acceptance, and then quit:
-  auto future = std::async(std::launch::async, [this] {
-    m_create->DelayUntilInitiated();
+  auto future = std::async(std::launch::async, [this, &ctxt] {
+    ctxt->DelayUntilInitiated();
   });
 
   // Verify that this thread doesn't back out right away:
   ASSERT_EQ(std::future_status::timeout, future.wait_for(std::chrono::milliseconds(10))) << "CoreJob did not block a client who was waiting for its readiness to accept dispatchers";
 
   // Now start the context and verify that certain properties changed as anticipated:
-  m_create->Initiate();
-  ASSERT_TRUE(m_create->DelayUntilInitiated()) << "CoreJob did not correctly delay for dispatch acceptance";
+  ctxt->Initiate();
+  ASSERT_TRUE(ctxt->DelayUntilInitiated()) << "CoreJob did not correctly delay for dispatch acceptance";
 
   // Verify that the blocked thread has become unblocked and quits properly:
   ASSERT_EQ(std::future_status::ready, future.wait_for(std::chrono::seconds(1))) << "CoreJob did not correctly signal a blocked thread that it was ready to accept dispatchers";
 
-  m_create->SignalShutdown(true);
+  ctxt->SignalShutdown(true);
 }
 
 TEST_F(CoreJobTest, VerifySimpleSubmission) {

--- a/src/autowiring/test/CoreJobTest.hpp
+++ b/src/autowiring/test/CoreJobTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class CoreJobTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/CoreThreadTest.hpp
+++ b/src/autowiring/test/CoreThreadTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class CoreThreadTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/CurrentContextPusherTest.hpp
+++ b/src/autowiring/test/CurrentContextPusherTest.hpp
@@ -1,6 +1,5 @@
 // Copyright (c) 2010 - 2013 Leap Motion. All rights reserved. Proprietary and confidential.
 #pragma once
-#include <gtest/gtest.h>
 
 class CurrentContextPusherTest:
   public testing::Test

--- a/src/autowiring/test/DecoratorTest.hpp
+++ b/src/autowiring/test/DecoratorTest.hpp
@@ -1,9 +1,8 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class DecoratorTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {
 public:
   DecoratorTest(void);

--- a/src/autowiring/test/DispatchQueueTest.cpp
+++ b/src/autowiring/test/DispatchQueueTest.cpp
@@ -48,7 +48,8 @@ TEST_F(DispatchQueueTest, PathologicalStartAndStop){
   AutoRequired<Thread<2>> t2;
   AutoRequired<Thread<3>> t3;
   AutoRequired<Thread<4>> t4;
-  m_create->Initiate();
+  AutoCurrentContext ctxt;
+  ctxt->Initiate();
 
   // We don't need a strong guarantee that these threads exit in a timely fashion, just that they
   // do so _eventually_.

--- a/src/autowiring/test/DispatchQueueTest.hpp
+++ b/src/autowiring/test/DispatchQueueTest.hpp
@@ -1,10 +1,9 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class DispatchQueue;
 
 class DispatchQueueTest:
-  public EnclosedContextTestBase,
+  public testing::Test,
   public DispatchQueue
 {};

--- a/src/autowiring/test/DtorCorrectnessTest.cpp
+++ b/src/autowiring/test/DtorCorrectnessTest.cpp
@@ -120,7 +120,6 @@ TEST_F(DtorCorrectnessTest, VerifyDeferringDtors) {
   EXPECT_TRUE(listener2->m_hitDeferred) << "Failed to hit a listener's deferred call";
 
   // Release all of our pointers:
-  m_create.reset();
   listener1.reset();
   listener2.reset();
 

--- a/src/autowiring/test/DtorCorrectnessTest.hpp
+++ b/src/autowiring/test/DtorCorrectnessTest.hpp
@@ -1,13 +1,12 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class CtorDtorListener;
 template<int i>
 class MyCtorDtorListenerN;
 
 class DtorCorrectnessTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {
 public:
   DtorCorrectnessTest(void);

--- a/src/autowiring/test/EnclosedContextTestBase.cpp
+++ b/src/autowiring/test/EnclosedContextTestBase.cpp
@@ -1,0 +1,61 @@
+#include "stdafx.h"
+#include "EnclosedContextTestBase.hpp"
+
+struct TestInfoProxy {
+  TestInfoProxy(const testing::TestInfo& info) :
+    m_info(info)
+  {}
+
+  const testing::TestInfo& m_info;
+};
+
+void EnclosedContextTestBase::OnTestStart(const testing::TestInfo& info) {
+  AutoRequired<EnclosedContextExceptionFilter> filter;
+
+  // The context proper.  This is automatically assigned as the current
+  // context when SetUp is invoked.
+  AutoCreateContext create;
+  create->Construct<TestInfoProxy>(info);
+
+  // Add exception filter in this context:
+  create->Inject<EnclosedContextExceptionFilter>();
+
+  // Now make it current and let the test run:
+  create->SetCurrent();
+}
+
+void EnclosedContextTestBase::OnTestEnd(const testing::TestInfo& info) {
+  // Verify we can grab the test case back out and that the pointer is correct:
+  Autowired<TestInfoProxy> ti;
+  Autowired<EnclosedContextExceptionFilter> ecef;
+  auto ctxt = ecef ? ecef->GetContext() : nullptr;
+
+  // Unconditionally reset the global context as the current context
+  AutoGlobalContext()->SetCurrent();
+
+  // Global initialization tests are special, we don't bother checking closure principle on them:
+  if(!strcmp("GlobalInitTest", info.test_case_name()))
+    return;
+
+  // Need to make sure we got back our exception filter before continuing:
+  ASSERT_TRUE(ecef.IsAutowired()) << "Failed to find the enclosed context exception filter; unit test may have incorrectly reset the enclosing context before returning";
+
+  // Now try to tear down the test context enclosure:
+  ctxt->SignalShutdown();
+
+  // Do not allow teardown to take more than 250 milliseconds or so
+  if(!ctxt->Wait(std::chrono::milliseconds(250))) {
+    // Critical error--took too long to tear down
+    assert(false);
+  }
+
+  static const char sc_autothrow[] = "AUTOTHROW_";
+  if(!strncmp(sc_autothrow, info.name(), ARRAYCOUNT(sc_autothrow) - 1))
+    // Throw expected, end here
+    return;
+
+  // If an exception occurred somewhere, report it:
+  ASSERT_FALSE(ecef->m_excepted)
+    << "An unhandled exception occurred in this context" << std::endl
+    << "[" << (ecef->m_ti ? ecef->m_ti->name() : "unknown") << "] " << ecef->m_what;
+}

--- a/src/autowiring/test/EventReceiverTest.cpp
+++ b/src/autowiring/test/EventReceiverTest.cpp
@@ -304,11 +304,12 @@ TEST_F(EventReceiverTest, PathologicalTransmitterTest) {
 }
 
 TEST_F(EventReceiverTest, VerifyDirectInvocation) {
+  AutoCurrentContext ctxt;
   AutoRequired<SimpleReceiver> receiver;
 
   // Indirect invocation:
-  m_create->Invoke(&CallableInterface::ZeroArgs)();
-  m_create->Invoke(&CallableInterface::OneArg)(100);
+  ctxt->Invoke(&CallableInterface::ZeroArgs)();
+  ctxt->Invoke(&CallableInterface::OneArg)(100);
 
   // Verify that stuff happens even when the thread isn't running:
   EXPECT_TRUE(receiver->m_zero);

--- a/src/autowiring/test/EventReceiverTest.hpp
+++ b/src/autowiring/test/EventReceiverTest.hpp
@@ -1,9 +1,8 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class EventReceiverTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {
 public:
   EventReceiverTest(void);

--- a/src/autowiring/test/ExceptionFilterTest.cpp
+++ b/src/autowiring/test/ExceptionFilterTest.cpp
@@ -82,7 +82,7 @@ public:
   }
 };
 
-TEST_F(ExceptionFilterTest, ExceptionDestruction) {
+TEST_F(ExceptionFilterTest, AUTOTHROW_ExceptionDestruction) {
   // Add the exception filter type to the context first
   AutoRequired<GenericFilter> filter;
 
@@ -90,7 +90,7 @@ TEST_F(ExceptionFilterTest, ExceptionDestruction) {
   AutoRequired<ThrowsWhenRun<tracking_exception>> thrower;
 
   // Run:
-  m_create->Initiate();
+  AutoCurrentContext()->Initiate();
   thrower->Wait();
 
   // Verify that the exception was destroyed the correct number of times:
@@ -108,7 +108,7 @@ TEST_F(ExceptionFilterTest, CheckThrowThrow) {
   EXPECT_THROW(throw example(), std::exception) << "An exception type which throws from its ctor did not throw the expected type";
 }
 
-TEST_F(ExceptionFilterTest, ThreadThrowsCheck) {
+TEST_F(ExceptionFilterTest, AUTOTHROW_ThreadThrowsCheck) {
   // Add the exception filter type to the context first
   AutoRequired<GenericFilter> filter;
 
@@ -116,7 +116,7 @@ TEST_F(ExceptionFilterTest, ThreadThrowsCheck) {
   AutoRequired<ThrowsWhenRun<custom_exception>> thrower;
 
   // Wait for the thrower to terminate, should be pretty fast:
-  m_create->Initiate();
+  AutoCurrentContext()->Initiate();
   thrower->Wait();
 
   // Hopefully the filter got hit in the right spot:
@@ -160,10 +160,10 @@ TEST_F(ExceptionFilterTest, FireContainmentCheck) {
   EXPECT_TRUE(ctxt->IsShutdown()) << "An unhandled exception from a fire call in a context should have signalled it to stop";
 
   // Verify that the parent context was protected:
-  EXPECT_FALSE(m_create->IsShutdown()) << "An unhandled exception incorrectly terminated a parent context";
+  EXPECT_FALSE(AutoCurrentContext()->IsShutdown()) << "An unhandled exception incorrectly terminated a parent context";
 }
 
-TEST_F(ExceptionFilterTest, EnclosedThrowCheck) {
+TEST_F(ExceptionFilterTest, AUTOTHROW_EnclosedThrowCheck) {
   // Create our listener:
   AutoRequired<GenericFilter> filter;
 
@@ -209,7 +209,8 @@ TEST_F(ExceptionFilterTest, ExceptionFirewall) {
 }
 
 TEST_F(ExceptionFilterTest, VerifySimpleConfinement) {
-  m_create->Initiate();
+  AutoCurrentContext ctxt;
+  ctxt->Initiate();
 
   // Create a subcontext where the errant recipients will live:
   AutoCreateContext child;
@@ -224,7 +225,7 @@ TEST_F(ExceptionFilterTest, VerifySimpleConfinement) {
   tl(&ThrowingListener::DoThrow)();
 
   // Verify that the parent scope wasn't incorrectly terminated:
-  EXPECT_FALSE(m_create->IsShutdown()) << "Parent scope was terminated incorrectly due to an exception sourced by a child context";
+  EXPECT_FALSE(ctxt->IsShutdown()) << "Parent scope was terminated incorrectly due to an exception sourced by a child context";
 
   // Verify that the child scope was terminated as expected:
   EXPECT_TRUE(child->IsShutdown()) << "An event recipient in a child scope threw an exception and the child context was not correctly terminated";

--- a/src/autowiring/test/ExceptionFilterTest.hpp
+++ b/src/autowiring/test/ExceptionFilterTest.hpp
@@ -1,8 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
 
-#include "EnclosedContextTestBase.hpp"
-
 class ExceptionFilterTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/FactoryTest.hpp
+++ b/src/autowiring/test/FactoryTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class FactoryTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/GlobalInitTest.hpp
+++ b/src/autowiring/test/GlobalInitTest.hpp
@@ -1,6 +1,5 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include <gtest/gtest.h>
 
 class GlobalInitTest:
   public testing::Test

--- a/src/autowiring/test/GuardObjectTest.hpp
+++ b/src/autowiring/test/GuardObjectTest.hpp
@@ -1,6 +1,5 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class GuardObjectTest:
   public testing::Test

--- a/src/autowiring/test/InterlockedRoutinesTest.hpp
+++ b/src/autowiring/test/InterlockedRoutinesTest.hpp
@@ -1,6 +1,5 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include <gtest/gtest.h>
 
 class InterlockedRoutinesTest:
   public testing::Test

--- a/src/autowiring/test/MarshalingTest.hpp
+++ b/src/autowiring/test/MarshalingTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class MarshalingTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/MultiInheritTest.hpp
+++ b/src/autowiring/test/MultiInheritTest.hpp
@@ -1,6 +1,5 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include <gtest/gtest.h>
 
 class MultiInheritTest:
   public testing::Test

--- a/src/autowiring/test/ObjectPoolTest.cpp
+++ b/src/autowiring/test/ObjectPoolTest.cpp
@@ -108,6 +108,7 @@ public:
 };
 
 TEST_F(ObjectPoolTest, EmptyPoolIssuance) {
+  AutoCurrentContext ctxt;
   ObjectPool<int> pool;
 
   // Create the thread which will hold the shared pointer for awhile:
@@ -123,7 +124,7 @@ TEST_F(ObjectPoolTest, EmptyPoolIssuance) {
   EXPECT_ANY_THROW(pool.Wait()) << "An attempt to obtain an element on an empty pool did not throw an exception as expected";
 
   // Now see if we can delay for the thread to back out:
-  m_create->Initiate();
+  ctxt->Initiate();
   pool.Rundown();
 
   // Verify that it got released as expected:

--- a/src/autowiring/test/ObjectPoolTest.hpp
+++ b/src/autowiring/test/ObjectPoolTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class ObjectPoolTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/PeerContextTest.cpp
+++ b/src/autowiring/test/PeerContextTest.cpp
@@ -10,7 +10,8 @@ struct PeerContextName2 {};
 
 TEST_F(PeerContextTest, VerifySimplePeerage) {
   // Accept Events
-  AutoCurrentContext()->Initiate();
+  AutoCurrentContext ctxt;
+  ctxt->Initiate();
 
   // Insert a simple receiver first:
   AutoRequired<SimpleReceiver> sr;
@@ -29,7 +30,7 @@ TEST_F(PeerContextTest, VerifySimplePeerage) {
 
   {
     // Create a single peer context, make it current, and try to fire:
-    auto peer = m_create->CreatePeer<PeerContextName1>();
+    auto peer = ctxt->CreatePeer<PeerContextName1>();
     ASSERT_TRUE(nullptr != peer.get()) << "Peer context creation method returned a null pointer";
 
     CurrentContextPusher pshr(peer);
@@ -45,13 +46,14 @@ TEST_F(PeerContextTest, VerifySimplePeerage) {
 }
 
 TEST_F(PeerContextTest, VerifyPeerTransitivity) {
-  AutoCurrentContext()->Initiate();
+  AutoCurrentContext ctxt;
+  ctxt->Initiate();
 
   // Insert our simple receiver:
   AutoRequired<SimpleReceiver> sr;
 
   // Now create the first peer context:
-  auto peer1 = m_create->CreatePeer<PeerContextName1>();
+  auto peer1 = ctxt->CreatePeer<PeerContextName1>();
   peer1->Initiate();
   ASSERT_TRUE(nullptr != peer1.get());
 
@@ -72,13 +74,14 @@ TEST_F(PeerContextTest, VerifyPeerTransitivity) {
 
 TEST_F(PeerContextTest, VerifyNoAutowiringLeakage) {
   // Accept Events
-  AutoCurrentContext()->Initiate();
+  AutoCurrentContext ctxt;
+  ctxt->Initiate();
 
   // Insert a simple object in the base context
   AutoRequired<SimpleObject> obj1;
 
   // Create a peer context and make it current:
-  auto peer = m_create->CreatePeer<PeerContextName1>();
+  auto peer = ctxt->CreatePeer<PeerContextName1>();
   CurrentContextPusher pshr(peer);
 
   // Verify that, in this peer context, SimpleObject is not visible

--- a/src/autowiring/test/PeerContextTest.hpp
+++ b/src/autowiring/test/PeerContextTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class PeerContextTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/PostConstructTest.cpp
+++ b/src/autowiring/test/PostConstructTest.cpp
@@ -257,9 +257,10 @@ TEST_F(PostConstructTest, VerifyAllInstancesSatisfied) {
 
 TEST_F(PostConstructTest, ContextNotifyWhenAutowired) {
   auto called = std::make_shared<bool>(false);
+  AutoCurrentContext ctxt;
   
   // Now we'd like to be notified when SimpleObject gets added:
-  m_create->NotifyWhenAutowired<SimpleObject>(
+  ctxt->NotifyWhenAutowired<SimpleObject>(
     [called] {
       *called = true;
     }

--- a/src/autowiring/test/PostConstructTest.hpp
+++ b/src/autowiring/test/PostConstructTest.hpp
@@ -1,8 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
 
-#include "EnclosedContextTestBase.hpp"
-
 class PostConstructTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/ScopeTest.cpp
+++ b/src/autowiring/test/ScopeTest.cpp
@@ -109,6 +109,7 @@ TEST_F(ScopeTest, AutowiringHeapMangle){
 }
 
 TEST_F(ScopeTest, AutowiringOrdering) {
+  AutoCurrentContext ctxt;
   AutoCreateContext outer;
   CurrentContextPusher outerPshr(outer);
   AutoCreateContext inner1;
@@ -155,7 +156,7 @@ TEST_F(ScopeTest, AutowiringOrdering) {
     // Verify preconditions and postconditions on autowiring:
     ASSERT_FALSE(d.IsAutowired());
     ASSERT_FALSE(d2.IsAutowired());
-    AutoRequired<D> derp(m_create);
+    AutoRequired<D> derp(ctxt);
 
     ASSERT_TRUE(d.IsAutowired()) << "Outer scope autowired field failed to be instantiated on an element created in an interior scope";
     ASSERT_TRUE(d2.IsAutowired()) << "Interior scope field failed to be satisfied by a field initiated at an outer context";

--- a/src/autowiring/test/ScopeTest.hpp
+++ b/src/autowiring/test/ScopeTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class ScopeTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/SelfSelectingFixtureTest.cpp
+++ b/src/autowiring/test/SelfSelectingFixtureTest.cpp
@@ -28,6 +28,7 @@ public:
 };
 
 TEST_F(SelfSelectingFixtureTest, LocalFixtureTest) {
+  AutoCurrentContext ctxt;
   Autowired<HitCountingBolt> hcb;
   ASSERT_FALSE(hcb.IsAutowired()) << "Hit-counting bolt was created before it was enabled";
 
@@ -38,7 +39,7 @@ TEST_F(SelfSelectingFixtureTest, LocalFixtureTest) {
   ASSERT_TRUE(hcb.IsAutowired()) << "Bolt not created after being enabled";
 
   // Verify the bolt gets hit:
-  m_create->Create<SimpleLocalClass>();
+  ctxt->Create<SimpleLocalClass>();
   ASSERT_EQ(1UL, hcb->m_hitCount) << "Bolt was not hit when a matching class was created";
 }
 

--- a/src/autowiring/test/SelfSelectingFixtureTest.hpp
+++ b/src/autowiring/test/SelfSelectingFixtureTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class SelfSelectingFixtureTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/SnoopTest.hpp
+++ b/src/autowiring/test/SnoopTest.hpp
@@ -1,8 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
 
-#include "EnclosedContextTestBase.hpp"
-
 class SnoopTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/TeardownNotifierTest.hpp
+++ b/src/autowiring/test/TeardownNotifierTest.hpp
@@ -1,6 +1,5 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include <gtest/gtest.h>
 
 class TeardownNotifierTest:
   public testing::Test

--- a/src/autowiring/test/TypeRegistryTest.hpp
+++ b/src/autowiring/test/TypeRegistryTest.hpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "EnclosedContextTestBase.hpp"
 
 class TypeRegistryTest:
-  public EnclosedContextTestBase
+  public testing::Test
 {};

--- a/src/autowiring/test/UuidTest.hpp
+++ b/src/autowiring/test/UuidTest.hpp
@@ -1,6 +1,5 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include <gtest/gtest.h>
 
 class UuidTest:
   public testing::Test

--- a/src/autowiring/test/gtest-all-guard.cpp
+++ b/src/autowiring/test/gtest-all-guard.cpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-private-field"
 #endif
+#include "EnclosedContextTestBase.hpp"
 #include <gtest/gtest-all.cc>
 #include <iostream>
 
@@ -23,6 +24,8 @@ int main(int argc, char* argv[])
   g_argc = argc;
   g_argv = argv;
 
+  auto& listeners = testing::UnitTest::GetInstance()->listeners();
+  listeners.Append(new EnclosedContextTestBase);
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/autowiring/test/stdafx.h
+++ b/src/autowiring/test/stdafx.h
@@ -3,9 +3,9 @@
 
 #include <C++11/cpp11.h>
 #include <gtest/gtest.h>
+#include <autowiring/autowiring.h>
 
 #ifdef _MSC_VER
-  #include <autowiring/Autowired.h>
   #include <thread>
   #include <mutex>
 #endif


### PR DESCRIPTION
This makes it easier to properly report exceptions that occur in spawned CoreThread instances.  No specific ExceptionFilter handling is required on a per-test basis.
