### PR TITLE
Recommend that we build AutoNet by default unconditionally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 include(CMakeModules/pch.cmake)
+set(AUTOWIRING_BUILD_AUTONET_DEFAULT ON)
 
 # We don't build tests unless we're being built by ourselves in our own source tree
 # When we're embedded in someone else's subtree, it's not likely that they will want
@@ -40,7 +41,6 @@ get_filename_component(AUTOWIRING_ROOT_DIR . ABSOLUTE)
 if(CMAKE_SOURCE_DIR STREQUAL AUTOWIRING_ROOT_DIR)
   set(AUTOWIRING_BUILD_TESTS_DEFAULT ON)
   set(AUTOWIRING_BUILD_EXAMPLES_DEFAULT ON)
-  set(AUTOWIRING_BUILD_AUTONET_DEFAULT ON)
   
   # All of our binaries go to one place:  The binaries output directory.  We only want to tinker
   # with this if we're building by ourselves, otherwise we just do whatever the enclosing project
@@ -49,7 +49,6 @@ if(CMAKE_SOURCE_DIR STREQUAL AUTOWIRING_ROOT_DIR)
 else()
   set(AUTOWIRING_BUILD_TESTS_DEFAULT OFF)
   set(AUTOWIRING_BUILD_EXAMPLES_DEFAULT OFF)
-  set(AUTOWIRING_BUILD_AUTONET_DEFAULT OFF)
 endif()
 
 option(AUTOWIRING_BUILD_TESTS "Build Autowiring unit tests" ${AUTOWIRING_BUILD_TESTS_DEFAULT})


### PR DESCRIPTION
I think we should still keep the property around, though, so in the case of subtree import, consumes can override the default setting for their applications.
