### PR TITLE
DataFlow should be placed in the autowiring namespace

### DIFF
--- a/autowiring/AutoFilterDescriptor.h
+++ b/autowiring/AutoFilterDescriptor.h
@@ -139,8 +139,8 @@ struct subscriber_traits<AutoPacket&> {
 /// </summary>
 template<class Arg>
 struct sourced_checkout {
-  typename subscriber_traits<Arg>::ret_type operator()(AutoPacket& packet, const DataFill& satisfaction) const {
-    DataFill::const_iterator source_find = satisfaction.find(typeid(typename subscriber_traits<Arg>::type));
+  typename subscriber_traits<Arg>::ret_type operator()(AutoPacket& packet, const autowiring::DataFill& satisfaction) const {
+    autowiring::DataFill::const_iterator source_find = satisfaction.find(typeid(typename subscriber_traits<Arg>::type));
     if (source_find != satisfaction.end()) {
       return subscriber_traits<Arg>()(packet, *source_find->second);
     }
@@ -165,7 +165,7 @@ struct CallExtractor<void (T::*)(Args...)>:
   /// Binder struct, lets us refer to an instance of Call by type
   /// </summary>
   template<void(T::*memFn)(Args...)>
-  static void Call(void* pObj, AutoPacket& autoPacket, const DataFill& satisfaction) {
+  static void Call(void* pObj, AutoPacket& autoPacket, const autowiring::DataFill& satisfaction) {
     // Handoff
     (((T*) pObj)->*memFn)(
       sourced_checkout<Args>()(autoPacket, satisfaction)...
@@ -184,14 +184,14 @@ struct CallExtractor<Deferred (T::*)(Args...)>:
   static const size_t N = sizeof...(Args);
 
   template<Deferred(T::*memFn)(Args...)>
-  static void Call(void* pObj, AutoPacket& autoPacket, const DataFill& satisfaction) {
+  static void Call(void* pObj, AutoPacket& autoPacket, const autowiring::DataFill& satisfaction) {
     // Obtain a shared pointer of the AutoPacket in order to ensure the packet
     // stays resident when we pend this lambda to the destination object's
     // dispatch queue.
     auto pAutoPacket = autoPacket.shared_from_this();
 
     // Pend the call to this object's dispatch queue:
-    // WARNING: The DataFill information will be referenced,
+    // WARNING: The autowiring::DataFill information will be referenced,
     // since it should be from a SatCounter associated to autoPacket,
     // and will therefore have the same lifecycle as the AutoPacket.
     *(T*) pObj += [pObj, pAutoPacket, &satisfaction] {
@@ -249,7 +249,7 @@ struct AutoFilterDescriptorInput {
 /// </summary>
 struct AutoFilterDescriptorStub {
   // The type of the call centralizer
-  typedef void(*t_call)(void*, AutoPacket&, const DataFill&);
+  typedef void(*t_call)(void*, AutoPacket&, const autowiring::DataFill&);
 
   AutoFilterDescriptorStub(void) :
     m_pType(nullptr),
@@ -295,7 +295,7 @@ struct AutoFilterDescriptorStub {
 
     for(auto pArg = m_pArgs; *pArg; pArg++) {
       // DEFAULT: All data is broadcast
-      DataFlow& data = m_dataMap[*pArg->ti];
+      autowiring::DataFlow& data = m_dataMap[*pArg->ti];
       data.output = AutoFilterDescriptorInput::isOutput(pArg->subscriberType);
       data.broadcast = true;
       switch(pArg->subscriberType) {
@@ -319,7 +319,7 @@ protected:
   // NOTE: This is a reference to a static generated list,
   // therefor it MUST be const and MUST be shallow-copied.
   const AutoFilterDescriptorInput* m_pArgs;
-  typedef std::unordered_map<std::type_index, DataFlow> FlowMap;
+  typedef std::unordered_map<std::type_index, autowiring::DataFlow> FlowMap;
   FlowMap m_dataMap;
 
   // Set if this is a deferred subscriber.  Deferred subscribers cannot receive immediate-style
@@ -372,12 +372,12 @@ public:
   /// Copies the data flow information for the argument type to the flow argument.
   /// </summary>
   /// <returns>true when the argument type is found</returns>
-  DataFlow GetDataFlow(const std::type_info* argType) const {
+  autowiring::DataFlow GetDataFlow(const std::type_info* argType) const {
     FlowMap::const_iterator data = m_dataMap.find(*argType);
     if (data != m_dataMap.end()) {
       return data->second;
     }
-    return DataFlow(); //DEFAULT: No flow
+    return autowiring::DataFlow(); //DEFAULT: No flow
   }
 
   /// <returns>A call lambda wrapping the associated subscriber</returns>
@@ -400,7 +400,7 @@ public:
     FlowMap::iterator flowFind = m_dataMap.find(*dataType);
     if (flowFind == m_dataMap.end())
       return;
-    DataFlow& flow = flowFind->second;
+    autowiring::DataFlow& flow = flowFind->second;
     flow.broadcast = enable;
   }
 
@@ -419,7 +419,7 @@ public:
     FlowMap::iterator flowFind = m_dataMap.find(*dataType);
     if (flowFind == m_dataMap.end())
       return;
-    DataFlow& flow = flowFind->second;
+    autowiring::DataFlow& flow = flowFind->second;
     if (enable)
       flow.halfpipes.insert(*nodeType);
     else

--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -74,12 +74,12 @@ private:
   /// Broadcast is always true for added or snooping recipients.
   /// Pipes are always absent for added or snooping recipients.
   /// </remarks>
-  DataFlow GetDataFlow(const DecorationDisposition& entry) const;
+  autowiring::DataFlow GetDataFlow(const DecorationDisposition& entry) const;
 
   /// <summary>
   /// Retrieve data flow information from source
   /// </summary>
-  DataFlow GetDataFlow(const std::type_info& data, const std::type_info& source);
+  autowiring::DataFlow GetDataFlow(const std::type_info& data, const std::type_info& source);
 
   /// <summary>
   /// Adds all AutoFilter argument information for a recipient
@@ -178,7 +178,7 @@ private:
     {
       std::lock_guard<std::mutex> lk(m_lock);
 
-      DataFlow flow = GetDataFlow(typeid(type), source);
+      autowiring::DataFlow flow = GetDataFlow(typeid(type), source);
       if (flow.broadcast) {
         broadDeco = &m_decorations[Index(typeid(type), typeid(void))];
 
@@ -324,7 +324,7 @@ public:
     if(!ptr)
       throw std::runtime_error("Cannot checkout with shared_ptr == nullptr");
 
-    DataFlow flow = GetDataFlow(typeid(type), source);
+    autowiring::DataFlow flow = GetDataFlow(typeid(type), source);
     if (flow.broadcast) {
       std::lock_guard<std::mutex> lk(m_lock);
 

--- a/autowiring/DataFlow.h
+++ b/autowiring/DataFlow.h
@@ -4,6 +4,8 @@
 #include STL_UNORDERED_SET
 #include STL_UNORDERED_MAP
 
+namespace autowiring {
+
 /// <summary>
 /// Mutable properties used by AutoFilterDescriptor to describe data pipes.
 /// </summary>
@@ -27,3 +29,5 @@ struct DataFlow {
 /// Key is argument type, value is source type.
 /// If the data is broadcast value will be &typeid(void)
 typedef std::unordered_map<std::type_index, const std::type_info*> DataFill;
+
+}

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -9,6 +9,8 @@
 #include "SatCounter.h"
 #include <list>
 
+using namespace autowiring;
+
 // This must appear in .cpp in order to avoid compilation failure due to:
 // "Arithmetic on a point to an incomplete type 'SatCounter'"
 AutoPacket::~AutoPacket() {}


### PR DESCRIPTION
DataFlow is a common enough typename that we're getting collisions with certain Windows headers.  Namespace wrapping should be considered for other externally visible types with common names.
