### PR TITLE
Simplification of DecorateImmediate

### DIFF
--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -49,6 +49,28 @@ AutoPacket::~AutoPacket(void) {
   );
 }
 
+DecorationDisposition& AutoPacket::CheckoutImmediateUnsafe(const std::type_info& ti, const void* pvImmed)
+{
+  // Obtain the decoration disposition of the entry we will be returning
+  DecorationDisposition& dec = m_decorations[ti];
+
+  // Ensure correct type if instantiated here
+  dec.m_type = &ti;
+
+  if (dec.satisfied || dec.isCheckedOut) {
+    std::stringstream ss;
+    ss << "Cannot perform immediate decoration with type " << autowiring::demangle(ti)
+       << ", the requested decoration already exists";
+    throw std::runtime_error(ss.str());
+  }
+
+  // Mark the entry as appropriate:
+  dec.isCheckedOut = true;
+  dec.satisfied = true;
+  dec.m_pImmediate = pvImmed;
+  return dec;
+}
+
 void AutoPacket::AddSatCounter(SatCounter& satCounter) {
   for(auto pCur = satCounter.GetAutoFilterInput(); *pCur; pCur++) {
     const std::type_info& dataType = *pCur->ti;

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -1026,3 +1026,4 @@ TEST_F(AutoFilterTest, AutoFilterInBaseClassNoAlias) {
   // Trivial validation that we got something back
   ASSERT_EQ(1UL, d->m_called) << "Filter defined in base class in an Object-inheriting type was not called the expected number of times";
 }
+


### PR DESCRIPTION
Making use of a function defined at file level for an array initialization, should also ease the burden in object files where DecorateImmediate is heavily used
