### PR TITLE
Should be able to autowire concrete factory new derived types

### DIFF
--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -192,12 +192,19 @@ void CoreContext::AddInternal(const AddInternalTraits& traits) {
   {
     std::unique_lock<std::mutex> lk(m_stateBlock->m_lock);
 
-    // Validate that this addition does not generate an ambiguity:
-    auto& v = m_typeMemos[typeid(*traits.pObject)];
-    if(*v.m_value == traits.pObject)
-      throw std::runtime_error("An attempt was made to add the same value to the same context more than once");
-    if(*v.m_value)
-      throw std::runtime_error("An attempt was made to add the same type to the same context more than once");
+    // Validate that this addition does not generate an ambiguity.  We need to use the proper type of
+    // pObject, rather than the type passed in via traits.type, because the proper type might be a
+    // concrete type defined in another context or potentially a unifier type.  Creating a slot here
+    // is also undesirable because the complete type is not available and we can't create a dynaimc
+    // caster to identify when this slot gets satisfied.
+    auto q = m_typeMemos.find(typeid(*traits.pObject));
+    if(q != m_typeMemos.end()) {
+      auto& v = q->second;
+      if(*v.m_value == traits.pObject)
+        throw std::runtime_error("An attempt was made to add the same value to the same context more than once");
+      if(*v.m_value)
+        throw std::runtime_error("An attempt was made to add the same type to the same context more than once");
+    }
 
     // Add the new concrete type:
     m_concreteTypes.push_back(traits.value);

--- a/src/autowiring/test/FactoryTest.cpp
+++ b/src/autowiring/test/FactoryTest.cpp
@@ -133,3 +133,25 @@ TEST_F(FactoryTest, CompatibleFactoryNewCall) {
   auto aliased = AutoCreateContext()->Construct<HasAliasedConstructorType>(22);
   ASSERT_EQ(22, aliased->m_value) << "Failed to pass a compatible value to an aliasing constructor type";
 }
+
+class FactoryNewAbstractBase:
+  public ContextMember
+{
+public:
+  static FactoryNewAbstractBase* New(void);
+};
+
+class FactoryNewConcreteType:
+  public FactoryNewAbstractBase
+{};
+
+FactoryNewAbstractBase* FactoryNewAbstractBase::New(void) {
+  return new FactoryNewConcreteType;
+}
+
+TEST_F(FactoryTest, VerifyCanAutowireActualType) {
+  AutoRequired<FactoryNewAbstractBase> myBase;
+  Autowired<FactoryNewConcreteType> concrete;
+
+  ASSERT_TRUE(concrete.IsAutowired()) << "Failed to find the concrete derived type in a factory new construction in a case where it is known to exist";
+}

--- a/src/autowiring/test/MultiInheritTest.cpp
+++ b/src/autowiring/test/MultiInheritTest.cpp
@@ -30,7 +30,8 @@ public:
   Derived(void) {
     EXPECT_TRUE(Base::m_member.IsAutowired()) << "Base AutoRequired member was not initialized properly";
     EXPECT_EQ(100, Base::m_member->m_i) << "Autowired instance was not properly constructed";
-    EXPECT_EQ(m_member, m_secondMember) << "Autowiring idempotency was violated";
+    EXPECT_TRUE(m_secondMember.IsAutowired()) << "Failed to autowire a type which should have been injected in this context";
+    EXPECT_EQ(m_member.get(), m_secondMember.get()) << "Autowiring idempotency was violated";
   }
 
   Autowired<Shared> m_secondMember;


### PR DESCRIPTION
The injection step was attempting to use the actual type of the object, which might not actually be available in any compilation unit except in the location where it's constructed.
