### PR TITLE
Fixing a CoreContext::Initiate reentrant deadlock

### DIFF
--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -323,6 +323,11 @@ std::vector<std::shared_ptr<BasicThread>> CoreContext::CopyBasicThreadList(void)
 }
 
 void CoreContext::Initiate(void) {
+  // First-pass check, used to prevent recursive deadlocks traceable to here that might
+  // result from entities trying to initiate subcontexts from CoreRunnable::Start
+  if(m_initiated || m_isShutdown)
+    return;
+
   {
     std::lock_guard<std::mutex> lk(m_stateBlock->m_lock);
     if(m_initiated)

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -11,6 +11,7 @@ set(AutowiringTest_SRCS
   BoltTest.cpp
   CoreContextTest.cpp
   CoreJobTest.cpp
+  CoreRunnableTest.cpp
   ContextCleanupTest.cpp
   ContextEnumeratorTest.cpp
   ContextMapTest.cpp

--- a/src/autowiring/test/CoreRunnableTest.cpp
+++ b/src/autowiring/test/CoreRunnableTest.cpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include <autowiring/autowiring.h>
+#include <autowiring/CoreRunnable.h>
+
+class CoreRunnableTest:
+  public testing::Test
+{};
+
+class StartsSubcontextWhileStarting:
+  public CoreRunnable
+{
+public:
+  AutoCreateContext m_myContext;
+
+  bool Start(std::shared_ptr<Object> outstanding) override {
+    m_myContext->Initiate();
+    return true;
+  }
+
+  void Stop(bool graceful) override {}
+  bool IsRunning(void) const override { return false; }
+  bool ShouldStop(void) const override { return true; }
+  void Wait(void) override {}
+};
+
+TEST_F(CoreRunnableTest, CanStartSubcontextWhileInitiating) {
+  AutoRequired<StartsSubcontextWhileStarting>();
+  AutoCurrentContext()->Initiate();
+}


### PR DESCRIPTION
CoreRunnable::Start can potentially deadlock if it tries to start a subcontext; this behavior should be supported as there are cases where a subcontext should be initiated in response to parent initiation.
