### PR TITLE
Using a more robust check to detect whether AutoNet is being built

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,16 +14,15 @@ add_executable(AutoFilterExample AutoFilterExample.cpp)
 target_link_libraries(AutoFilterExample Autowiring)
 set_property(TARGET AutoFilterExample PROPERTY FOLDER "Examples")
 
-find_package(Boost QUIET)
-if(NOT Boost_FOUND)
-  message("Cannot build AutoNetExample, boost not installed on this system")
-  return()
+if(TARGET AutoNet)
+  find_package(Boost QUIET)
+  if(NOT Boost_FOUND)
+    message("Cannot build AutoNetExample, boost not installed on this system")
+    return()
+  endif()
+
+  add_executable(AutoNetExample AutoNetExample.cpp)
+  target_link_libraries(AutoNetExample Autowiring AutoNet)
+  target_include_directories(AutoNetExample PRIVATE ${Boost_INCLUDE_DIR})
+  set_property(TARGET AutoNetExample PROPERTY FOLDER "Examples")
 endif()
-
-include_directories(
-  ${Boost_INCLUDE_DIR}
-)
-
-add_executable(AutoNetExample AutoNetExample.cpp)
-target_link_libraries(AutoNetExample Autowiring AutoNet)
-set_property(TARGET AutoNetExample PROPERTY FOLDER "Examples")

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -71,7 +71,7 @@ add_executable(AutowiringTest ${AutowiringTest_SRCS})
 target_link_libraries(AutowiringTest Autowiring AutowiringFixture AutoTesting)
 
 # Link AutoNet if we've got it
-if(AUTOWIRING_BUILD_AUTONET)
+if(TARGET AutoNet)
   target_link_libraries(AutowiringTest AutoNet)
 endif()
 


### PR DESCRIPTION
if(TARGET AutoNet) is generally a more straightforward way to tell, within Autowiring, whether AutoNet is being built.  Checking flags like AUTOWIRING_BUILD_AUTONET or trying to check AutoNet's dependencies are both unreliable and fragile ways of accomplishing this.
