### PR TITLE
Correcting platform incompatibilities

### DIFF
--- a/autowiring/AutoPacketFactory.h
+++ b/autowiring/AutoPacketFactory.h
@@ -80,7 +80,7 @@ public:
   }
 
   // CoreRunnable overrides:
-  bool DoStart(void) override;
+  bool OnStart(void) override;
   void OnStop(bool graceful) override;
   void DoAdditionalWait(void) override;
 
@@ -136,7 +136,7 @@ public:
   std::shared_ptr<AutoPacket> ConstructPacket(void);
 
   /// <returns>the number of outstanding AutoPackets</returns>
-  size_t GetOutstanding(void) const;
+  size_t GetOutstandingPacketCount(void) const;
 
   /// <summary>
   /// Called by each AutoPacket's Finalize method to allow the factory

--- a/autowiring/AutoRestarter.h
+++ b/autowiring/AutoRestarter.h
@@ -52,12 +52,12 @@ public:
   const AutoRestarterConfig config;
 
   // CoreRunnable overrides:
-  bool DoStart() override {
+  bool OnStart() override {
     // Start the enclosed context, do nothing else
     auto ctxt = GetContext();
     if(ctxt && config.startWhenCreated)
       ctxt->Initiate();
-    return false;
+    return true;
   }
 
   void OnStop(bool graceful) override {
@@ -81,7 +81,7 @@ private:
     // Parent restarter, we hand control here when we're stopped
     AutoRestarter<Sigil>& ar;
 
-    bool DoStart(void) override {
+    bool OnStart(void) override {
       return true;
     }
 

--- a/autowiring/BasicThread.h
+++ b/autowiring/BasicThread.h
@@ -176,7 +176,7 @@ protected:
   /// Start will not be called from more than one place on the same object.  The thread
   /// will be invoked from the context which was active at the time the thread was created.
   /// </remarks>
-  bool DoStart() override;
+  bool OnStart() override;
 
   void OnStop(bool graceful) override;
 
@@ -192,6 +192,16 @@ public:
   /// told to quit.
   /// </remarks>
   virtual void Run() = 0;
+
+  /// <summary>
+  /// Provides derived members with a way of obtaining notification that this thread is being stopped
+  /// </summary>
+  /// <remarks>
+  /// Callers must not perform any time-consuming operations in this callback; the method may be called
+  /// from a time-sensitive context and unacceptable system performance could result if long-duration
+  /// operations are undertaken here.
+  /// </remarks>
+  virtual void OnStop(void) {}
 
   /// <summary>
   /// Forces all Autowiring threads to reidentify themselves

--- a/autowiring/CoreJob.h
+++ b/autowiring/CoreJob.h
@@ -40,7 +40,7 @@ protected:
 
 public:
   // "CoreRunnable" overrides
-  bool DoStart(void) override;
+  bool OnStart(void) override;
   void OnStop(bool graceful) override;
   void DoAdditionalWait(void) override;
 };

--- a/autowiring/CoreThread.h
+++ b/autowiring/CoreThread.h
@@ -67,6 +67,19 @@ public:
   void Run(void) override;
 
   /// <summary>
+  /// Provides derived members with a way of obtaining notification that this thread is being stopped
+  /// </summary>
+  /// <remarks>
+  /// This method is called before the dispatch queue is aborted or run down.  Users wishing to perform
+  /// operations gracefully during termination should pend these operations as lambdas to the thread's
+  /// dispatch queue; these lambdas will be invoked if graceful termination is requested, and destroyed
+  /// without invocation otherwise.
+  ///
+  /// The base implementation of this method is guaranteed to do nothing.
+  /// </remarks>
+  virtual void OnStop(void) {}
+
+  /// <summary>
   /// Event which may be used to perform custom handling when the thread is told to stop
   /// </summary>
   /// <param name="graceful">Set to true to rundown the dispatch queue before quitting</param>
@@ -74,8 +87,8 @@ public:
   /// This method is called when the thread should stop.  When invoked, the value of
   /// CoreThread::ShouldStop is guaranteed to be true.
   ///
-  /// Callers are not required to call CoreThread::OnStop.  This method is guaranteed to do
+  /// Derived classes are not required to call CoreThread::OnStop.  This method is guaranteed to do
   /// nothing by default.
   /// </remarks>
-  void OnStop(bool graceful) override;
+  void OnStop(bool graceful) override final;
 };

--- a/src/autonet/AutoNetServerImpl.cpp
+++ b/src/autonet/AutoNetServerImpl.cpp
@@ -65,7 +65,7 @@ void AutoNetServerImpl::Run(void){
   CoreThread::Run();
 }
 
-void AutoNetServerImpl::OnStop(bool graceful) {
+void AutoNetServerImpl::OnStop(void) {
   if (m_Server.is_listening())
     m_Server.stop_listening();
   

--- a/src/autonet/AutoNetServerImpl.hpp
+++ b/src/autonet/AutoNetServerImpl.hpp
@@ -31,7 +31,7 @@ public:
 
   // Functions from BasicThread
   virtual void Run(void) override;
-  virtual void OnStop(bool graceful) override;
+  virtual void OnStop(void) override;
 
   // Server Handler functions
   void OnOpen(websocketpp::connection_hdl hdl);

--- a/src/autowiring/AutoPacketFactory.cpp
+++ b/src/autowiring/AutoPacketFactory.cpp
@@ -54,7 +54,7 @@ std::shared_ptr<void> AutoPacketFactory::GetInternalOutstanding(void) {
   if (retVal)
     return retVal;
 
-  auto outstanding = m_outstanding;
+  std::shared_ptr<Object> outstanding = GetOutstanding();
   retVal = std::shared_ptr<void>(
     (void*)1,
     [this, outstanding] (void*) mutable {
@@ -70,7 +70,7 @@ std::shared_ptr<void> AutoPacketFactory::GetInternalOutstanding(void) {
   return retVal;
 }
 
-bool AutoPacketFactory::DoStart(void) {
+bool AutoPacketFactory::OnStart(void) {
   m_stateCondition.notify_all();
   return true;
 }
@@ -143,7 +143,7 @@ AutoFilterDescriptor AutoPacketFactory::GetTypeDescriptorUnsafe(const std::type_
   return AutoFilterDescriptor();
 }
 
-size_t AutoPacketFactory::GetOutstanding(void) const {
+size_t AutoPacketFactory::GetOutstandingPacketCount(void) const {
   return m_outstandingInternal.use_count();
 }
 

--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -114,7 +114,7 @@ bool BasicThread::ThreadSleep(std::chrono::nanoseconds timeout) {
   return m_state->m_stateCondition.wait_for(lk, timeout, [this] { return ShouldStop(); });
 }
 
-bool BasicThread::DoStart(void) {
+bool BasicThread::OnStart(void) {
   std::shared_ptr<CoreContext> context = m_context.lock();
   if(!context)
     return false;
@@ -124,7 +124,7 @@ bool BasicThread::DoStart(void) {
 
   // Place the new thread entity directly in the space where it goes to avoid
   // any kind of races arising from asynchronous access to this space
-  auto outstanding = m_outstanding;
+  auto outstanding = GetOutstanding();
   m_state->m_thisThread.~thread();
   new (&m_state->m_thisThread) std::thread(
     [this, outstanding] () mutable {
@@ -139,6 +139,9 @@ void BasicThread::OnStop(bool graceful) {
   if (!m_running) {
     m_completed = true;
   }
+
+  // Always invoke stop handler:
+  OnStop();
 }
 
 void BasicThread::DoAdditionalWait(void) {

--- a/src/autowiring/CoreThread.cpp
+++ b/src/autowiring/CoreThread.cpp
@@ -106,6 +106,9 @@ void CoreThread::Run() {
 }
 
 void CoreThread::OnStop(bool graceful) {
+  // Base class handling first:
+  BasicThread::OnStop(graceful);
+
   if(graceful) {
     // Pend a call which will invoke Abort once the dispatch queue is done:
     DispatchQueue::Pend([this] {
@@ -117,7 +120,4 @@ void CoreThread::OnStop(bool graceful) {
   } else
     // Abort the dispatch queue so anyone waiting will wake up
     DispatchQueue::Abort();
-
-  // Pass off to base class handling:
-  BasicThread::OnStop(graceful);
 }

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -26,10 +26,10 @@ TEST_F(AutoFilterTest, GetOutstandingTest) {
 
   {
     auto packet = factory->NewPacket();
-    ASSERT_EQ(1UL, factory->GetOutstanding()) << "Factory outstanding count mismatch";
+    ASSERT_EQ(1UL, factory->GetOutstandingPacketCount()) << "Factory outstanding count mismatch";
   }
 
-  ASSERT_EQ(0UL, factory->GetOutstanding()) << "Factory outstanding did not go to zero after releasing the only outstanding packet";
+  ASSERT_EQ(0UL, factory->GetOutstandingPacketCount()) << "Factory outstanding did not go to zero after releasing the only outstanding packet";
 }
 
 TEST_F(AutoFilterTest, VerifyDescendentAwareness) {
@@ -668,11 +668,11 @@ TEST_F(AutoFilterTest, SingleImmediate) {
     // Verify we can't decorate this value a second time:
     ASSERT_ANY_THROW(packet->DecorateImmediate(val)) << "Expected an exception when a second attempt was made to attach a decoration";
   }
-  ASSERT_EQ(0, factory->GetOutstanding()) << "Destroyed packet remains outstanding";
+  ASSERT_EQ(0, factory->GetOutstandingPacketCount()) << "Destroyed packet remains outstanding";
 
   static const int pattern = 1365; //1365 ~ 10101010101
   AutoRequired<FilterGen<Decoration<pattern>>> fgp;
-  ASSERT_EQ(0, factory->GetOutstanding()) << "Outstanding packet count is correct after incrementing m_poolVersion due to AutoFilter addition";
+  ASSERT_EQ(0, factory->GetOutstandingPacketCount()) << "Outstanding packet count is correct after incrementing m_poolVersion due to AutoFilter addition";
   {
     auto packet = factory->NewPacket();
     Decoration<pattern> dec;
@@ -681,7 +681,7 @@ TEST_F(AutoFilterTest, SingleImmediate) {
     ASSERT_TRUE(fgp->m_called == 1) << "Filter should called " << fgp->m_called << " times, expected 1";
     ASSERT_TRUE(std::get<0>(fgp->m_args).i == pattern) << "Filter argument yielded " << std::get<0>(fgp->m_args).i << "expected " << pattern;
   }
-  ASSERT_EQ(0, factory->GetOutstanding()) << "Destroyed packet remains outstanding";
+  ASSERT_EQ(0, factory->GetOutstandingPacketCount()) << "Destroyed packet remains outstanding";
 
   // Terminate enclosing context
   AutoCurrentContext()->SignalShutdown(true);

--- a/src/autowiring/test/CoreRunnableTest.cpp
+++ b/src/autowiring/test/CoreRunnableTest.cpp
@@ -13,7 +13,7 @@ class StartsSubcontextWhileStarting:
 public:
   AutoCreateContext m_myContext;
 
-  bool DoStart(void) override {
+  bool OnStart(void) override {
     m_myContext->Initiate();
     return false;
   }

--- a/src/autowiring/test/TestFixtures/SimpleReceiver.hpp
+++ b/src/autowiring/test/TestFixtures/SimpleReceiver.hpp
@@ -193,10 +193,8 @@ public:
   }
 
   // Overridden here so we can hit the barrier if we're still waiting on it
-  void OnStop(bool graceful) override {
+  void OnStop(void) override {
     Proceed();
-    // Allow our parent to handle the stop as well
-    CoreThread::OnStop(graceful);
   }
 
   /// <summary>


### PR DESCRIPTION
- OnStop should be invoked after Start has been called
- Adding a void OnStop override for users inheriting CoreThread
- Sealing OnStop(bool) to prevent odd behavior in CoreThread
- Adding a protected GetOutstanding method to CoreRunnable rather than requiring direct access to its members; fixing the resulting naming collision in AutoPacketFactory
