### PR TITLE
Ref is auto packet source

### DIFF
--- a/autowiring/ObjectTraits.h
+++ b/autowiring/ObjectTraits.h
@@ -39,7 +39,11 @@ struct ObjectTraits {
         return true;
     }
     return false;
-  }())
+  }()),
+  isAutoPacketSource(
+    std::is_convertible<T, AutoPacketFactory>::value || // via inheritance
+    std::is_convertible<T&, AutoPacketFactory&>::value //via casting
+  )
   {
     if(!pObject)
       throw autowiring_error("Cannot add a type which does not implement Object");
@@ -65,4 +69,7 @@ struct ObjectTraits {
 
   // Does this type receive events?
   const bool receivesEvents;
+
+  // Does this type generate AutoPackets?
+  const bool isAutoPacketSource;
 };

--- a/src/autonet/AutoNetServerImpl.cpp
+++ b/src/autonet/AutoNetServerImpl.cpp
@@ -192,11 +192,10 @@ void AutoNetServerImpl::NewObject(CoreContext& ctxt, const ObjectTraits& object)
       };
     }
 
-    // Check if this is capable of initializing AutoPackets.
-    // IMPORTANT: This field ensures that any object inheriting from
-    // AutoPacketFactory or providing a cast to AutoPacketFactory
-    // (exposing an AutoPacketFactory member) will be recognized.
-    if (dynamic_cast<AutoPacketFactory*>(object.pObject.get())) {
+    // Check if this object inherits from AutoPacketFactory or
+    // advertises an AutoPacketFactory member by providing a cast
+    // to AutoPacketFactory&.
+    if (object.isAutoPacketSource) {
       types["isAutoPacketSource"] = true;
     }
 


### PR DESCRIPTION
This adds AutoPacket source information to ObjectTraits. It also makes this field available in the AutoNet output.

The goal is be able to identify an object as an initiator of AutoPacket executions. Presently, it can identify inheritance from AutoPacketFactory, and advertised membership (via casting operator) of AutoPacketFactory.
