### PR TITLE
Eliminating of object pool concept from AutoPacketFactory

### DIFF
--- a/autowiring/AutoPacketFactory.h
+++ b/autowiring/AutoPacketFactory.h
@@ -5,7 +5,6 @@
 #include "AutoFilterDescriptor.h"
 #include "ContextMember.h"
 #include "CoreRunnable.h"
-#include "ObjectPool.h"
 #include <list>
 #include <vector>
 #include CHRONO_HEADER
@@ -48,15 +47,8 @@ private:
   // Outstanding reference if this factory is currently running:
   std::shared_ptr<Object> m_outstanding;
 
-  /// <summary>
-  /// An independently maintained object pool just for packets
-  /// </summary>
-  /// <remarks>
-  /// The object pool defined here is provided mainly to allow detection of
-  /// pipeline packet expiration in order to support expiration notification
-  /// broadcasts.
-  /// </remarks>
-  ObjectPool<AutoPacket> m_packets;
+  // Internal outstanding reference for issued packet:
+  std::weak_ptr<void> m_outstandingInternal;
 
   // Collection of known subscribers
   typedef std::unordered_set<AutoFilterDescriptor, std::hash<AutoFilterDescriptor>> t_autoFilterSet;
@@ -66,6 +58,9 @@ private:
   long long m_packetCount;
   double m_packetDurationSum;
   double m_packetDurationSqSum;
+
+  // Returns the internal outstanding count, for use with AutoPacket
+  std::shared_ptr<void> GetInternalOutstanding(void);
 
   // Recursive invalidation routine, causes AutoPacket object pools to be dumped to the root
   void Invalidate(void);

--- a/autowiring/AutoPacketInternal.h
+++ b/autowiring/AutoPacketInternal.h
@@ -1,0 +1,28 @@
+// Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "AutoPacket.h"
+
+/// <summary>
+/// Internal representation type for AutoPacket, provides methods for exclusive use with a packet factory
+/// <summary>
+class AutoPacketInternal:
+  public AutoPacket
+{
+public:
+  AutoPacketInternal(AutoPacketFactory& factory, std::shared_ptr<void>&& outstanding);
+  ~AutoPacketInternal(void);
+
+private:
+
+public:
+  /// <summary>
+  /// Decrements subscribers requiring AutoPacket argument then calls all initializing subscribers.
+  /// </summary>
+  /// <remarks>
+  /// Initialize is called when a packet is issued by the AutoPacketFactory.
+  /// It is not called when the Packet is created since that could result in
+  /// spurious calls when no packet is issued.
+  /// </remarks>
+  void Initialize(void);
+};
+

--- a/src/autowiring/AutoPacketInternal.cpp
+++ b/src/autowiring/AutoPacketInternal.cpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "AutoPacketInternal.h"
+#include "AutoPacketFactory.h"
+#include "SatCounter.h"
+
+AutoPacketInternal::AutoPacketInternal(AutoPacketFactory& factory, std::shared_ptr<void>&& outstanding) :
+  AutoPacket(factory, std::move(outstanding))
+{
+}
+
+AutoPacketInternal::~AutoPacketInternal(void)
+{
+}
+
+void AutoPacketInternal::Initialize(void) {
+  // Find all subscribers with no required or optional arguments:
+  std::list<SatCounter*> callCounters;
+  for (auto& satCounter : m_satCounters)
+    if (satCounter)
+      callCounters.push_back(&satCounter);
+
+  // Call all subscribers with no required or optional arguments:
+  // NOTE: This may result in decorations that cause other subscribers to be called.
+  for (SatCounter* call : callCounters)
+    call->CallAutoFilter(*this);
+
+  // First-call indicated by argumument type AutoPacket&:
+  UpdateSatisfaction(typeid(auto_arg<AutoPacket&>::id_type));
+}

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -28,6 +28,8 @@ set(Autowiring_SRCS
   AutoInjectable.h
   AutoPacket.cpp
   AutoPacket.h
+  AutoPacketInternal.cpp
+  AutoPacketInternal.h
   AutoPacketFactory.cpp
   AutoPacketFactory.h
   AutoPacketProfiler.cpp

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -21,6 +21,17 @@ public:
   }
 };
 
+TEST_F(AutoFilterTest, GetOutstandingTest) {
+  AutoRequired<AutoPacketFactory> factory;
+
+  {
+    auto packet = factory->NewPacket();
+    ASSERT_EQ(1UL, factory->GetOutstanding()) << "Factory outstanding count mismatch";
+  }
+
+  ASSERT_EQ(0UL, factory->GetOutstanding()) << "Factory outstanding did not go to zero after releasing the only outstanding packet";
+}
+
 TEST_F(AutoFilterTest, VerifyDescendentAwareness) {
   // Create a packet while the factory has no subscribers:
   AutoRequired<AutoPacketFactory> parentFactory;
@@ -138,6 +149,7 @@ public:
 TEST_F(AutoFilterTest, VerifyAutoOut) {
   AutoRequired<AutoPacketFactory> factory;
   AutoRequired<FilterOut> out;
+
   std::shared_ptr<AutoPacket> packet = factory->NewPacket();
   const Decoration<0>* result0 = nullptr;
   ASSERT_TRUE(packet->Get(result0)) << "Output missing";


### PR DESCRIPTION
The use of an object pool complicates AutoPacket's lifetime and does not appear to improve performance.  AutoPacket is actually a very small type; rather than using a pool to optimize initialization, it's probably more worthwhile to investigate memoization of the constructor into the AutoPacketFactory type.
