### PR TITLE
Adding TeardownListener functionality to AutoPacket

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -10,6 +10,7 @@
 #include "is_shared_ptr.h"
 #include "MicroAutoFilter.h"
 #include "ObjectPool.h"
+#include "TeardownNotifier.h"
 #include <list>
 #include <sstream>
 #include <typeinfo>
@@ -37,7 +38,8 @@ struct AutoFilterDescriptor;
 /// manually with the Advertise function.
 /// </remarks>
 class AutoPacket:
-  public std::enable_shared_from_this<AutoPacket>
+  public std::enable_shared_from_this<AutoPacket>,
+  public TeardownNotifier
 {
 private:
   AutoPacket(const AutoPacket& rhs) = delete;

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -1026,3 +1026,17 @@ TEST_F(AutoFilterTest, AutoFilterInBaseClassNoAlias) {
   // Trivial validation that we got something back
   ASSERT_EQ(1UL, d->m_called) << "Filter defined in base class in an Object-inheriting type was not called the expected number of times";
 }
+
+TEST_F(AutoFilterTest, PacketTeardownNotificationCheck) {
+  AutoRequired<AutoPacketFactory> factory;
+  auto called = std::make_shared<bool>(false);
+
+  {
+    auto packet = factory->NewPacket();
+    packet->AddTeardownListener([called] { *called = true; });
+    ASSERT_FALSE(*called) << "Teardown listener called before packet was destroyed";
+  }
+
+  ASSERT_TRUE(*called) << "Teardown listener was not called after packet destruction";
+  ASSERT_TRUE(called.unique()) << "Teardown listener lambda function was leaked";
+}


### PR DESCRIPTION
This gives users the ability to register a lambda which is notified when the underlying AutoPacket is destroyed.  This is useful when attempting to evaluate whether an AutoPacket has been fully processed.

Users to receive the packet on teardown should make the following call:

```
packet->AddTeardownListener([] {
    // ...foo...
});
```
