### PR TITLE
Eliminating unnecessary linkage declaration

### DIFF
--- a/autowiring/AutoNetServer.h
+++ b/autowiring/AutoNetServer.h
@@ -4,17 +4,7 @@
 
 class AutoNetServer;
 
-#ifdef _MSC_VER
-  #ifdef AUTOWIRING_EXPORT_AUTONET
-    #define AUTONET_EXPORT __declspec(dllexport)
-  #else
-    #define AUTONET_EXPORT __declspec(dllimport)
-  #endif
-#else
-  #define AUTONET_EXPORT
-#endif
-
-extern AUTONET_EXPORT AutoNetServer* NewAutoNetServerImpl(void);
+extern AutoNetServer* NewAutoNetServerImpl(void);
 
 class AutoNetServer:
   public CoreThread

--- a/contrib/autoboost/boost/system/config.hpp
+++ b/contrib/autoboost/boost/system/config.hpp
@@ -46,25 +46,5 @@
 # define BOOST_SYSTEM_DECL
 #endif
 
-//  enable automatic library variant selection  ----------------------------------------// 
-
-#if !defined(BOOST_SYSTEM_SOURCE) && !defined(BOOST_ALL_NO_LIB) && !defined(BOOST_SYSTEM_NO_LIB)
-//
-// Set the name of our library, this will get undef'ed by auto_link.hpp
-// once it's done with it:
-//
-#define BOOST_LIB_NAME autoboost_system
-//
-// If we're importing code from a dll, then tell auto_link.hpp about it:
-//
-#if defined(BOOST_ALL_DYN_LINK) || defined(BOOST_SYSTEM_DYN_LINK)
-#  define BOOST_DYN_LINK
-#endif
-//
-// And include the header that does the work:
-//
-#include <boost/config/auto_link.hpp>
-#endif  // auto-linking disabled
-
 #endif // BOOST_SYSTEM_CONFIG_HPP
 


### PR DESCRIPTION
- This function is no longer in a DLL, so a dllexport/dllimport declspec is no longer needed
- Oh my god no pragma comment(lib) please for the love of god no
