### PR TITLE
Filter exceptions thrown by AutoDesired

### DIFF
--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -281,7 +281,9 @@ public:
 ///
 ///  try {
 ///    AutoCurrentContext()->Inject&lt;T&gt;();
-///  catch(...) {}
+///  catch(...) {
+///    AutoCurrentContext()->FilterException();
+///  }
 ///  Autowired&lt;T&gt; foo;
 ///
 /// Users who wish to know whether an exception was thrown may replace uses of AutoDesired with the above
@@ -294,7 +296,9 @@ class AutoDesired:
 public:
   AutoDesired(void) {
     try { AutoRequired<T>(); }
-    catch(...) {}
+    catch(...) {
+      CoreContext::CurrentContext()->FilterException();
+    }
   }
 };
 

--- a/src/autowiring/test/AutowiringTest.cpp
+++ b/src/autowiring/test/AutowiringTest.cpp
@@ -76,3 +76,31 @@ TEST_F(AutowiringTest, PathologicalAutowiringRace) {
   // in spin-up or tear-down, 
   AutoRequired<SimpleObject>();
 }
+
+class ChecksForExceptions:
+  public ExceptionFilter
+{
+public:
+  ChecksForExceptions(void):
+    m_called(false)
+  {}
+
+  bool m_called;
+
+  void Filter(void) override {
+    m_called = true;
+  }
+};
+
+class ThrowsExceptionInCtor {
+public:
+  ThrowsExceptionInCtor(void) {
+    throw std::exception();
+  }
+};
+
+TEST_F(AutowiringTest, AUTOTHROW_CanSeeThrownAutoDesiredExceptions) {
+  AutoRequired<ChecksForExceptions> cfe;
+  AutoDesired<ThrowsExceptionInCtor>();
+  ASSERT_TRUE(cfe->m_called) << "Exception was not caught by exception filter in Autowiring context";
+}


### PR DESCRIPTION
I shouldn't have written AutoDesired to just blindly eat any exception that comes along.  I'm adding handling so that AutoDesired invokes all of the standard exception filters when an AutoDesired request fails.

I'm not really sure yet what AutoDesired is going to be; at this point, it's just an experimental proposition.  I'm open to suggestions on how it should behave--perhaps reworking the ExceptionFilter interface to have a concept of a nonfatal exception is a good idea?
