### PR TITLE
Clarification of some static asserts

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -542,7 +542,7 @@ public:
     static_assert(std::is_base_of<Object, TActual>::value, "Constructive type does not implement Object as expected");
     static_assert(
       std::is_base_of<Object, T>::value || !has_static_new<T>::value,
-      "If type T provides a static new method, then the constructed type MUST directly inherit Object"
+      "If type T provides a static New method, then the constructed type MUST directly inherit Object"
     );
 
     // First see if the object has already been injected:

--- a/autowiring/CreationRules.h
+++ b/autowiring/CreationRules.h
@@ -24,7 +24,7 @@ struct CreationRules {
     auto retVal = U::New(std::forward<Args>(args)...);
     static_assert(
       std::is_convertible<decltype(retVal), U*>::value,
-      "Attempted to create T using T::New, but the return value of T::New is not derived from T"
+      "Attempted to create T using T::New, but the type of T::New() is not derived from T"
     );
     return retVal;
   }
@@ -32,7 +32,7 @@ struct CreationRules {
   template<typename U, typename... Args>
   static typename std::enable_if<!has_static_new<U, Args...>::value, U*>::type New(Args&&... args) {
     static_assert(!std::is_abstract<U>::value, "Cannot create a type which is abstract");
-    static_assert(!has_static_new<U, Args...>::value, "Can't inject member with arguments if it has a static new");
+    static_assert(!has_static_new<U, Args...>::value, "Can't inject member with arguments if it has a static New");
 
     // Allocate slot first before registration
     auto* pSpace = Allocate<U>(nullptr);

--- a/src/autowiring/test/FactoryTest.cpp
+++ b/src/autowiring/test/FactoryTest.cpp
@@ -37,7 +37,7 @@ public:
 
 static_assert(has_simple_constructor<ClassWithStaticNew>::value, "Class with default-argument constructor was not correctly detected as such ");
 static_assert(has_static_new<ClassWithStaticNew>::value, "Class with static allocator was not correctly detected as having one");
-static_assert(!has_static_new<Object>::value, "Static new detected on a class that does not have a static new");
+static_assert(!has_static_new<Object>::value, "Static New detected on a class that does not have a static New");
 
 TEST_F(FactoryTest, VerifyFactoryCall) {
   // Try to create the static new type:


### PR DESCRIPTION
When we talk about static New, we're referring to a function called New, not the operator new.  Best to make use of consistent terminology when referring to this concept.
