### PR TITLE
Targets should have be associated with a set of architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,18 +5,27 @@ project(autowiring VERSION ${autowiring_VERSION})
 include(CTest)
 include(CheckTypeSize)
 
+if(APPLE)
+  option(autowiring_BUILD_FAT "Build fat binaries for Autowiring" ON)
+  set(CMAKE_OSX_ARCHITECTURES "x86_64;i386" CACHE STRING "Mac OS X build architectures" FORCE)
+endif()
+
 # Need to classify the architecture before we run anything else
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
-  set(autowiring_ARCHITECTURE "arm")
+  set(autowiring_BUILD_ARM ON)
+  set(autowiring_BUILD_ARCHITECTURES "arm")
   set(autowiring_BUILD_64 OFF)
+elseif(CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64;i386")
+  set(autowiring_BUILD_ARCHITECTURES x64 x86)
+  set(autowiring_BUILD_64 ON)
 elseif(CMAKE_SIZEOF_VOID_P STREQUAL 4)
-  set(autowiring_ARCHITECTURE "x86")
+  set(autowiring_BUILD_ARCHITECTURES "x86")
   set(autowiring_BUILD_64 OFF)
 else()
-  set(autowiring_ARCHITECTURE "x64")
+  set(autowiring_BUILD_ARCHITECTURES "x64")
   set(autowiring_BUILD_64 ON)
 endif()
-message(STATUS "Using architecture: ${autowiring_ARCHITECTURE}")
+message(STATUS "Using architecture: ${autowiring_BUILD_ARCHITECTURES}")
 
 # Determine whether Autowiring has been embedded in another project
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
@@ -56,7 +65,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   endif()
 endif()
 
-message("Version number ${CMAKE_CXX_COMPILER_VERSION}")
+message(STATUS "Compiler version ${CMAKE_CXX_COMPILER_VERSION}")
 
 # Always use c++11 compiler
 if(NOT WIN32)
@@ -67,19 +76,19 @@ endif()
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
   # Apple needs us to tell it that we're using libc++, or it will try to use libstdc++ instead
   if(autowiring_USE_LIBCXX)
-    message("AppleClang C++11")
+    message(STATUS "AppleClang C++11")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
     set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
   else()
-    message("AppleClang C++11 with libstdc++")
+    message(STATUS "AppleClang C++11 with libstdc++")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
     set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libstdc++")
   endif()
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  message("Clang C++11")
+  message(STATUS "Clang C++11")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lstdc++")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  message("GCC C++11")
+  message(STATUS "GCC C++11")
 endif()
 
 # Also need position-independent code to make things work correctly on certain 64-bit machines
@@ -90,7 +99,7 @@ endif()
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 include(CMakeModules/pch.cmake)
 
-if(autowiring_ARCHITECTURE STREQUAL "arm")
+if(autowiring_BUILD_ARM)
   # Currently cannot build Autonet for ARM, so default this off on that platform
   set(AUTOWIRING_BUILD_AUTONET_DEFAULT OFF)
 else()
@@ -125,7 +134,7 @@ endif()
 
 # ARM installations should have "arm" as the suffix for the generated libraries and should be
 # position-independent
-if(autowiring_ARCHITECTURE STREQUAL "arm")
+if(autowiring_BUILD_ARM)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
   foreach(config IN LISTS CMAKE_CONFIGURATION_TYPES)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ Autowiring is an [inversion-of-control](http://en.wikipedia.org/wiki/Inversion_o
 
 Autowiring project structure is specified with [CMake](http://www.cmake.org/). Simply point CMake to the root project directory and generate your desired project file. While Autowiring is written using C++11 features, it supports linking the non-C++11 STL. The `C++11/` directory provides [boost](http://www.boost.org/) shims for missing C++11 library features.
 
+### CMake Options
+
+Because AutoNet has a Boost dependency, it can sometimes be desirable to influence how Boost should be linked to the project.  You can influence the decision
+making process by setting CMake Boost attributes, which are described by the [cmake documentation](http://www.cmake.org/cmake/help/v3.0/module/FindBoost.html).
+A common use case is to statically link to a pre-specified installation of boost.  To do this, run CMake as follows:
+
+    cmake . \ 
+      -DBOOST_ROOT:PATH=/path/to/boost \ 
+      -DBoost_USE_STATIC_LIBS:BOOL=ON \ 
+      -DBoost_NO_SYSTEM_PATHS:BOOL=ON
+
+Watch the cases, you will get "unused variable" warnings if you don't match what is written above exactly.
+
 ### Mac
 
 Mac dependencies are installed with [port](http://guide.macports.org/) or [brew](http://brew.sh/).  If you have port installed, this will build the project:
@@ -17,6 +30,12 @@ Mac dependencies are installed with [port](http://guide.macports.org/) or [brew]
     make
     make test
     sudo make install
+
+This will configure the project to build fat binaries by default.  If you wish to build only 64-bit binaries, use the following CMake command instead:
+
+    cmake . -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64
+
+Note that AutoNet will be built for 64-bit only, unless your Boost installation was built as fat binaries.
 
 ### Unix
 

--- a/autowiring-configVersion.cmake.in
+++ b/autowiring-configVersion.cmake.in
@@ -4,8 +4,8 @@ if(autowiring_DEBUG)
   message(STATUS "Debug mode on")
   message(STATUS "Installed autowiring_VERSION: @autowiring_VERSION@")
 
-  message(STATUS "Installed autowiring_ARCHITECTURE: @autowiring_ARCHITECTURE@")
-  message(STATUS "Configured autowiring_ARCHITECTURE: ${autowiring_ARCHITECTURE}")
+  message(STATUS "Installed autowiring_BUILD_ARCHITECTURES: @autowiring_BUILD_ARCHITECTURES@")
+  message(STATUS "Configured autowiring_BUILD_ARCHITECTURES: ${autowiring_BUILD_ARCHITECTURES}")
 
   message(STATUS "Installed CMAKE_SIZEOF_VOID_P: @CMAKE_SIZEOF_VOID_P@")
   message(STATUS "Configured CMAKE_SIZEOF_VOID_P: ${CMAKE_SIZEOF_VOID_P}")
@@ -16,50 +16,53 @@ endif()
 
 # If the customer has an override architecture requirement, use that
 if(DEFINED autowiring_ARCHITECTURE)
-  string(REGEX MATCH "amd64|x86_64|x64" autowiring_is_x64 ${autowiring_ARCHITECTURE})
-  string(REGEX MATCH "i386|x86" autowiring_is_x86 ${autowiring_ARCHITECTURE})
-  string(REGEX MATCH "arm" autowiring_is_arm ${autowiring_ARCHITECTURE})
+  foreach(i IN LISTS autowiring_ARCH)
+    string(REGEX MATCH "amd64|x86_64|x64" autowiring_is_x64 ${i})
+    string(REGEX MATCH "i386|x86" autowiring_is_x86 ${i})
+    string(REGEX MATCH "arm" autowiring_is_arm ${i})
 
-  # Clear the autowiring_ARCHITECTURE variable so we can tell if something went wrong
-  set(autowiring_ARCHITECTURE)
-
-  # Classify
-  if(autowiring_is_x86)
-    set(autowiring_ARCHITECTURE x86)
-  elseif(autowiring_is_x64)
-    set(autowiring_ARCHITECTURE x64)
-  elseif(autowiring_is_arm)
-    set(autowiring_ARCHITECTURE arm)
-  endif()
-
-  if(NOT DEFINED autowiring_ARCHITECTURE)
-    message(WARNING "Unrecognized architecture ${autowiring_ARCHITECTURE}")
-    set(autowiring_WORD_WIDTH -1)
-  endif()
+    # Classify
+    if(autowiring_is_x86)
+      list(APPEND autowiring_ARCHITECTURES x86)
+    elseif(autowiring_is_x64)
+      list(APPEND autowiring_ARCHITECTURES x64)
+    elseif(autowiring_is_arm)
+      list(APPEND autowiring_ARCHITECTURES arm)
+    else()
+      message(WARNING "Unrecognized architecture ${i}")
+    endif()
+  endforeach()
 else()
   # Try to infer what the user wants
   if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
-    set(autowiring_ARCHITECTURE arm)
+    set(autowiring_ARCHITECTURES arm)
   elseif(CMAKE_SIZEOF_VOID_P EQUAL "8")
-    set(autowiring_ARCHITECTURE x64)
+    set(autowiring_ARCHITECTURES x64)
   else()
-    set(autowiring_ARCHITECTURE x86)
+    set(autowiring_ARCHITECTURES x86)
   endif()
 endif()
 
 if(autowiring_DEBUG)
   message(STATUS "autowiring_ARCHITECTURE: ${autowiring_ARCHITECTURE}")
+  message(STATUS "autowiring_ARCHITECTURES: ${autowiring_ARCHITECTURES}")
 endif()
 
-# Verify that we have a word width matching the bit depth desired by the customer
-if(NOT autowiring_ARCHITECTURE STREQUAL "@autowiring_ARCHITECTURE@")
-  set(PACKAGE_VERSION_COMPATIBLE FALSE)
-  set(PACKAGE_VERSION_UNSUITABLE TRUE)
-  if(autowiring_DEBUG)
-    message(STATUS "Requested architecture of ${autowiring_ARCHITECTURE} not compatible with @autowiring_ARCHITECTURE@")
+# Architectures we were built with
+set(autowiring_BUILD_ARCHITECTURES @autowiring_BUILD_ARCHITECTURES@)
+
+# Verify that we match all of the architectures requested by the customer
+foreach(i IN LISTS autowiring_ARCHITECTURES)
+  list(FIND autowiring_BUILD_ARCHITECTURES $i found)
+  if(found EQUAL -1)
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+    set(PACKAGE_VERSION_UNSUITABLE TRUE)
+    if(autowiring_DEBUG)
+      message(STATUS "Requested architecture of ${autowiring_ARCHITECTURE} not compatible with @autowiring_BUILD_ARCHITECTURES@")
+    endif()
+    return()
   endif()
-  return()
-endif()
+endforeach()
 
 # Determine whether the user's request (either implied or explicit) for libstdc++ can
 # be met by this verison of Autowiring

--- a/src/autonet/CMakeLists.txt
+++ b/src/autonet/CMakeLists.txt
@@ -1,7 +1,9 @@
-find_package(Boost COMPONENTS system QUIET)
 if(NOT Boost_FOUND)
-  message("Cannot build Autonet, boost not installed on this system")
-  return()
+  find_package(Boost COMPONENTS system QUIET)
+  if(NOT Boost_FOUND)
+    message("Cannot build Autonet, boost not installed on this system")
+    return()
+  endif()
 endif()
 
 option(AUTOWIRING_BUILD_AUTONET "Build Autonet debugging server" ${AUTOWIRING_BUILD_AUTONET_DEFAULT})
@@ -9,7 +11,7 @@ if(NOT AUTOWIRING_BUILD_AUTONET)
   return()
 endif()
 
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
+if(autowiring_BUILD_ARM)
   message(FATAL_ERROR "Cannot currently build Autonet for ARM processors")
 endif()
 
@@ -42,11 +44,35 @@ set_target_properties(AutoNet PROPERTIES INTERFACE_LINK_LIBRARIES Autowiring)
 
 set_property(TARGET AutoNet PROPERTY FOLDER "Autowiring")
 
+# On Mac, we have to figure out whether the target is 64-bit or fat
+if(APPLE)
+  foreach(i IN LISTS Boost_LIBRARIES)
+    execute_process(COMMAND otool -arch all -vh "${i}" OUTPUT_VARIABLE LibProps)
+    string(FIND ${LibProps} "x86_64" LibProps_MATCH_X64)
+    string(FIND ${LibProps} "i386" LibProps_MATCH_I386)
+
+    if(NOT LibProps_MATCH_X64 EQUAL -1)
+      if(NOT LibProps_MATCH_I386 EQUAL -1)
+        # Fat binary, no action necessary
+      else()
+        # 64-bit only, remove the 64-bit target
+        message(WARNING "Boost library ${i} is not a fat binary, building Autonet for 64-bit only")
+        set_target_properties(AutoNet PROPERTIES OSX_ARCHITECTURES "x86_64")
+        set_target_properties(AutoNetTest PROPERTIES OSX_ARCHITECTURES "x86_64")
+        set(NO_INSTALL_AUTONET ON)
+      endif()
+    else()
+      message(${LibProps})
+      message(FATAL_ERROR "Cannot build autonet with 32-bit boost binaries, set Boost_ROOT to point to a 64-bit boost installation")
+    endif()
+  endforeach()
+endif()
+
 #
 # Install library
 #
 
-if(NOT AUTOWIRING_IS_EMBEDDED)
+if(NOT NO_INSTALL_AUTONET AND NOT AUTOWIRING_IS_EMBEDDED)
   install(TARGETS AutoNet EXPORT AutowiringTargets
     DESTINATION lib
     COMPONENT autowiring 


### PR DESCRIPTION
Additionally, Mac should build fat binaries by default.  Furthermore, the name "autowiring_ARCHITECTURE" is now exclusively used for package configuration, and the variable autowiring_BUILD_ARCHITECTURES is used internally instead.
- [x] Verify that this builds and links properly to a fat target on Mac
