### PR TITLE
Relaxing rules on CoreContext::Construct, adding unit test

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -518,8 +518,10 @@ public:
 
   /// <summary>
   /// Utility method which will inject the specified types into this context
-  /// Arguments will be passed to the T constructor if provided
   /// </summary>
+  /// <remarks>
+  /// Arguments will be passed to the T constructor if provided
+  /// </remarks>
   template<typename T, typename... Args>
   std::shared_ptr<T> Construct(Args&&... args) {
     // Add this type to the TypeRegistry

--- a/autowiring/CreationRules.h
+++ b/autowiring/CreationRules.h
@@ -33,7 +33,6 @@ struct CreationRules {
   static typename std::enable_if<!has_static_new<U, Args...>::value, U*>::type New(Args&&... args) {
     static_assert(!std::is_abstract<U>::value, "Cannot create a type which is abstract");
     static_assert(!has_static_new<U, Args...>::value, "Can't inject member with arguments if it has a static new");
-    static_assert(!sizeof...(Args) || !has_simple_constructor<U>::value, "Can't inject member with arguments if it has a default constructor");
 
     // Allocate slot first before registration
     auto* pSpace = Allocate<U>(nullptr);

--- a/autowiring/TypeUnifier.h
+++ b/autowiring/TypeUnifier.h
@@ -12,42 +12,29 @@ class TypeUnifierComplex:
   public TypeUnifier
 {
 public:
-  template<class Arg0, class... Args>
-  TypeUnifierComplex(Arg0&& arg0, Args&&... args) :
-    T(std::forward<Arg0>(arg0), std::forward<Args>(args)...)
+  template<class... Args>
+  TypeUnifierComplex(Args&&... args) :
+    T(std::forward<Args>(args)...)
   {}
 };
-
-template<class T>
-class TypeUnifierSimple:
-  public T,
-  public TypeUnifier
-{};
 
 /// <summary>
 /// Utility class which allows us to either use the pure type T, or a unifier, as appropriate
 /// </summary>
 template<
   class T,
-  bool inheritsObject = std::is_base_of<Object, T>::value,
-  bool hasSimpleCtor = has_simple_constructor<T>::value
+  bool inheritsObject = std::is_base_of<Object, T>::value
 >
 struct SelectTypeUnifier;
 
 // Anyone already inheriting Object can just use Object
-template<class T, bool hasSimpleCtor>
-struct SelectTypeUnifier<T, true, hasSimpleCtor> {
-  typedef T type;
-};
-
-// If T has a simple ctor, we don't want to confuse the compiler with the complex TypeUnifier
 template<class T>
-struct SelectTypeUnifier<T, false, true> {
-  typedef TypeUnifierSimple<T> type;
+struct SelectTypeUnifier<T, true> {
+  typedef T type;
 };
 
 // Otherwise, if there's a complex ctor, we have to use Args
 template<class T>
-struct SelectTypeUnifier<T, false, false> {
+struct SelectTypeUnifier<T, false> {
   typedef TypeUnifierComplex<T> type;
 };

--- a/src/autowiring/test/AutoConstructTest.cpp
+++ b/src/autowiring/test/AutoConstructTest.cpp
@@ -1,0 +1,27 @@
+#include "stdafx.h"
+
+class AutoConstructTest:
+  public testing::Test
+{};
+
+class HasDefaultCtorAndOthers {
+public:
+  HasDefaultCtorAndOthers(void) :
+    v(101)
+  {}
+  HasDefaultCtorAndOthers(int v) :
+    v(v)
+  {}
+
+  const int v;
+};
+
+TEST_F(AutoConstructTest, AutoConstructNoArgs) {
+  AutoConstruct<HasDefaultCtorAndOthers> hdcao;
+  ASSERT_EQ(101, hdcao->v) << "Default constructor was not called as expected";
+}
+
+TEST_F(AutoConstructTest, AutoConstructWithArgs) {
+  AutoConstruct<HasDefaultCtorAndOthers> hdcao(495);
+  ASSERT_EQ(495, hdcao->v) << "Constructor call was not made as expected";
+}

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(AutowiringTest_SRCS
   AnySharedPointerTest.cpp
   AutoAnchorTest.cpp
+  AutoConstructTest.cpp
   AutoFilterTest.cpp
   AutoInjectableTest.cpp
   AutoPacketFactoryTest.cpp


### PR DESCRIPTION
There are use cases where a type will need to be constructed in a context even if it also provides a default ctor.  We're just going to have to live with these cases, and allow clients to deal with the ambiguity that might result if they construct a type with varying args in the same context.
