### PR TITLE
Correcting broken MSVC build

### DIFF
--- a/autowiring/hash_tuple.h
+++ b/autowiring/hash_tuple.h
@@ -6,10 +6,10 @@ namespace std
 {
   template<class... Types>
   struct hash<std::tuple<Types...>> {
-    static size_t hash_combine(const size_t& lhs, const size_t& rhs) {
+    static uint64_t hash_combine(const size_t& lhs, const size_t& rhs) {
       //return lhs ^ rhs;
       //static const size_t salt = 0x9e3779b9;
-      static const size_t salt = 0x278dde6e5fd29e00;
+      static const uint64_t salt = 0x278dde6e5fd29e00;
       return rhs ^ (salt + (lhs << 6) + (lhs >> 2));
       // Adding pseudo-random bits reduces collisions between consecutive values
       // 0 < 1/phi < 1 so the denominator includes a shift.
@@ -25,8 +25,11 @@ namespace std
     // General: combine hash<head> with recursion on tail
     template<int N, class Head, class... Tail>
     static size_t hash_tuple(const std::tuple<Types...>& value) {
-      constexpr int I = N - sizeof...(Tail) - 1;
-      return hash_combine(std::hash<Head>()(std::get<I>(value)), hash_tuple<N, Tail...>(value));
+      return (size_t)hash_combine(
+        std::hash<Head>()(
+          std::get<N - sizeof...(Tail) - 1>(value)),
+          hash_tuple<N, Tail...>(value)
+        );
     }
 
   public:


### PR DESCRIPTION
Unfortunately constexpr doesn't exist in MSVC currently, and MSVC doesn't like it when we assume uint64_t and size_t are the same size.
