### PR TITLE
Add a "Has" function to allow quick queries for the existence of a type

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -566,6 +566,16 @@ public:
   static void InjectCurrent(void) {
     CurrentContext()->Inject<T>();
   }
+
+  /// <returns>
+  /// True if the specified type can be autowired in this context
+  /// </returns>
+  template<class T>
+  bool Has(void) const {
+    std::shared_ptr<T> ptr;
+    FindByType(ptr);
+    return ptr != nullptr;
+  }
   
   template<typename T, typename... Args>
   std::shared_ptr<T> DEPRECATED(Construct(Args&&... args), "'Construct' is deprecated, use 'Inject' instead");


### PR DESCRIPTION
This is the current way to determine whether the current context contains some type:
    Autowired<T>().IsAutowired();

This way is now supported:
    AutoCurrentContext()->Has<T>();
