### PR TITLE
Fixing DefaultAutoNetServer problems

### DIFF
--- a/src/autowiring/DefaultAutoNetServer.cpp
+++ b/src/autowiring/DefaultAutoNetServer.cpp
@@ -10,7 +10,7 @@ class DefaultAutoNetServer:
   public AutoNetServer
 {
 public:
-  DefaultAutoNetServer(void);
+  DefaultAutoNetServer(void) {}
 
   void Breakpoint(std::string name) {}
   void HandleResumeFromBreakpoint(std::string name) {}

--- a/src/autowiring/stdafx.h
+++ b/src/autowiring/stdafx.h
@@ -14,5 +14,8 @@
   #include <stdlib.h>
 #endif
 
+// Preconfiguration:
+#include "AutowiringConfig.h"
+
 // C++11 glue logic, for platforms that have incomplete C++11 support
 #include "contrib/C++11/cpp11.h"


### PR DESCRIPTION
Configuration should be project-wide, also fixing a DefaultAutoNetServer linker problem
