### PR TITLE
Update target_link_libraries for AutoNet

### DIFF
--- a/src/autonet/CMakeLists.txt
+++ b/src/autonet/CMakeLists.txt
@@ -33,7 +33,7 @@ rewrite_header_paths(AutoNet_SRCS)
 ADD_MSVC_PRECOMPILED_HEADER("stdafx.h" "stdafx.cpp" AutoNet_SRCS)
 
 add_library(AutoNet SHARED ${AutoNet_SRCS})
-target_link_libraries(AutoNet Autowiring ${Boost_LIBRARIES})
+target_link_libraries(AutoNet PRIVATE ${Boost_LIBRARIES} Autowiring)
 set_target_properties(AutoNet PROPERTIES INTERFACE_LINK_LIBRARIES Autowiring)
 
 set_property(TARGET AutoNet PROPERTY FOLDER "Autowiring")


### PR DESCRIPTION
Boost link libraries are not needed as a transitive dependency for AutoNet
