### PR TITLE
Constexpr not supported in MSVC, fixing other miscellaneous MSVC compiler errors

### DIFF
--- a/autowiring/AutoParameter.h
+++ b/autowiring/AutoParameter.h
@@ -60,6 +60,6 @@ protected:
   const T m_default;
   
   bool isValid(const T& value) const {
-    return CallValidate<T, TKey>(value, has_validate<TKey>());
+    return CallValidate<T, TKey>(value, typename has_validate<TKey>::has_valid());
   }
 };

--- a/autowiring/has_validate.h
+++ b/autowiring/has_validate.h
@@ -5,14 +5,21 @@
 
 template<class T>
 struct has_validate_function {
+};
+
+/// <summary>
+/// Detects whether the specified type T has a static method with the name Validate
+/// </summary>
+template<class T>
+struct has_validate {
   template<class Fn, Fn>
   struct unnamed_constant;
 
   template<class U>
-  static std::false_type select(...);
+  static std::true_type select(decltype(&U::Validate));
 
   template<class U>
-  static std::true_type select(unnamed_constant<decltype(&U::Validate), &U::Validate>*);
+  static std::false_type select(...);
 
   // Conveninece typedef used externally:
   typedef decltype(select<T>(nullptr)) has_valid;
@@ -21,19 +28,11 @@ struct has_validate_function {
   static const bool value = has_valid::value;
 };
 
-/// <summary>
-/// Detects whether the specified type T has a static method with the name Validate
-/// </summary>
-template<class T>
-struct has_validate : has_validate_function<T>::has_valid {};
-
-template<class Object, class Validator>
-static bool CallValidate(const Object& obj, std::true_type) {
+template<class T, class Validator>
+static bool CallValidate(const T& obj, std::true_type) {
   return Validator::Validate(obj);
 }
 
-template<class Object, class Validator>
-static bool CallValidate(const Object& obj, std::false_type) {
-  return true;
-}
+template<class T, class Validator>
+static bool CallValidate(const T& obj, std::false_type) {return true;}
 

--- a/src/autowiring/test/AutoParameterTest.cpp
+++ b/src/autowiring/test/AutoParameterTest.cpp
@@ -16,6 +16,11 @@ struct MyParamClass1 {
   AutoParameter<int, MyIntParam1> m_param;
 };
 
+static_assert(
+  !has_validate<MyParamClass1::MyIntParam1>::value,
+  "has_validate SFINAE class incorrectly detected validator on MyIntParam1"
+);
+
 TEST_F(AutoParameterTest, VerifyCorrectDeconstruction) {
   AutoRequired<MyParamClass1> mpc;
   auto& param = mpc->m_param;
@@ -65,6 +70,11 @@ struct MyParamClass2 {
   
   AutoParameter<int, MyIntParam2> m_param;
 };
+
+static_assert(
+  has_validate<MyParamClass2::MyIntParam2>::value,
+  "has_validate SFINAE class failed to detect a validator on MyIntParam2"
+);
 
 TEST_F(AutoParameterTest, VerifyValidationFunction) {
   AutoRequired<MyParamClass2> mpc;


### PR DESCRIPTION
- [x] Fix unit test on Windows
