### PR TITLE
Adding the ability to attach a non-modifying listener to a packet

### DIFF
--- a/autowiring/CallExtractor.h
+++ b/autowiring/CallExtractor.h
@@ -19,7 +19,9 @@ template<class RetType, class... Args>
 struct CallExtractor<RetType (*)(Args...)>:
   Decompose<RetType(*)(Args...)>
 {
+  static const bool has_outputs = is_any<auto_arg<Args>::is_output...>::value;
   static const bool deferred = false;
+  static const bool stateless = true;
 
   /// <summary>
   /// Binder struct, lets us refer to an instance of Call by type
@@ -41,6 +43,7 @@ template<class T, class... Args>
 struct CallExtractor<void (T::*)(Args...)>:
   Decompose<void (T::*)(Args...)>
 {
+  static const bool has_outputs = is_any<auto_arg<Args>::is_output...>::value;
   static const bool stateless = false;
   static const bool deferred = false;
   static const size_t N = sizeof...(Args);
@@ -71,6 +74,7 @@ template<class T, class... Args>
 struct CallExtractor<void (T::*)(Args...) const> :
   Decompose<void (T::*)(Args...)>
 {
+  static const bool has_outputs = is_any<auto_arg<Args>::is_output...>::value;
   static const bool stateless = true;
   static const bool deferred = false;
   static const size_t N = sizeof...(Args);
@@ -93,6 +97,7 @@ template<class T, class... Args>
 struct CallExtractor<Deferred (T::*)(Args...)>:
   Decompose<void (T::*)(Args...)>
 {
+  static const bool has_outputs = is_any<auto_arg<Args>::is_output...>::value;
   static const bool stateless = false;
   static const bool deferred = true;
   static const size_t N = sizeof...(Args);

--- a/autowiring/InvokeRelay.h
+++ b/autowiring/InvokeRelay.h
@@ -68,7 +68,7 @@ public:
     erp(nullptr)
   {}
 
-  static_assert(!is_any<std::is_rvalue_reference<Args>...>::value, "Can't use rvalue references as event argument type");
+  static_assert(!is_any<std::is_rvalue_reference<Args>::value...>::value, "Can't use rvalue references as event argument type");
 
 private:
   std::shared_ptr<JunctionBox<T>> erp;
@@ -103,7 +103,7 @@ public:
     erp(nullptr)
   {}
 
-  static_assert(!is_any<std::is_rvalue_reference<Args>...>::value, "Can't use rvalue references as event argument type");
+  static_assert(!is_any<std::is_rvalue_reference<Args>::value...>::value, "Can't use rvalue references as event argument type");
 
 private:
   std::shared_ptr<JunctionBox<T>> erp;

--- a/autowiring/is_any.h
+++ b/autowiring/is_any.h
@@ -3,19 +3,19 @@
 #include TYPE_TRAITS_HEADER
 
 /// <summary>
-/// Check if any T::value is true
+/// Check if any T is true
 /// </summary>
 /// <remarks>
 /// Check is_any<...>::value for result
 /// </remarks>
-template<typename... T>
-struct is_any{
+template<bool... val>
+struct is_any {
   static const bool value = false;
 };
 
-template<typename Head, typename... Tail>
-struct is_any<Head, Tail...>{
-  static const bool value = Head::value || is_any<Tail...>::value;
+template<bool Head, bool... Tail>
+struct is_any<Head, Tail...> {
+  static const bool value = Head || is_any<Tail...>::value;
 };
 
 /// <summary>

--- a/src/autowiring/test/AutoFilterFunctionTest.cpp
+++ b/src/autowiring/test/AutoFilterFunctionTest.cpp
@@ -107,3 +107,20 @@ TEST_F(AutoFilterFunctionalTest, RecipientRemovalTest) {
 
   ASSERT_FALSE(*called) << "A recipient that should have been removed was called";
 }
+
+TEST_F(AutoFilterFunctionalTest, ObservingFunctionTest) {
+  AutoRequired<AutoPacketFactory> factory;
+
+  auto packet = factory->NewPacket();
+
+  // Attach a lambda to a const version of this packet:
+  auto called = std::make_shared<bool>(false);
+  static_cast<const AutoPacket&>(*packet) += [called](const Decoration<0>& dec, Decoration<1> dec1) {
+    *called = true;
+  };
+
+  // Verify that a call was made as expected once we decorate:
+  packet->Decorate(Decoration<0>());
+  packet->Decorate(Decoration<1>());
+  ASSERT_TRUE(*called) << "Receive-only filter attached to a const packet image was not correctly called";
+}


### PR DESCRIPTION
This permits users who have a const reference to an AutoPacket to monitor for the introduction of another decoration without running the risk of accidentally attaching unintended decorations to that packet.
