### PR TITLE
Correcting Mac build error

### DIFF
--- a/autowiring/AutoInjectable.h
+++ b/autowiring/AutoInjectable.h
@@ -10,8 +10,6 @@ public:
   virtual void operator()(AutoFuture* pFuture) const = 0;
 };
 
-extern template class std::shared_ptr<AutoInjectableExpressionBase>;
-
 /// <summary>
 /// An expression type, which generally encapsulates a single injection operation
 /// </summary>

--- a/src/autowiring/AutoInjectable.cpp
+++ b/src/autowiring/AutoInjectable.cpp
@@ -4,7 +4,6 @@
 
 AutoInjectableExpressionBase::AutoInjectableExpressionBase(void){}
 AutoInjectableExpressionBase::~AutoInjectableExpressionBase(void){}
-template class std::shared_ptr<AutoInjectableExpressionBase>;
 
 AutoInjectable::AutoInjectable(AutoInjectableExpressionBase* pValue) :
   pValue(pValue),


### PR DESCRIPTION
We don't actually need to explicitly instantiate this template type, and attempting to do so causes certain member functions (such as the [] operator) to be defined where normally they would not be instantiated.
