### PR TITLE
Adding an overload to support a common Autowired use case

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -800,6 +800,14 @@ public:
   }
 
   /// <summary>
+  /// Resolution overload
+  /// </summary>
+  template<class T>
+  void Snoop(const Autowired<T>& snooper) {
+    return Snoop(static_cast<const std::shared_ptr<T>&>(snooper));
+  }
+
+  /// <summary>
   /// Unregisters an event receiver previously registered to receive snooped events
   /// </summary>
   /// <remarks>

--- a/src/autowiring/test/SnoopTest.cpp
+++ b/src/autowiring/test/SnoopTest.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/Decoration.hpp"
+#include "TestFixtures/SimpleObject.hpp"
 
 class SnoopTest:
   public testing::Test
@@ -299,4 +300,13 @@ TEST_F(SnoopTest, SimplePackets) {
   packet2->Decorate(Decoration<0>());
   packet2->Decorate(Decoration<1>());
   EXPECT_FALSE(!!filter->m_called) << "Unsnoop didn't work";
+}
+
+TEST_F(SnoopTest, CanSnoopAutowired) {
+  AutoCurrentContext ctxt;
+  ctxt->Inject<SimpleObject>();
+
+  // Now autowire what we injeced and verify we can snoop this directly
+  Autowired<SimpleObject> so;
+  ctxt->Snoop(so);
 }


### PR DESCRIPTION
CoreContext::Snoop is used directly with an Autowired field very often, but unfortunately an implicit cast from Autowired to std::shared_ptr is not possible in a template context in cases where multiple cast operators are available.

This fix includes a convenience overload which matches Autowired<T>, as well as a use case unit test to guard this against regressions.
