### PR TITLE
Adding missing required library

### DIFF
--- a/src/autonet/CMakeLists.txt
+++ b/src/autonet/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost COMPONENTS regex QUIET)
+find_package(Boost COMPONENTS regex system QUIET)
 if(NOT Boost_FOUND)
   message("Cannot build Autonet, boost not installed on this system")
   return()

--- a/src/autonet/test/CMakeLists.txt
+++ b/src/autonet/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_library(Boost REQUIRED)
+
 include_directories(
   #include test helpers form autowiring
   ${PROJECT_SOURCE_DIR}/src/autowiring/test
@@ -10,6 +12,7 @@ set(AutoNetTest_SRCS
 )
 
 ADD_MSVC_PRECOMPILED_HEADER("stdafx.h" "stdafx.cpp" AutoNetTest_SRCS)
+link_directories(${Boost_LIBRARY_DIRS})
 add_executable(AutoNetTest ${AutoNetTest_SRCS})
 target_link_libraries(AutoNetTest AutoNet Autowiring)
 set_property(TARGET AutoNetTest PROPERTY FOLDER "Autowiring")


### PR DESCRIPTION
This is needed on Windows at a minimum because of the loathsome use of pragma comment, other platforms may have the same requirement.
