### PR TITLE
Unnecessary to specify boost as a link dependency of autowiring

### DIFF
--- a/AutowiringConfig.h.in
+++ b/AutowiringConfig.h.in
@@ -9,8 +9,8 @@
 #cmakedefine01 AUTOWIRING_BUILD_AUTONET
 
 // Are we linking with C++11 STL?
-#cmakedefine01 USE_LIBCXX
-#if USE_LIBCXX
+#cmakedefine01 autowiring_USE_LIBCXX
+#if autowiring_USE_LIBCXX
 #define AUTOWIRING_USE_LIBCXX 1
 #else
 #define AUTOWIRING_USE_LIBCXX 0

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -216,10 +216,11 @@ target_include_directories(Autowiring INTERFACE
 )
 set_property(TARGET Autowiring PROPERTY FOLDER "Autowiring")
 
-# The boost C++11 shim is required when building without autowiring_USE_LIBCXX
-if(NOT autowiring_USE_LIBCXX)
+# The boost C++11 shim is required when building without autowiring_USE_LIBCXX off Windows
+# We do not mention the link libraries; rather, we require that downstream clients
+# satisfy this link dependency.
+if(NOT WIN32 AND NOT autowiring_USE_LIBCXX)
   find_package(Boost COMPONENTS thread atomic chrono system date_time QUIET)
-  target_link_libraries(Autowiring ${Boost_LIBRARIES})
 endif()
 
 # Need multithreading services if available

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -80,6 +80,10 @@ set_property(TARGET AutowiringFixture PROPERTY FOLDER "Autowiring")
 ADD_MSVC_PRECOMPILED_HEADER("stdafx.h" "stdafx.cpp" AutowiringTest_SRCS)
 add_executable(AutowiringTest ${AutowiringTest_SRCS})
 target_link_libraries(AutowiringTest Autowiring AutowiringFixture AutoTesting)
+if(WIN32 AND NOT autowiring_USE_LIBCXX)
+  find_package(Boost COMPONENTS thread atomic chrono system date_time QUIET)
+  target_link_libraries(AutowiringTest ${Boost_LIBRARIES})
+endif()
 
 # Link AutoNet if we've got it
 if(TARGET AutoNet)


### PR DESCRIPTION
Boost is only required during the link step for libstdc++ when building autowiring, we should require that customers of Autowiring link to their preferred version of boost rather than trying to mandate that they use a version that we specify ourselves.  Our own internally specified version will not have the correct path, anyway, and so a specification here is counterproductive
