### PR TITLE
Providing an override to correct an invalid demangle call

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -375,7 +375,7 @@ public:
         pTypeSubs[i] = &m_decorations[*s_argTypes[i]];
         if(pTypeSubs[i]->wasCheckedOut) {
           std::stringstream ss;
-          ss << "Cannot perform immediate decoration with type " << autowiring::demangle(s_argTypes[i])
+          ss << "Cannot perform immediate decoration with type " << autowiring::demangle(*s_argTypes[i])
              << ", the requested decoration already exists";
           throw std::runtime_error(ss.str());
         }

--- a/autowiring/demangle.h
+++ b/autowiring/demangle.h
@@ -32,7 +32,11 @@ namespace autowiring {
   }
   
 #endif
-  
+
+  static inline std::string demangle(const std::type_info* ti) {
+    return demangle(*ti);
+  }
+
   template<typename T>
   static inline std::string demangle(const T&) {
     return demangle(typeid(T));


### PR DESCRIPTION
This was a bad call to demangle a typeinfo.  Corrected the original call, and also provided an overload to prevent linker errors from being generated in cases where an attempt is made to demangle a type_info*
