### PR TITLE
AutoConstruct should not inherit AutoRequired

### DIFF
--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -306,13 +306,17 @@ public:
 /// </summary>
 template<class T>
 class AutoConstruct:
-  public AutoRequired<T>
+  public std::shared_ptr<T>
 {
 public:
   template<class... Args>
   AutoConstruct(Args&&... args) :
-    AutoRequired<T>(CoreContext::CurrentContext(), std::forward<Args>(args)...)
+    std::shared_ptr<T>(CoreContext::CurrentContext()->template Construct<T>(std::forward<Args&&>(args)...))
   {}
+
+  operator bool(void) const { return IsAutowired(); }
+  operator T*(void) const { return std::shared_ptr<T>::get(); }
+  bool IsAutowired(void) const { return std::shared_ptr<T>::get() != nullptr; }
 };
 
 /// <summary>


### PR DESCRIPTION
This just complicates the inheritance hierarchy and might make it harder to deprecate AutoRequired later, easier if we just keep the concepts separated.
