### PR TITLE
Fix missing return from auto_out assignment.

### DIFF
--- a/autowiring/auto_out.h
+++ b/autowiring/auto_out.h
@@ -99,6 +99,7 @@ public:
     cancel();
     shared_type::operator = (rhs);
     m_makeable = false;
+    return *this;
   }
 
   auto_out (std::shared_ptr<AutoPacket> packet, const std::type_info& source = typeid(void)):


### PR DESCRIPTION
Quick fix - will self-grant merge.
