### PR TITLE
Break AutoNet linker dependency on Autowiring

### DIFF
--- a/src/autonet/CMakeLists.txt
+++ b/src/autonet/CMakeLists.txt
@@ -35,5 +35,5 @@ endforeach()
 
 ADD_MSVC_PRECOMPILED_HEADER("stdafx.h" "stdafx.cpp" AutoNet_SRCS)
 add_library(AutoNet STATIC ${AutoNet_SRCS})
-target_link_libraries(AutoNet Autowiring json11 ${Boost_LIBRARIES})
+target_link_libraries(AutoNet json11 ${Boost_LIBRARIES})
 set_property(TARGET AutoNet PROPERTY FOLDER "Autowiring")

--- a/src/autonet/test/CMakeLists.txt
+++ b/src/autonet/test/CMakeLists.txt
@@ -11,7 +11,7 @@ set(AutoNetTest_SRCS
 
 ADD_MSVC_PRECOMPILED_HEADER("stdafx.h" "stdafx.cpp" AutoNetTest_SRCS)
 add_executable(AutoNetTest ${AutoNetTest_SRCS})
-target_link_libraries(AutoNetTest AutoNet)
+target_link_libraries(AutoNetTest AutoNet Autowiring)
 set_property(TARGET AutoNetTest PROPERTY FOLDER "Autowiring")
 
 # This is a unit test, let CMake know this


### PR DESCRIPTION
AutoNet does not have any actual linker dependencies on Autowiring.  By breaking this dependency, we can actually make Autowiring depend on AutoNet in cases where AutoNet can be built.
