### PR TITLE
32-bit build is selected from the CMake command line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,4 @@
 cmake_minimum_required(VERSION 3.0)
-include(version.cmake)
-project(autowiring VERSION ${autowiring_VERSION})
-include(CTest)
 
 # Determine whether Autowiring has been embedded in another project
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
@@ -16,12 +13,10 @@ if(EXTERNAL_LIBRARY_DIR)
   list(APPEND CMAKE_INCLUDE_PATH ${EXTERNAL_LIBRARY_DIR})
 endif()
 
-if(CMAKE_COMPILER_IS_GNUCC)
-  option(autowiring_BUILD_32 "Target a 32-bit build" OFF)
-  if(autowiring_BUILD_32)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
-  endif()
-endif()
+include(version.cmake)
+project(autowiring VERSION ${autowiring_VERSION})
+include(CTest)
+include(CheckTypeSize)
 
 if(NOT WIN32)
   # Offer option for autowiring_USE_LIBCXX

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ CentOS systems use yum.  The major apparent difference to the user will be that 
     make test
     sudo make install
 
+If you want to build for 32-bit Linux, run the following CMake command instead:
+
+    cmake . -DCMAKE_CXX_FLAGS=-m32 -DCMAKE_C_FLAGS=-m32
+
 ### Windows
 
 Unfortunately, Windows doesn't have any sort of nifty package manager, and this requires that you download and install the boost dependency by hand.  Once


### PR DESCRIPTION
A CMake command line option rather than a build option is required to select 32-bit builds.  The readme file has been updated correspondingly.  Doing this allows CMake to correctly set variables such as CMAKE_SIZEOF_VOID_P and ensures that the behavior of find_package and find_library is correct.
