### PR TITLE
Fix cpack build target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ script:
   - sudo make install
 
   # Package
-  - sudo cpack || cat _CPack_Packages/Linux/TGZ/InstallOutput.log
+  - sudo cpack || (cat _CPack_Packages/Linux/TGZ/InstallOutput.log; exit 1)
 
   # Build examples from installed Autowiring
   - cd examples 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,8 +175,8 @@ if(NOT AUTOWIRING_IS_EMBEDDED)
 
   # Run the script that will grab the debug and release configurations and install them during packaging
   set(CPACK_INSTALL_COMMANDS
-    "${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config Debug --target all_build"
-    "${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config Release --target all_build"
+    "${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config Debug"
+    "${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config Release"
     "${CMAKE_COMMAND} -DBUILD_TYPE=Debug -P \\\"${CMAKE_SOURCE_DIR}/cmake_package.cmake\\\""
     "${CMAKE_COMMAND} -DBUILD_TYPE=Release -P \\\"${CMAKE_SOURCE_DIR}/cmake_package.cmake\\\""
   )


### PR DESCRIPTION
`make` in cpack was erroring because it couldn't find the target `all_build`. This wasn't causing the travis build to fail. `ALL_BUILD` is the default target, so specifying it shouldn't be needed.
