### PR TITLE
Status of LibCXX is now validated in version checker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,13 +16,13 @@ if(EXTERNAL_LIBRARY_DIR)
   list(APPEND CMAKE_INCLUDE_PATH ${EXTERNAL_LIBRARY_DIR})
 endif()
 
-# Offer option for USE_LIBCXX only if not defined by enclosing project
-# Check for existing definition of USE_LIBCXX
-if(NOT DEFINED USE_LIBCXX)
-  option(USE_LIBCXX "Build Autowiring using c++11" ON)
+# Offer option for autowiring_USE_LIBCXX only if not defined by enclosing project
+# Check for existing definition of autowiring_USE_LIBCXX
+if(NOT DEFINED autowiring_USE_LIBCXX)
+  option(autowiring_USE_LIBCXX "Build Autowiring using c++11" ON)
 else()
-  if(NOT USE_LIBCXX)
-    message("Parent project has set USE_LIBCXX = OFF -> Build Autowiring using c++98")
+  if(NOT autowiring_USE_LIBCXX)
+    message("Parent project has set autowiring_USE_LIBCXX = OFF -> Build Autowiring using c++98")
   endif()
 endif()
 
@@ -30,7 +30,7 @@ if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
   set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libstdc++")
 endif()
-if(USE_LIBCXX)
+if(autowiring_USE_LIBCXX)
   # Clang needs special additional flags to build with C++11
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
     # Apple needs us to tell it that we're using libc++, or it will try to use libstdc++ instead

--- a/autowiring-configVersion.cmake.in
+++ b/autowiring-configVersion.cmake.in
@@ -7,6 +7,22 @@ if(NOT ${CMAKE_SIZEOF_VOID_P} STREQUAL @CMAKE_SIZEOF_VOID_P@)
   return()
 endif()
 
+# Determine whether the user's request (either implied or explicit) for libstdc++ can
+# be met by this verison of Autowiring
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+  # If this value isn't defined, then we assume the user's request is "on"
+  if(NOT DEFINED autowiring_USE_LIBCXX)
+    SET(autowiring_USE_LIBCXX ON)
+  endif()
+
+  # Our built version must be the same as the requested version.  If it's not, then we are
+  # not a match for the user's request
+  if((NOT ${autowiring_USE_LIBCXX} AND @autowiring_USE_LIBCXX@) OR (${autowiring_USE_LIBCXX} AND NOT @autowiring_USE_LIBCXX@))
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+    set(PACKAGE_VERSION_UNSUITABLE TRUE)
+  endif()
+endif()
+
 # Check whether the requested PACKAGE_FIND_VERSION is compatible
 if("${PACKAGE_VERSION}" VERSION_LESS "${PACKAGE_FIND_VERSION}")
   set(PACKAGE_VERSION_COMPATIBLE FALSE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,12 +6,12 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/src/autotesting
 )
 
-# The boost C++11 shim is required when building without USE_LIBCXX
-if(NOT USE_LIBCXX)
+# The boost C++11 shim is required when building without autowiring_USE_LIBCXX
+if(NOT autowiring_USE_LIBCXX)
   find_package(Boost COMPONENTS thread atomic chrono system date_time QUIET)
 
   if (NOT Boost_FOUND)
-    message(FATAL_ERROR "Boost is required when building without USE_LIBCXX")
+    message(FATAL_ERROR "Boost is required when building without autowiring_USE_LIBCXX")
   endif()
 
   include_directories(${Boost_INCLUDE_DIR})

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -216,8 +216,8 @@ target_include_directories(Autowiring INTERFACE
 )
 set_property(TARGET Autowiring PROPERTY FOLDER "Autowiring")
 
-# The boost C++11 shim is required when building without USE_LIBCXX
-if(NOT USE_LIBCXX)
+# The boost C++11 shim is required when building without autowiring_USE_LIBCXX
+if(NOT autowiring_USE_LIBCXX)
   find_package(Boost COMPONENTS thread atomic chrono system date_time QUIET)
   target_link_libraries(Autowiring ${Boost_LIBRARIES})
 endif()

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -55,7 +55,7 @@ set(AutowiringTest_SRCS
   UuidTest.cpp
 )
 
-if(USE_LIBCXX)
+if(autowiring_USE_LIBCXX)
   set(AutowiringTest_SRCS ${AutowiringTest_SRCS}
     AutoFilterFunctionTest.cpp
     AutoFilterPipeTest.cpp


### PR DESCRIPTION
Because autowiring_USE_LIBCXX affects whether or not the requested version is compilable by a client, we now allow a client to specify this flag before invoking find_package in order to assess compatibility of the client's request with the version of autowiring identified.  This is a necessary first step to getting side-by-side installations of Autowiring.
