### PR TITLE
Fix Windows warnings-as-errors introduced by ref-awmodule

### DIFF
--- a/src/autonet/stdafx.h
+++ b/src/autonet/stdafx.h
@@ -3,7 +3,9 @@
 #include <math.h>
 #include <assert.h>
 #include <cctype>
-#define NOMINMAX
+#ifndef NOMINMAX
+  #define NOMINMAX
+#endif
 
 #ifndef _MSC_VER
   #include <stdlib.h>

--- a/src/autotesting/stdafx.h
+++ b/src/autotesting/stdafx.h
@@ -5,7 +5,9 @@
 // Currently this is only supported on MSVC
 #ifdef _MSC_VER
   #include <thread>
-  #define NOMINMAX
+  #ifndef NOMINMAX
+    #define NOMINMAX
+  #endif
 #endif
 	
 #ifndef _MSC_VER

--- a/src/autowiring/stdafx.h
+++ b/src/autowiring/stdafx.h
@@ -5,7 +5,9 @@
 // Currently this is only supported on MSVC
 #ifdef _MSC_VER
   #include <thread>
-  #define NOMINMAX
+  #ifndef NOMINMAX
+    #define NOMINMAX
+  #endif
 #endif
   
 #ifndef _MSC_VER


### PR DESCRIPTION
NOMINMAX is common enough that some embedded configurations define it on the command line.  We need to check to see if it's defined before we go defining it, otherwise the result will be a bunch of warnings-as-errors.
