### PR TITLE
AutowiredFast should be allowed to work with a pointer type as its ctor arg

### DIFF
--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -261,8 +261,12 @@ public:
 
   // !!!!! Read comment in AutoRequired if you get a compiler error here !!!!!
   AutowiredFast(const std::shared_ptr<CoreContext>& ctxt = CoreContext::CurrentContext()) {
-    if(ctxt)
+    if (ctxt)
       ctxt->FindByTypeRecursive(*this);
+  }
+
+  AutowiredFast(const CoreContext* pCtxt) {
+    pCtxt->FindByTypeRecursive(*this);
   }
 
   operator bool(void) const {


### PR DESCRIPTION
This allows us to use AutowiredFast in cases where a shared pointer might not be avilable, such as early CoreContext construction and in teardown notifiers
