### PR TITLE
Corrected a minor defect with the direction of a linked list reference

### DIFF
--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -290,7 +290,7 @@ AutoPacket::Recipient AutoPacket::AddRecipient(const AutoFilterDescriptor& descr
     // (1) Append & Initialize new satisfaction counter
     m_satCounters.push_front(descriptor);
     retVal.position = m_satCounters.begin();
-    recipient = &m_satCounters.back();
+    recipient = &m_satCounters.front();
     recipient->Reset();
 
     // (2) Update satisfaction & Append types from subscriber


### PR DESCRIPTION
This verification should guard against future issues about the wrong saturation counter's AutoFilter getting called when a filter is detected as being full satisfied.
- Added unit test to verify multiple observers are called as expected
