### PR TITLE
Eliminating externally visible reference to std::future

### DIFF
--- a/autowiring/CoreJob.h
+++ b/autowiring/CoreJob.h
@@ -6,11 +6,6 @@
 
 class Object;
 
-namespace std {
-  template<class T>
-  class future;
-};
-
 class CoreJob:
   public ContextMember,
   public DispatchQueue,
@@ -25,7 +20,7 @@ private:
   bool m_running;
 
   // The current outstanding async in the thread pool, if one exists:
-  std::unique_ptr<std::future<void>> m_curEvent;
+  void* m_curEvent;
 
   // Flag, indicating whether curEvent is in a teardown pathway.  This
   // flag is highly stateful.

--- a/src/autowiring/CoreJob.cpp
+++ b/src/autowiring/CoreJob.cpp
@@ -7,6 +7,7 @@
 CoreJob::CoreJob(const char* name) :
   ContextMember(name),
   m_running(false),
+  m_curEvent(nullptr),
   m_curEventInTeardown(true)
 {}
 
@@ -38,17 +39,16 @@ void CoreJob::OnPended(std::unique_lock<std::mutex>&& lk){
   } else {
     // Need to ask the thread pool to handle our events again:
     m_curEventInTeardown = false;
-    m_curEvent.reset(
-      new std::future<void>(
-        std::async(
-          std::launch::async,
-          [this, outstanding] () mutable {
-            this->DispatchAllAndClearCurrent();
-            outstanding.reset();
-          }
-        )
-      )
-    );
+    
+    if (m_curEvent)
+      delete static_cast<std::future<void>*>(m_curEvent);
+    
+    m_curEvent = new std::future<void>(std::async(std::launch::async,
+                   [this, outstanding] () mutable {
+                     this->DispatchAllAndClearCurrent();
+                     outstanding.reset();
+                   }
+                 ));
   }
 }
 
@@ -110,7 +110,9 @@ void CoreJob::OnStop(bool graceful) {
 
 void CoreJob::DoAdditionalWait(void) {
   if (m_curEvent) {
-    m_curEvent->wait();
-    m_curEvent.reset();
+    std::future<void>* ptr = static_cast<std::future<void>*>(m_curEvent);
+    ptr->wait();
+    delete ptr;
+    m_curEvent = nullptr;
   }
 }


### PR DESCRIPTION
This is intended to make it easier to build Autowiring on platforms where std::future might not be available (IE, android)
