### PR TITLE
Fix library postfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ if(autowiring_ARCHITECTURE STREQUAL "arm")
 
   foreach(config IN LISTS CMAKE_CONFIGURATION_TYPES)
     string(TOUPPER ${config} config)
-    string(CONCAT CMAKE_${config}_POSTFIX CMAKE_${config}_POSTFIX "64")
+    string(CONCAT CMAKE_${config}_POSTFIX "${CMAKE_${config}_POSTFIX}" "64")
   endforeach()
 endif()
 
@@ -138,7 +138,7 @@ endif()
 if(autowiring_BUILD_64)
   foreach(config IN LISTS CMAKE_CONFIGURATION_TYPES)
     string(TOUPPER ${config} config)
-    string(CONCAT CMAKE_${config}_POSTFIX CMAKE_${config}_POSTFIX "64")
+    string(CONCAT CMAKE_${config}_POSTFIX "${CMAKE_${config}_POSTFIX}" "64")
   endforeach()
 endif()
 


### PR DESCRIPTION
On mac at least, `CMAKE_DEBUG_POSTFIX` and `CMAKE_LIBRARY_POSTFIX` were literally added to 64 bit library file names. This is because they weren't being escaped properly.
