### PR TITLE
Fix unit test which uses an invalid unowned lock release

### DIFF
--- a/src/autowiring/test/ObjectPoolTest.cpp
+++ b/src/autowiring/test/ObjectPoolTest.cpp
@@ -275,22 +275,45 @@ TEST_F(ObjectPoolTest, CanRundownOneIssued) {
   pool.Rundown();
 }
 
+class ExposedObjectPool:
+  public ObjectPool<int>
+{
+public:
+  using ObjectPool<int>::m_monitor;
+};
+
 TEST_F(ObjectPoolTest, RundownWhileWaiting) {
   ObjectPool<int> pool(1);
   auto first = pool.Wait();
   
-  std::mutex mut;
-  
-  std::unique_lock<std::mutex> lk1(mut);
-  auto future = std::async(std::launch::async, [&pool, &lk1]{
-    ASSERT_ANY_THROW((lk1.unlock(), pool.Wait())) << "pool should throw if it is rundown while threads are waiting";
+  std::mutex lock;
+  std::condition_variable cv;
+  bool proceed = false;
+
+  auto future = std::async(std::launch::async, [&] {
+    {
+      std::lock_guard<std::mutex> lk(lock);
+      proceed = true;
+      cv.notify_all();
+    }
+    ASSERT_ANY_THROW(pool.Wait()) << "Wait operation should throw if it is rundown while threads are waiting";
   });
   
-  // Make sure async call is waiting
-  std::unique_lock<std::mutex> lk2(mut);
+  // Block until the async call is at least started
+  std::unique_lock<std::mutex> lk(lock);
+  ASSERT_TRUE(
+    cv.wait_for(lk, std::chrono::seconds(5), [&proceed] { return proceed; })
+  ) << "Dependent thread did not initiate in time";
+
+  // Block until the thread is (probably) waiting
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
   
+  // Now, ensure no crashing:
   first.reset();
   pool.Rundown();
+
+  // Make sure the thread goes away before we do:
+  future.wait();
 }
 
 TEST_F(ObjectPoolTest, OutstandingLimitIsOne) {


### PR DESCRIPTION
This pattern might work on certain systems, but it's actually not correct to release a lock from anywhere except the thread which originally obtained that lock.  For synchronization in this fashion, a barrier or a conditional variable is preferred--a conditional variable is used here for portability.  Unfortunately, in this case, a total guarantee that the async is waiting is not possible--a short thread sleep is used instead to provide a one-sided error guarantee in this test.
