### PR TITLE
Fixing issues with types that inherit their AutoFilter implementation

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -494,7 +494,7 @@ public:
     std::shared_ptr<typename CreationRules::TActual> retVal;
     FindByType(retVal);
     if(retVal)
-      return retVal;
+      return std::static_pointer_cast<T>(retVal);
 
     // We must make ourselves current for the remainder of this call:
     CurrentContextPusher pshr(shared_from_this());
@@ -519,7 +519,7 @@ public:
     // Factory registration if sensible to do so, but only after the underlying type has been
     // added, so that the proper type can succeed
     RegisterFactory(*retVal, autowiring::member_new_type<typename CreationRules::TActual>());
-    return retVal;
+    return std::static_pointer_cast<T>(retVal);
   }
 
   /// <summary>

--- a/autowiring/TypeUnifier.h
+++ b/autowiring/TypeUnifier.h
@@ -21,9 +21,12 @@ public:
   {}
 };
 
-template<class T, class RetType, class... Args>
-class TypeUnifierComplexAutoFilter:
-  public T,
+template<class TrueType, class MemFn>
+struct TypeUnifierComplexAutoFilter;
+
+template<class TrueType, class T, class RetType, class... Args>
+class TypeUnifierComplexAutoFilter<TrueType, RetType(T::*)(Args...)>:
+  public TrueType,
   public TypeUnifier
 {
 public:
@@ -46,15 +49,6 @@ public:
   RetType AutoFilter(Args... args) {
     return T::AutoFilter(std::forward<Args>(args)...);
   }
-};
-
-template<class MemFn>
-struct TypeUnifierComplexAutoFilterSelect;
-
-template<class T, class RetType, class... Args>
-struct TypeUnifierComplexAutoFilterSelect<RetType(T::*)(Args...)>
-{
-  typedef TypeUnifierComplexAutoFilter<T, RetType, Args...> type;
 };
 
 /// <summary>
@@ -82,6 +76,7 @@ struct SelectTypeUnifier<T, false, false> {
 
 // Otherwise, if there's a complex ctor, we have to use Args
 template<class T>
-struct SelectTypeUnifier<T, false, true>:
-  TypeUnifierComplexAutoFilterSelect<decltype(&T::AutoFilter)>
-{};
+struct SelectTypeUnifier<T, false, true>
+{
+  typedef TypeUnifierComplexAutoFilter<T, decltype(&T::AutoFilter)> type;
+};

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -1173,3 +1173,19 @@ TEST_F(AutoFilterTest, DeclareAutoFilterTest) {
   ASSERT_EQ(3, mf01->call_vals.size()) << "Failed to call AutoFilter wrapped method";
   ASSERT_EQ(2, mf01->call_vals.back()) << "Calling value was not propagated";
 }
+
+class MyInheritingAutoFilter:
+  public FilterGen<std::vector<int>>
+{};
+
+TEST_F(AutoFilterTest, AutoFilterInBaseClass) {
+  AutoRequired<MyInheritingAutoFilter> d;
+  AutoRequired<AutoPacketFactory> f;
+
+  // Packet decoration shouldn't cause problems by itself
+  auto packet = f->NewPacket();
+  packet->Decorate(std::vector<int>{0, 1, 2});
+
+  // Trivial validation that we got something back
+  ASSERT_EQ(1UL, d->m_called) << "Filter defined in base class was not called the expected number of times";
+}


### PR DESCRIPTION
Adding a unit test to demonstrate this problem, and a corresponding fix which involves modification of the TypeUnifierComplexAutoFilter to include the original type.

The root of the problem is that decltype(&T::Foo) might actually evaluate to a member function type incompatible with T.  This occurs when Foo is declared in a base of T, rather than in T itself, and the result is that TypeUnifierComplexAutoFilter will actually create concrete types that completely bypass T.
