### PR TITLE
DO NOT force boost static linkage

### DIFF
--- a/src/autonet/CMakeLists.txt
+++ b/src/autonet/CMakeLists.txt
@@ -1,4 +1,3 @@
-set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost COMPONENTS system QUIET)
 if(NOT Boost_FOUND)
   message("Cannot build Autonet, boost not installed on this system")


### PR DESCRIPTION
Static libraries will have funny behaviors on certain platforms, and aren't always necessary to cure portability concerns on platforms like Linux.  Instead, do what the FindBoost documentation recommends, and allow it to default in a platform-specific way.
