### PR TITLE
Cleaning up boost find_package and linkage spec

### DIFF
--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -163,13 +163,17 @@ endif()
 set_property(TARGET Autowiring PROPERTY FOLDER "Autowiring")
 
 # Might as well reference the boost libraries to satisfy link dependencies, if we know they exist
-find_package(Boost COMPONENTS system date_time QUIET)
+find_package(Boost COMPONENTS thread atomic system chrono date_time QUIET)
 if(Boost_FOUND)
   target_link_libraries(Autowiring ${Boost_LIBRARIES})
 endif()
 
-if(UNIX)
-  target_link_libraries(Autowiring pthread)
+# Need multithreading services if available
+find_package(Threads)
+if(Threads_FOUND)
+  if(CMAKE_USE_PTHREADS_INIT)
+    target_link_libraries(Autowiring ${CMAKE_THREAD_LIBS_INIT})
+  endif()
 endif()
 
 install(TARGETS Autowiring DESTINATION lib COMPONENT autowiring CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES})


### PR DESCRIPTION
We shouldn't be attempting to link with pthread directly; Boost provides a find_package for pthread that we should use to assess whether we should link to it, and the name of the library if linkage is desired.

If we're going to reference Boost with find_package, we should probably reference all of the components we're using in one go.
