### PR TITLE
Made cmake export an import target file for the Autowiring project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ if(NOT AUTOWIRING_IS_EMBEDDED)
     DESTINATION "cmake"
     COMPONENT autowiring
   )
-
+  install(EXPORT AutowiringTargets FILE AutowiringTargets.cmake NAMESPACE Autowiring:: DESTINATION cmake)
   # This is the upgrade GUID.  Part of the GUID is derived from the major version number.  Any time
   # the major version number is adjusted, the upgrade GUID changes.  This allows multiple versions
   # of the same product to be installed on a user's system at the same time, but also means that

--- a/autowiring-config.cmake.in
+++ b/autowiring-config.cmake.in
@@ -3,5 +3,6 @@
 #  AUTOWIRING_FOUND - indicates that the module was found
 #  AUTOWIRING_INCLUDE_DIR - include directories
 
+include(${CMAKE_CURRENT_LIST_DIR}/AutowiringTargets.cmake)
 set(autowiring_FOUND TRUE)
 set(autowiring_INCLUDE_DIR "@INSTALL_INCLUDE_DIR@")

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -168,9 +168,11 @@ endif()
 
 rewrite_header_paths(Autowiring_SRCS)
 ADD_MSVC_PRECOMPILED_HEADER("stdafx.h" "stdafx.cpp" Autowiring_SRCS)
+
 add_library(Autowiring STATIC ${Autowiring_SRCS})
+
 if(CMAKE_MAJOR_VERSION GREATER 2)
-  target_include_directories(Autowiring INTERFACE "../..")
+  target_include_directories(Autowiring INTERFACE "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>" "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>")
 endif()
 set_property(TARGET Autowiring PROPERTY FOLDER "Autowiring")
 
@@ -189,7 +191,11 @@ if(Threads_FOUND)
 endif()
 
 if(NOT AUTOWIRING_IS_EMBEDDED)
-  install(TARGETS Autowiring DESTINATION lib COMPONENT autowiring CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES})
+  install(TARGETS Autowiring EXPORT AutowiringTargets
+    DESTINATION lib
+    COMPONENT autowiring 
+    CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES}
+  )
 
   foreach (src ${Autowiring_SRCS})
     string(REGEX MATCH ".*\\.h" hfile ${src})


### PR DESCRIPTION
This allows you to link with the autowiring project via
target_link_libraries(<target> [LINK_TYPE] Autowiring::Autowiring)

Requires testing & verification on other platforms & use cases.
