### PR TITLE
Do not permit find_package to cheat

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.0.0)
 include(../version.cmake)
-find_package(autowiring ${autowiring_VERSION} REQUIRED)
+
+project(examples)
+
+set(autowiring_VERSION_REQUESTED ${autowiring_VERSION})
+set(autowiring_VERSION)
+find_package(autowiring ${autowiring_VERSION_REQUESTED} EXACT REQUIRED NO_CMAKE_BUILDS_PATH)
+message("Found autowiring ${autowiring_VERSION}")
+message("Include dir is ${autowiring_INCLUDE_DIR}")
 
 # Use C++11
 if(USE_LIBCXX)


### PR DESCRIPTION
Using the list of previously built packages circumvents the checking that's supposed to be done by hand by the code in this module.  We want to be absolutely sure that the installed version of Autowiring is being used, and not the one that's checked out currently.
