### PR TITLE
More unnecessary header elimination

### DIFF
--- a/src/autowiring/benchmark/AutowiringBenchmarkTest.cpp
+++ b/src/autowiring/benchmark/AutowiringBenchmarkTest.cpp
@@ -1,6 +1,5 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
-#include "AutowiringBenchmarkTest.hpp"
 #include "gtest-all-guard.h"
 
 class Foo {};
@@ -8,6 +7,10 @@ class Foo {};
 int main(int argc, const char* argv[]) {
   return autotesting_main(argc, argv);
 }
+
+class AutowiringBenchmarkTest:
+  public testing::Test
+{};
 
 TEST_F(AutowiringBenchmarkTest, VerifySimplePerformance) {
   const size_t n = 10000;

--- a/src/autowiring/benchmark/AutowiringBenchmarkTest.hpp
+++ b/src/autowiring/benchmark/AutowiringBenchmarkTest.hpp
@@ -1,6 +1,0 @@
-// Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
-#pragma once
-
-class AutowiringBenchmarkTest:
-  public testing::Test
-{};

--- a/src/autowiring/benchmark/CMakeLists.txt
+++ b/src/autowiring/benchmark/CMakeLists.txt
@@ -3,7 +3,6 @@ if(NOT AUTOWIRING_BUILD_BENCHMARKS)
 endif()
 
 set(AutowiringBenchmarkTest_SRCS
-  AutowiringBenchmarkTest.hpp
   AutowiringBenchmarkTest.cpp
 )
 


### PR DESCRIPTION
AutowiringBenchmarkTest also has some stray unneeded header files.
