### PR TITLE
Marking base64-related global functions as static

### DIFF
--- a/contrib/websocketpp/base64/base64.hpp
+++ b/contrib/websocketpp/base64/base64.hpp
@@ -50,7 +50,7 @@ static inline bool is_base64(unsigned char c) {
            (c >= 97 && c <= 122)); // a-z
 }
 
-inline std::string base64_encode(unsigned char const* bytes_to_encode, unsigned
+static inline std::string base64_encode(unsigned char const* bytes_to_encode, unsigned
     int in_len)
 {
     std::string ret;
@@ -100,11 +100,11 @@ inline std::string base64_encode(unsigned char const* bytes_to_encode, unsigned
   return ret;
 }
 
-inline std::string base64_encode(const std::string & data) {
+static inline std::string base64_encode(const std::string & data) {
     return base64_encode(reinterpret_cast<const unsigned char *>(data.data()),data.size());
 }
 
-inline std::string base64_decode(std::string const& encoded_string) {
+static inline std::string base64_decode(std::string const& encoded_string) {
     size_t in_len = encoded_string.size();
     int i = 0;
     int j = 0;


### PR DESCRIPTION
These inline functions should also be marked static so as to avoid linker problems on msvc, because msvc doesn't automatically make them static like other compilers do.
