### PR TITLE
Fixing race condition

### DIFF
--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -372,7 +372,8 @@ public:
   bool HasListeners(void) const {
     //TODO: Refactor this so it isn't messy
     //check: does it have any direct listeners, or are any appropriate marshalling objects wired into the immediate context?
-    return !m_junctionBox.expired() && m_junctionBox.lock()->HasListeners();
+    auto junctionBox = m_junctionBox.lock();
+    return junctionBox && junctionBox->HasListeners();
   }
 
   template<class MemFn>


### PR DESCRIPTION
This is potentially a really bad one, would only show up extremely rarely and only during teardown.  Generally speaking, action should only be taken in response to a "true" return value of "expired".
