### PR TITLE
Do not reset anything in initialization

### DIFF
--- a/autowiring/SatCounter.h
+++ b/autowiring/SatCounter.h
@@ -19,7 +19,7 @@ struct SatCounter:
   SatCounter(const AutoFilterDescriptor& source):
     AutoFilterDescriptor(source),
     called(false),
-    remaining(0)
+    remaining(m_requiredCount)
   {}
 
   SatCounter(const SatCounter& source):
@@ -27,13 +27,6 @@ struct SatCounter:
     called(source.called),
     remaining(source.remaining)
   {}
-
-  SatCounter& operator = (const SatCounter& source) {
-    AutoFilterDescriptor::operator = (source);
-    called = source.called;
-    remaining = source.remaining;
-    return *this;
-  }
 
   // The number of times the AutoFilter is called
   bool called;
@@ -52,14 +45,6 @@ struct SatCounter:
     }
     called = true;
     GetCall()(GetAutoFilter(), packet);
-  }
-
-  /// <summary>
-  /// Resets the remaining counter to its initial value
-  /// </summary>
-  void Reset(void) {
-    called = false;
-    remaining = m_requiredCount;
   }
 
   /// <summary>

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -347,7 +347,6 @@ AutoPacket::Recipient AutoPacket::AddRecipient(const AutoFilterDescriptor& descr
     m_satCounters.push_front(descriptor);
     retVal.position = m_satCounters.begin();
     recipient = &m_satCounters.front();
-    recipient->Reset();
 
     // (2) Update satisfaction & Append types from subscriber
     AddSatCounter(*recipient);

--- a/src/autowiring/AutoPacketInternal.cpp
+++ b/src/autowiring/AutoPacketInternal.cpp
@@ -31,14 +31,6 @@ void AutoPacketInternal::Initialize(void) {
   for(auto& satCounter : m_satCounters)
     AddSatCounter(satCounter);
   
-  // Initialize all counters:
-  for (auto& satCounter : m_satCounters)
-    satCounter.Reset();
-  
-  // Clear all references:
-  for (auto& decoration : m_decorations)
-    decoration.second.Reset();
-  
   // Find all subscribers with no required or optional arguments:
   std::list<SatCounter*> callCounters;
   for (auto& satCounter : m_satCounters)


### PR DESCRIPTION
This is a relic from a time when AutoPacket entries were pooled, and it was necessary to clear decoration counters before issuing them.
