### PR TITLE
Fix autowiring-config to not depend on install location

### DIFF
--- a/autowiring-config.cmake.in
+++ b/autowiring-config.cmake.in
@@ -5,11 +5,10 @@
 
 # Check if local build
 if ("@CMAKE_CURRENT_BINARY_DIR@" STREQUAL CMAKE_CURRENT_LIST_DIR)
-  include("${CMAKE_CURRENT_LIST_DIR}/AutowiringTargets.cmake")
   set(autowiring_INCLUDE_DIR "@PROJECT_SOURCE_DIR@")
 else()
-  include("@CMAKE_INSTALL_PREFIX@/cmake/AutowiringTargets.cmake")
-  set(autowiring_INCLUDE_DIR "@CMAKE_INSTALL_PREFIX@/include")
+  set(autowiring_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/../include")
 endif()
 
+include("${CMAKE_CURRENT_LIST_DIR}/AutowiringTargets.cmake")
 set(autowiring_FOUND TRUE)

--- a/src/autonet/CMakeLists.txt
+++ b/src/autonet/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost COMPONENTS system QUIET)
 if(NOT Boost_FOUND)
   message("Cannot build Autonet, boost not installed on this system")
@@ -33,8 +34,8 @@ rewrite_header_paths(AutoNet_SRCS)
 ADD_MSVC_PRECOMPILED_HEADER("stdafx.h" "stdafx.cpp" AutoNet_SRCS)
 
 add_library(AutoNet SHARED ${AutoNet_SRCS})
-set_target_properties(AutoNet PROPERTIES DEBUG_POSTFIX d)
 target_link_libraries(AutoNet Autowiring ${Boost_LIBRARIES})
+set_target_properties(AutoNet PROPERTIES INTERFACE_LINK_LIBRARIES Autowiring)
 set_property(TARGET AutoNet PROPERTY FOLDER "Autowiring")
 
 #


### PR DESCRIPTION
Also remove hardcoded interface link to boost in AutoNet install.
