### PR TITLE
Packaging command should be targeting all_build, not install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,11 +154,13 @@ if(NOT AUTOWIRING_IS_EMBEDDED)
   # leave those alone.
   SET(CPACK_WIX_TEMPLATE autowiring.wxs)
   SET(CPACK_MONOLITHIC_INSTALL ON)
-  
+
   # Run the script that will grab the debug and release configurations and install them during packaging
   set(CPACK_INSTALL_COMMANDS
-    "${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config Debug --target install"
-    "${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config Release --target install"
+    "${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config Debug --target all_build"
+    "${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config Release --target all_build"
+    "${CMAKE_COMMAND} -DBUILD_TYPE=Debug -P \\\"${CMAKE_SOURCE_DIR}/cmake_package.cmake\\\""
+    "${CMAKE_COMMAND} -DBUILD_TYPE=Release -P \\\"${CMAKE_SOURCE_DIR}/cmake_package.cmake\\\""
   )
 
   # Pick the generator in an appropriate way

--- a/cmake_package.cmake
+++ b/cmake_package.cmake
@@ -1,0 +1,2 @@
+set(CMAKE_INSTALL_PREFIX $ENV{CMAKE_INSTALL_PREFIX})
+include(cmake_install.cmake)


### PR DESCRIPTION
Install should run separately and forward in the install prefix path, this means we need a separate cmake_package script which can perform the forwarding, otherwise invoking "install" will instead attempt to perform the real install to the program files directory.
