### PR TITLE
Reducing Autowiring dependencies in order to clean up definitions

### DIFF
--- a/autowiring/AutoNetServer.h
+++ b/autowiring/AutoNetServer.h
@@ -2,6 +2,10 @@
 #pragma once
 #include "CoreThread.h"
 
+class AutoNetServer;
+
+extern AutoNetServer* NewAutoNetServerImpl(void);
+
 class AutoNetServer:
   public CoreThread
 {
@@ -10,7 +14,9 @@ protected:
 
 public:
   virtual ~AutoNetServer();
-  static AutoNetServer* New(void);
+	static AutoNetServer* New(void) {
+		return NewAutoNetServerImpl();
+	}
 
   /// <summary>
   /// Waits until resume message is sent from the visualizer

--- a/src/autonet/AutoNetServer.cpp
+++ b/src/autonet/AutoNetServer.cpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "AutoNetServer.h"
-#include "AutoNetServerImpl.hpp"
 
 AutoNetServer::AutoNetServer():
   CoreThread("AutoNetServer")
@@ -9,7 +8,3 @@ AutoNetServer::AutoNetServer():
 }
 
 AutoNetServer::~AutoNetServer(){}
-
-AutoNetServer* AutoNetServer::New(void) {
-  return new AutoNetServerImpl;
-}

--- a/src/autonet/AutoNetServerImpl.cpp
+++ b/src/autonet/AutoNetServerImpl.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "AutoNetServerImpl.hpp"
-#include "autowiring.h"
 #include "at_exit.h"
+#include "autowiring.h"
 #include "EventRegistry.h"
 #include "TypeRegistry.h"
 #include <iostream>
@@ -56,6 +56,10 @@ AutoNetServerImpl::AutoNetServerImpl(void) :
 
 AutoNetServerImpl::~AutoNetServerImpl()
 {
+}
+
+AutoNetServer* NewAutoNetServerImpl(void) {
+	return new AutoNetServerImpl;
 }
 
 // CoreThread overrides

--- a/src/autonet/AutoNetServerImpl.hpp
+++ b/src/autonet/AutoNetServerImpl.hpp
@@ -172,3 +172,7 @@ protected:
   const int m_Port; // Port to listen on
 };
 
+/// <summary>
+/// Equivalent to new AutoNetServerImpl
+/// </summary>
+AutoNetServer* NewAutoNetServerImpl(void);


### PR DESCRIPTION
Shoud allow the Autonet source file compile a tad bit faster, because it doesn't really have much to bring in.  Also allows us to avoid including the mangled websocketpp header in more than one spot--our mangling is really something we don't want to propagate too far from its origination point.
