### PR TITLE
Fix the autowiring install include path

### DIFF
--- a/autowiring-config.cmake.in
+++ b/autowiring-config.cmake.in
@@ -5,4 +5,4 @@
 
 include(${CMAKE_CURRENT_LIST_DIR}/AutowiringTargets.cmake)
 set(autowiring_FOUND TRUE)
-set(autowiring_INCLUDE_DIR "@INSTALL_INCLUDE_DIR@")
+set(autowiring_INCLUDE_DIR "@CMAKE_INSTALL_PREFIX@/include")


### PR DESCRIPTION
This fixes the issue that on Windows that the autowiring_INCLUDE_DIR is empty
