### PR TITLE
Eliminating dangerous boost package finding overrides

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,10 +5,6 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/src/autowiring
 )
 
-set(Boost_USE_STATIC_LIBS        ON)
-set(Boost_USE_MULTITHREADED      ON)
-set(Boost_USE_STATIC_RUNTIME    OFF)
-
 if(APPLE)
   # Boost is actually required on Mac
   find_package(Boost REQUIRED)


### PR DESCRIPTION
We shouldn't be trying to override these options if it isn't necessary, it just creates linker problems on other platforms
