### PR TITLE
Fix inline docs for Autowired

### DIFF
--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -198,7 +198,7 @@ public:
 /// </remarks>
 template<class T>
 class AutoRequired:
-public std::shared_ptr<T>
+  public std::shared_ptr<T>
 {
 public:
   using std::shared_ptr<T>::operator=;
@@ -227,7 +227,7 @@ public:
   //
   // !!!!! READ THIS IF YOU ARE GETTING A COMPILER ERROR HERE !!!!!
   AutoRequired(const std::shared_ptr<CoreContext>& ctxt = CoreContext::CurrentContext()):
-  std::shared_ptr<T>(ctxt->template Inject<T>())
+    std::shared_ptr<T>(ctxt->template Inject<T>())
   {}
   
   /// <summary>
@@ -235,7 +235,7 @@ public:
   /// </summary>
   template<class... Args>
   AutoRequired(const std::shared_ptr<CoreContext>& ctxt, Args&&... args) :
-  std::shared_ptr<T>(ctxt->template Inject<T>(std::forward<Args>(args)...))
+    std::shared_ptr<T>(ctxt->template Inject<T>(std::forward<Args>(args)...))
   {}
   
   operator bool(void) const {

--- a/autowiring/ObjectTraits.h
+++ b/autowiring/ObjectTraits.h
@@ -42,6 +42,7 @@ struct ObjectTraits {
           if (identifier->IsSameAs(pObject.get()))
             return true;
         }
+        // HACK: Manually check if type implements AutowiringEvents
         return !!dynamic_cast<const AutowiringEvents*>(pObject.get());
       }()
     )


### PR DESCRIPTION
The comments in Autowired didn't reflect that it works with forward-declared types
