### PR TITLE
Descriptor now uses the actual class type of &T::AutoFilter

### DIFF
--- a/autowiring/AutoFilterDescriptor.h
+++ b/autowiring/AutoFilterDescriptor.h
@@ -278,7 +278,13 @@ struct AutoFilterDescriptor:
   template<class T>
   AutoFilterDescriptor(const std::shared_ptr<T>& subscriber) :
     AutoFilterDescriptor(
-      AnySharedPointer(subscriber),
+      AnySharedPointer(
+        // Because T::AutoFilter might actually be present in a _base type_ of T, it's important that
+        // AnySharedPointer be instantiated with a pointer to the base type where the AutoFilter is
+        // actually defined.  In order to obtain this name, we decompose this member function, and
+        // then take the type of the decomposed result.
+        std::static_pointer_cast<typename Decompose<decltype(&T::AutoFilter)>::type>(subscriber)
+      ),
       &typeid(T),
       Decompose<decltype(&T::AutoFilter)>::template Enumerate<AutoFilterDescriptorInput>::types,
       CallExtractor<decltype(&T::AutoFilter)>::deferred,

--- a/autowiring/TypeUnifier.h
+++ b/autowiring/TypeUnifier.h
@@ -21,61 +21,23 @@ public:
   {}
 };
 
-template<class TrueType, class MemFn>
-class TypeUnifierComplexAutoFilter;
-
-template<class TrueType, class T, class RetType, class... Args>
-class TypeUnifierComplexAutoFilter<TrueType, RetType(T::*)(Args...)>:
-  public TrueType,
-  public TypeUnifier
-{
-public:
-  TypeUnifierComplexAutoFilter(void) {}
-
-  template<class ArgsHead, class... ArgsTail>
-  TypeUnifierComplexAutoFilter(ArgsHead&& argsh, ArgsTail&&... argst) :
-    T(std::forward<ArgsHead>(argsh), std::forward<ArgsTail>(argst)...)
-  {}
-
-  /// <summary>
-  /// Fixup AutoFilter call
-  /// </summary>
-  /// <remarks>
-  /// This is necessary because nonpolymorphic types cannot be held by an AnySharedPointer type,
-  /// and so we must instead hold a pointer to the type unifier instead of to the proper type.
-  /// Thus, in order to ensure that the nonpolymorphic instance is called with a correct value
-  /// of "this", this trivial forwarding routine is used to perform the fixup for us.
-  /// </remarks>
-  RetType AutoFilter(Args... args) {
-    return T::AutoFilter(std::forward<Args>(args)...);
-  }
-};
-
 /// <summary>
 /// Utility class which allows us to either use the pure type T, or a unifier, as appropriate
 /// </summary>
 template<
   class T,
-  bool inheritsObject = std::is_base_of<Object, T>::value,
-  bool has_autofilter = has_autofilter<T>::value
+  bool inheritsObject = std::is_base_of<Object, T>::value
 >
 struct SelectTypeUnifier;
 
 // Anyone already inheriting Object can just use Object
-template<class T, bool has_autofilter>
-struct SelectTypeUnifier<T, true, has_autofilter> {
+template<class T>
+struct SelectTypeUnifier<T, true> {
   typedef T type;
 };
 
 // Otherwise, if there's a complex ctor, we have to use Args
 template<class T>
-struct SelectTypeUnifier<T, false, false> {
+struct SelectTypeUnifier<T, false> {
   typedef TypeUnifierComplex<T> type;
-};
-
-// If an AutoFilter is present on this type, a special forwarding AutoFilter is necessary
-template<class T>
-struct SelectTypeUnifier<T, false, true>
-{
-  typedef TypeUnifierComplexAutoFilter<T, decltype(&T::AutoFilter)> type;
 };

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -1189,3 +1189,20 @@ TEST_F(AutoFilterTest, AutoFilterInBaseClass) {
   // Trivial validation that we got something back
   ASSERT_EQ(1UL, d->m_called) << "Filter defined in base class was not called the expected number of times";
 }
+
+class MyInheritingAutoFilterNoAlias:
+  public ContextMember,
+  public FilterGen<std::vector<int>>
+{};
+
+TEST_F(AutoFilterTest, AutoFilterInBaseClassNoAlias) {
+  AutoRequired<MyInheritingAutoFilterNoAlias> d;
+  AutoRequired<AutoPacketFactory> f;
+
+  // Packet decoration shouldn't cause problems by itself
+  auto packet = f->NewPacket();
+  packet->Decorate(std::vector<int>{0, 1, 2});
+
+  // Trivial validation that we got something back
+  ASSERT_EQ(1UL, d->m_called) << "Filter defined in base class in an Object-inheriting type was not called the expected number of times";
+}


### PR DESCRIPTION
Because T::AutoFilter might actually be present in a _base type_ of T, it's important that AnySharedPointer be instantiated with a to the base type where the AutoFilter is actually defined.  In order to obtain this name, we decompose this member function, and then take the type of the decomposed result.

An additional benefit of this change is that the AutoFilter type unifier is no longer necessary because the AnySharedPointer passed into the CallExtractor is guaranteed to already be instantiated with the correct type.
