### PR TITLE
Correcting MSVC warning C4800

### DIFF
--- a/src/autowiring/AutoPacketFactory.cpp
+++ b/src/autowiring/AutoPacketFactory.cpp
@@ -249,7 +249,7 @@ void AutoPacketFactory::PipeOneData(const std::type_info* nodeOutType, const std
 
     // Check for AutoPacket& (or const AutoPacket&) arguments
     bool allOut =
-      updateOut.GetArgumentType(&typeid(subscriber_traits<AutoPacket&>::type));
+      !!updateOut.GetArgumentType(&typeid(subscriber_traits<AutoPacket&>::type));
     bool allIn =
       updateIn.GetArgumentType(&typeid(subscriber_traits<AutoPacket&>::type)) ||
       updateIn.GetArgumentType(&typeid(subscriber_traits<const AutoPacket&>::type));
@@ -290,7 +290,7 @@ void AutoPacketFactory::PipeAllData(const std::type_info* nodeOutType, const std
 
     // Check for AutoPacket& (or const AutoPacket&) arguments
     bool allOut =
-      updateOut.GetArgumentType(&typeid(subscriber_traits<AutoPacket&>::type));
+      !!updateOut.GetArgumentType(&typeid(subscriber_traits<AutoPacket&>::type));
     bool allIn =
       updateIn.GetArgumentType(&typeid(subscriber_traits<AutoPacket&>::type)) ||
       updateIn.GetArgumentType(&typeid(subscriber_traits<const AutoPacket&>::type));


### PR DESCRIPTION
Whenever you coerce a non-bool type to a bool, you get a 'performance warning'.  This is because a simple truncation cannot be done when you coerce to bool; a test against zero has to be done first, and then the result used to set the boolean value either to "true" or "false".
