### PR TITLE
Correcting warnings in websocketpp sources

### DIFF
--- a/contrib/websocketpp/websocketpp/base64/base64.hpp
+++ b/contrib/websocketpp/websocketpp/base64/base64.hpp
@@ -52,8 +52,7 @@ static inline bool is_base64(unsigned char c) {
            (c >= 97 && c <= 122)); // a-z
 }
 
-inline std::string base64_encode(unsigned char const * bytes_to_encode, unsigned
-    int in_len)
+inline std::string base64_encode(unsigned char const * bytes_to_encode, size_t in_len)
 {
     std::string ret;
     int i = 0;
@@ -103,7 +102,7 @@ inline std::string base64_encode(unsigned char const * bytes_to_encode, unsigned
 }
 
 inline std::string base64_encode(std::string const & data) {
-    return base64_encode(reinterpret_cast<const unsigned char *>(data.data()),data.size());
+    return base64_encode(reinterpret_cast<const unsigned char *>(data.data()), data.size());
 }
 
 inline std::string base64_decode(std::string const & encoded_string) {

--- a/contrib/websocketpp/websocketpp/common/md5.hpp
+++ b/contrib/websocketpp/websocketpp/common/md5.hpp
@@ -364,7 +364,7 @@ void md5_append(md5_state_t *pms, md5_byte_t const * data, size_t nbytes) {
     return;
 
     /* Update the message length. */
-    pms->count[1] += nbytes >> 29;
+    pms->count[1] += (md5::md5_word_t)(nbytes >> 29);
     pms->count[0] += nbits;
     if (pms->count[0] < nbits)
     pms->count[1]++;

--- a/contrib/websocketpp/websocketpp/frame.hpp
+++ b/contrib/websocketpp/websocketpp/frame.hpp
@@ -249,9 +249,7 @@ struct extended_header {
         int offset = copy_payload(payload_size);
 
         // Copy Masking Key
-        uint32_converter temp32;
-        temp32.i = masking_key;
-        std::copy(temp32.c,temp32.c+4,bytes+offset);
+        (int&) bytes[offset] = masking_key;
     }
 
     uint8_t bytes[MAX_EXTENDED_HEADER_LENGTH];
@@ -856,7 +854,7 @@ inline size_t byte_mask_circ(uint8_t * input, uint8_t * output, size_t length,
     size_t prepared_key)
 {
     uint32_converter key;
-    key.i = prepared_key;
+    key.i = (uint32_t)prepared_key;
 
     for (size_t i = 0; i < length; ++i) {
         output[i] = input[i] ^ key.c[i % 4];

--- a/contrib/websocketpp/websocketpp/logger/basic.hpp
+++ b/contrib/websocketpp/websocketpp/logger/basic.hpp
@@ -132,7 +132,16 @@ private:
     // TODO: find a workaround for this or make this format user settable
     static std::ostream & timestamp(std::ostream & os) {
         std::time_t t = std::time(NULL);
-        std::tm* lt = std::localtime(&t);
+        std::tm* lt;
+
+        #ifdef _WEBSOCKETPP_LOCALTIME_S_
+          std::tm lts;
+          lt = &lts;
+          localtime_s(lt, &t);
+        #else
+          lt = std::localtime(&t);
+        #endif
+
         #ifdef _WEBSOCKETPP_CPP11_CHRONO_
             return os << std::put_time(lt,"%Y-%m-%d %H:%M:%S");
         #else // Falls back to strftime, which requires a temporary copy of the string.

--- a/contrib/websocketpp/websocketpp/processors/hybi00.hpp
+++ b/contrib/websocketpp/websocketpp/processors/hybi00.hpp
@@ -109,9 +109,11 @@ public:
         // TODO: decide if it is best to silently fail here or produce some sort
         //       of warning or exception.
         const std::string& key3 = req.get_header("Sec-WebSocket-Key3");
-        std::copy(key3.c_str(),
-                  key3.c_str()+(std::min)(static_cast<size_t>(8), key3.size()),
-                  &key_final[8]);
+        memcpy(
+          &key_final[8],
+          key3.c_str(),
+          std::min(static_cast<size_t>(8), key3.size())
+        );
 
         res.append_header(
             "Sec-WebSocket-Key3",
@@ -362,11 +364,9 @@ private:
         num = static_cast<uint32_t>(strtoul(digits.c_str(), NULL, 10));
         if (spaces > 0 && num > 0) {
             num = htonl(num/spaces);
-            std::copy(reinterpret_cast<char*>(&num),
-                      reinterpret_cast<char*>(&num)+4,
-                      result);
+            *(uint32_t*) result = num;
         } else {
-            std::fill(result,result+4,0);
+            *(uint32_t*) result = 0;
         }
     }
 

--- a/contrib/websocketpp/websocketpp/processors/hybi13.hpp
+++ b/contrib/websocketpp/websocketpp/processors/hybi13.hpp
@@ -211,7 +211,7 @@ public:
 
         for (int i = 0; i < 4; i++) {
             conv.i = m_rng();
-            std::copy(conv.c,conv.c+4,&raw_key[i*4]);
+            memcpy(&raw_key[i * 4], conv.c, 4);
         }
 
         req.replace_header("Sec-WebSocket-Key",base64_encode(raw_key, 16));
@@ -630,7 +630,7 @@ protected:
         key.append(constants::handshake_guid);
 
         unsigned char message_digest[20];
-        sha1::calc(key.c_str(),key.length(),message_digest);
+        sha1::calc(key.c_str(), (int)key.length(),message_digest);
         key = base64_encode(message_digest,20);
 
         return lib::error_code();
@@ -672,7 +672,7 @@ protected:
     size_t copy_extended_header_bytes(uint8_t const * buf, size_t len) {
         size_t bytes_to_read = (std::min)(m_bytes_needed,len);
 
-        std::copy(buf,buf+bytes_to_read,m_extended_header.bytes+m_cursor);
+        memcpy(m_extended_header.bytes + m_cursor, buf, bytes_to_read);
         m_cursor += bytes_to_read;
         m_bytes_needed -= bytes_to_read;
 

--- a/src/autonet/stdafx.h
+++ b/src/autonet/stdafx.h
@@ -9,6 +9,9 @@
 
 #ifndef _MSC_VER
   #include <stdlib.h>
+#else
+  #define _WEBSOCKETPP_CPP11_CHRONO_
+  #define _WEBSOCKETPP_LOCALTIME_S_
 #endif
 
 // C++11 glue logic, for platforms that have incomplete C++11 support


### PR DESCRIPTION
Many of these warnings have to do with size conversions, they've largely been addressed here.  A few are unsafe function calls--they have been addressed with preprocessor guards.
