### PR TITLE
Rename conflicting name in websocketpp

### DIFF
--- a/contrib/websocketpp/websocketpp/common/network.hpp
+++ b/contrib/websocketpp/websocketpp/common/network.hpp
@@ -50,7 +50,7 @@ inline bool is_little_endian() {
 #define TYP_SMLE 1
 #define TYP_BIGE 2
 
-inline uint64_t htonll(uint64_t src) {
+inline uint64_t htonll_good(uint64_t src) {
     static int typ = TYP_INIT;
     unsigned char c;
     union {
@@ -71,8 +71,8 @@ inline uint64_t htonll(uint64_t src) {
     return x.ull;
 }
 
-inline uint64_t ntohll(uint64_t src) {
-    return htonll(src);
+inline uint64_t ntohll_good(uint64_t src) {
+    return htonll_good(src);
 }
 
 } // net

--- a/contrib/websocketpp/websocketpp/frame.hpp
+++ b/contrib/websocketpp/websocketpp/frame.hpp
@@ -264,7 +264,7 @@ private:
         }
 
         uint64_converter temp64;
-        temp64.i = lib::net::htonll(payload_size);
+        temp64.i = lib::net::htonll_good(payload_size);
         std::copy(temp64.c+payload_offset,temp64.c+8,bytes);
 
         return 8-payload_offset;
@@ -581,7 +581,7 @@ inline uint16_t get_extended_size(const extended_header &e) {
 inline uint64_t get_jumbo_size(const extended_header &e) {
     uint64_converter temp64;
     std::copy(e.bytes,e.bytes+8,temp64.c);
-    return lib::net::ntohll(temp64.i);
+    return lib::net::ntohll_good(temp64.i);
 }
 
 /// Extract the full payload size field from a WebSocket header

--- a/src/autonet/AutoNetServerImpl.hpp
+++ b/src/autonet/AutoNetServerImpl.hpp
@@ -11,8 +11,8 @@
 // created if our static library is imported by another project that uses an incompatible
 // version of websocketpp.
 #define websocketpp websocketpp_autonet
-#include <websocketpp/config/asio_no_tls.hpp>
 #include <websocketpp/server.hpp>
+#include <websocketpp/config/asio_no_tls.hpp>
 
 struct ObjectTraits;
 struct TypeIdentifierBase;


### PR DESCRIPTION
OSX Yosemite defines a macro with the same name
