### PR TITLE
Header load reduction

### DIFF
--- a/autowiring/AutoFilterDescriptor.h
+++ b/autowiring/AutoFilterDescriptor.h
@@ -8,9 +8,6 @@
 #include "has_autofilter.h"
 #include "is_shared_ptr.h"
 #include MEMORY_HEADER
-#include FUNCTIONAL_HEADER
-#include STL_UNORDERED_SET
-#include STL_UNORDERED_MAP
 
 class AutoPacket;
 class Deferred;

--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -6,20 +6,16 @@
 #include "AutoCheckout.h"
 #include "DecorationDisposition.h"
 #include "demangle.h"
-#include "hash_tuple.h"
 #include "is_any.h"
 #include "is_shared_ptr.h"
-#include "MicroAutoFilter.h"
-#include "ObjectPool.h"
 #include "TeardownNotifier.h"
 #include <list>
-#include <sstream>
 #include <typeinfo>
 #include CHRONO_HEADER
 #include MEMORY_HEADER
 #include TYPE_INDEX_HEADER
 #include STL_UNORDERED_MAP
-#include EXCEPTION_PTR_HEADER
+#include MUTEX_HEADER
 
 class AutoPacket;
 class AutoPacketInternal;
@@ -176,6 +172,11 @@ protected:
   /// </remarks>
   std::list<DecorationDisposition> GetDispositions(const std::type_info& ti) const;
 
+  /// <summary>
+  /// Throws a formatted runtime error corresponding to the case where an absent decoration was demanded
+  /// </summary>
+  static void ThrowNotDecoratedException(const std::type_info& ti);
+
 public:
   /// <returns>
   /// True if this packet posesses a decoration of the specified type
@@ -198,12 +199,8 @@ public:
     static_assert(!std::is_same<T, AnySharedPointer>::value, "Oops!");
 
     const T* retVal;
-    if(!Get(retVal)) {
-      std::stringstream ss;
-      ss << "Attempted to obtain a type " << autowiring::demangle(retVal)
-         << " which was not decorated on this packet";
-      throw std::runtime_error(ss.str());
-    }
+    if (!Get(retVal))
+      ThrowNotDecoratedException(typeid(auto_id<T>));
     return *retVal;
   }
 

--- a/autowiring/AutoPacketFactory.h
+++ b/autowiring/AutoPacketFactory.h
@@ -1,20 +1,16 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "Autowired.h"
 #include "AutoPacket.h"
 #include "AutoFilterDescriptor.h"
 #include "ContextMember.h"
 #include "CoreRunnable.h"
+#include "TypeRegistry.h"
 #include <list>
-#include <vector>
 #include CHRONO_HEADER
-#include TYPE_INDEX_HEADER
 #include TYPE_TRAITS_HEADER
 #include STL_UNORDERED_SET
 
-struct AdjacencyEntry;
 class AutoPacketFactory;
-class Deferred;
 class DispatchQueue;
 class AutoPacketInternal;
 
@@ -171,8 +167,7 @@ public:
 
 // Extern explicit template instantiation declarations added to prevent
 // exterior instantation of internally used template instances
-extern template class ObjectPool<AutoPacket>;
-extern template class RegType<AutoPacketFactory>;
 extern template struct SlotInformationStump<AutoPacketFactory, false>;
 extern template const std::shared_ptr<AutoPacketFactory>& SharedPointerSlot::as<AutoPacketFactory>(void) const;
 extern template std::shared_ptr<AutoPacketFactory> autowiring::fast_pointer_cast<AutoPacketFactory, Object>(const std::shared_ptr<Object>& Other);
+extern template class RegType<AutoPacketFactory>;

--- a/autowiring/Bolt.h
+++ b/autowiring/Bolt.h
@@ -12,7 +12,6 @@
 /// To create a class that will have a new instance inserted into each instance of a context
 /// with a given sigil, use Boltable.
 /// </remarks>
-
 template<typename... Sigil>
 class Bolt:
   public BoltBase

--- a/autowiring/BoltBase.h
+++ b/autowiring/BoltBase.h
@@ -1,6 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include TYPE_INDEX_HEADER
+#include <typeinfo>
 
 class CoreContext;
 

--- a/autowiring/CallExtractor.h
+++ b/autowiring/CallExtractor.h
@@ -3,6 +3,7 @@
 #include "auto_arg.h"
 #include "AutoPacket.h"
 #include "Decompose.h"
+#include <assert.h>
 
 class Deferred;
 

--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -6,12 +6,10 @@
 #include "AutowiringEvents.h"
 #include "autowiring_error.h"
 #include "Bolt.h"
-#include "CoreContextStateBlock.h"
 #include "CoreRunnable.h"
 #include "ContextMember.h"
 #include "CreationRules.h"
 #include "CurrentContextPusher.h"
-#include "EventRegistry.h"
 #include "ExceptionFilter.h"
 #include "fast_pointer_cast.h"
 #include "has_autoinit.h"
@@ -26,16 +24,15 @@
 
 #include <list>
 #include MEMORY_HEADER
-#include FUNCTIONAL_HEADER
 #include TYPE_INDEX_HEADER
 #include STL_UNORDERED_MAP
-#include STL_UNORDERED_SET
 
+struct CoreContextStateBlock;
 class AutoInjectable;
-class DeferrableAutowiring;
 class BasicThread;
 class BoltBase;
 class CoreContext;
+class DeferrableAutowiring;
 class GlobalCoreContext;
 class JunctionBoxBase;
 class OutstandingCountTracker;
@@ -397,7 +394,7 @@ protected:
   template<class Fx>
   void AddTeardownListener2(Fx&& fx, void (Fx::*)(const CoreContext&)) { TeardownNotifier::AddTeardownListener([fx, this] () mutable { fx(*this); }); }
   template<class Fx>
-  void AddTeardownListener2(Fx&& fx, void (Fx::*)(void) const) { TeardownNotifier::AddTeardownListener(fx); }
+  void AddTeardownListener2(Fx&& fx, void (Fx::*)(void) const) { TeardownNotifier::AddTeardownListener(std::forward<Fx&&>(fx)); }
 
   template<class Fx>
   void AddTeardownListener2(Fx&& fx, void (Fx::*)(const CoreContext&) const) { TeardownNotifier::AddTeardownListener([fx, this] () mutable { fx(*this); }); }

--- a/autowiring/CreationRules.h
+++ b/autowiring/CreationRules.h
@@ -1,13 +1,11 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "autowiring_error.h"
-#include "ContextMember.h"
 #include "has_simple_constructor.h"
 #include "has_static_new.h"
 #include "SlotInformation.h"
-#include TYPE_TRAITS_HEADER
 #include RVALUE_HEADER
-#include <new>
+
+class CoreContext;
 
 template<typename T>
 struct is_injectable

--- a/autowiring/Decompose.h
+++ b/autowiring/Decompose.h
@@ -1,6 +1,5 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include TYPE_TRAITS_HEADER
 #include <typeinfo>
 
 template<class... Ts>

--- a/autowiring/Deferred.h
+++ b/autowiring/Deferred.h
@@ -1,6 +1,5 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include <assert.h>
 
 class CoreThread;
 
@@ -18,19 +17,4 @@ public:
   Deferred(void) {}
 
   Deferred(CoreThread* pThread) {}
-};
-
-/// <summary>
-/// Utility type which asserts when construction is attempted
-/// </summary>
-/// <remarks>
-/// Any consumer who attempts to invoke a deferred 
-/// </remarks>
-class FatalDeferredInvocation:
-  public Deferred
-{
-public:
-  FatalDeferredInvocation(void) {
-    assert(false);
-  }
 };

--- a/autowiring/DispatchThunk.h
+++ b/autowiring/DispatchThunk.h
@@ -1,7 +1,7 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include <utility>
 #include CHRONO_HEADER
-#include UTILITY_HEADER
 
 /// <summary>
 /// A simple virtual class used to hold a trivial thunk

--- a/autowiring/ExceptionFilter.h
+++ b/autowiring/ExceptionFilter.h
@@ -1,6 +1,5 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include FUNCTIONAL_HEADER
 
 class JunctionBoxBase;
 class Object;

--- a/autowiring/JunctionBoxBase.h
+++ b/autowiring/JunctionBoxBase.h
@@ -1,7 +1,7 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include <vector>
 #include "Object.h"
+#include <list>
 #include MUTEX_HEADER
 #include MEMORY_HEADER
 #include STL_UNORDERED_SET
@@ -37,7 +37,7 @@ protected:
   /// <summary>
   /// Invokes SignalTerminate on each context in the specified vector.  Does not wait.
   /// </summary>
-  static void TerminateAll(const std::vector<std::weak_ptr<CoreContext>>& teardown);
+  static void TerminateAll(const std::list<std::weak_ptr<CoreContext>>& teardown);
 
   /// <summary>
   /// Convenience routine for Fire calls

--- a/autowiring/JunctionBoxEntry.h
+++ b/autowiring/JunctionBoxEntry.h
@@ -30,7 +30,6 @@ struct JunctionBoxEntry:
   JunctionBoxEntry& operator=(const JunctionBoxEntry& rhs) {
     // This shouldn't be used. non-c++11 containers require this...
     throw std::runtime_error("Can't copy a JunctionBoxEntry");
-    return *this;
   }
 
   bool operator==(const JunctionBoxEntry& rhs) const {

--- a/autowiring/JunctionBoxManager.h
+++ b/autowiring/JunctionBoxManager.h
@@ -2,15 +2,9 @@
 #pragma once
 #include "JunctionBoxBase.h"
 #include "JunctionBoxEntry.h"
-#include "uuid.h"
-#include <map>
-#include <stdexcept>
-#include <vector>
-#include <cassert>
 #include TYPE_INDEX_HEADER
 #include MEMORY_HEADER
 #include STL_UNORDERED_MAP
-#include TYPE_TRAITS_HEADER
 
 class CoreContext;
 class JunctionBoxBase;

--- a/autowiring/SatCounter.h
+++ b/autowiring/SatCounter.h
@@ -3,7 +3,6 @@
 #include "AnySharedPointer.h"
 #include "AutoFilterDescriptor.h"
 #include "demangle.h"
-#include <sstream>
 
 /// <summary>
 /// A single subscription counter entry
@@ -34,15 +33,19 @@ struct SatCounter:
   // The number of inputs remaining to this counter:
   size_t remaining;
 
+private:
+  /// <summary>
+  /// Throws a formatted exception if the underlying filter is called more than once
+  /// </summary>
+  void ThrowRepeatedCallException(void) const;
+
+public:
   /// <summary>
   /// Calls the underlying AutoFilter method with the specified AutoPacketAdapter as input
   /// </summary>
   void CallAutoFilter(AutoPacket& packet) {
-    if (called) {
-      std::stringstream ss;
-      ss << "Repeated call to " << autowiring::demangle(m_pType);
-      throw std::runtime_error(ss.str());
-    }
+    if (called)
+      ThrowRepeatedCallException();
     called = true;
     GetCall()(GetAutoFilter(), packet);
   }

--- a/autowiring/TypeIdentifier.h
+++ b/autowiring/TypeIdentifier.h
@@ -1,7 +1,7 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include TYPE_INDEX_HEADER
 #include "Object.h"
+#include <typeinfo>
 
 // Checks if an Object* listens to a event T;
 struct TypeIdentifierBase {

--- a/autowiring/TypeRegistry.h
+++ b/autowiring/TypeRegistry.h
@@ -1,8 +1,8 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include "autowiring_error.h"
 #include "CreationRules.h"
 #include "TypeIdentifier.h"
-#include STL_TUPLE_HEADER
 #include MEMORY_HEADER
 
 namespace autowiring {
@@ -99,3 +99,4 @@ public:
 
 template<class T>
 const TypeRegistryEntryT<T> RegType<T>::r;
+

--- a/autowiring/TypeUnifier.h
+++ b/autowiring/TypeUnifier.h
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "has_autofilter.h"
-#include "has_simple_constructor.h"
 #include "Object.h"
 #include RVALUE_HEADER
 

--- a/autowiring/demangle.h
+++ b/autowiring/demangle.h
@@ -1,7 +1,7 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include TYPE_INDEX_HEADER
 #include <string>
+#include <typeinfo>
 
 #if __GNUG__ // Mac and linux
 #include <cxxabi.h>

--- a/autowiring/var_logic.h
+++ b/autowiring/var_logic.h
@@ -1,6 +1,5 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include TYPE_TRAITS_HEADER
 
 /*
  Variadic generalizations of boolean operations.

--- a/src/autowiring/AutoConfigManager.cpp
+++ b/src/autowiring/AutoConfigManager.cpp
@@ -2,6 +2,7 @@
 #include "stdafx.h"
 #include "AutoConfig.h"
 #include "AnySharedPointer.h"
+#include <sstream>
 
 using namespace autowiring;
 
@@ -47,6 +48,20 @@ AutoConfigManager::AutoConfigManager(void){
 }
 
 AutoConfigManager::~AutoConfigManager(void){}
+
+void AutoConfigManager::ThrowKeyNotFoundException(const std::string& key) const {
+  std::stringstream ss;
+  ss << "No configuration found for key '" << key << "'";
+  throw autowiring_error(ss.str());
+}
+
+void AutoConfigManager::ThrowTypeMismatchException(const std::string& key, const std::type_info& ti) const {
+  std::stringstream ss;
+  ss << "Attempting to set config '" << key << "' with incorrect type '"
+    << autowiring::demangle(ti) << "'";
+  throw autowiring_error(ss.str());
+
+}
 
 bool AutoConfigManager::IsConfigured(const std::string& key) {
   std::lock_guard<std::mutex> lk(m_lock);

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -9,6 +9,7 @@
 #include "ContextEnumerator.h"
 #include "SatCounter.h"
 #include <algorithm>
+#include <sstream>
 
 using namespace autowiring;
 
@@ -272,6 +273,12 @@ std::list<DecorationDisposition> AutoPacket::GetDispositions(const std::type_inf
     if (disposition.second.m_type == &ti)
       dispositions.push_back(disposition.second);
   return dispositions;
+}
+
+void AutoPacket::ThrowNotDecoratedException(const std::type_info& ti) {
+  std::stringstream ss;
+  ss << "Attempted to obtain a type " << autowiring::demangle(ti) << " which was not decorated on this packet";
+  throw std::runtime_error(ss.str());
 }
 
 void AutoPacket::Put(const std::type_info& ti, SharedPointerSlot&& in) {

--- a/src/autowiring/AutoPacketFactory.cpp
+++ b/src/autowiring/AutoPacketFactory.cpp
@@ -2,8 +2,7 @@
 #include "stdafx.h"
 #include "AutoPacketFactory.h"
 #include "AutoPacketInternal.hpp"
-#include "fast_pointer_cast.h"
-#include "thread_specific_ptr.h"
+#include "CoreContext.h"
 #include <cmath>
 
 AutoPacketFactory::AutoPacketFactory(void):
@@ -158,7 +157,7 @@ void AutoPacketFactory::ResetPacketStatistics(void) {
   m_packetDurationSqSum = 0.0;
 }
 
-template class RegType<AutoPacketFactory>;
 template struct SlotInformationStump<AutoPacketFactory, false>;
 template const std::shared_ptr<AutoPacketFactory>& SharedPointerSlot::as<AutoPacketFactory>(void) const;
 template std::shared_ptr<AutoPacketFactory> autowiring::fast_pointer_cast<AutoPacketFactory, Object>(const std::shared_ptr<Object>& Other);
+template class RegType<AutoPacketFactory>;

--- a/src/autowiring/AutoPacketGraph.cpp
+++ b/src/autowiring/AutoPacketGraph.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <fstream>
 #include <string>
+#include <sstream>
 #include FUNCTIONAL_HEADER
 
 AutoPacketGraph::AutoPacketGraph() {

--- a/src/autowiring/AutowirableSlot.cpp
+++ b/src/autowiring/AutowirableSlot.cpp
@@ -3,6 +3,7 @@
 #include "AutowirableSlot.h"
 #include "autowiring_error.h"
 #include "CoreContext.h"
+#include <cassert>
 #include <stdexcept>
 
 using namespace std;

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -135,6 +135,7 @@ set(Autowiring_SRCS
   ObjectPoolMonitor.h
   ObjectTraits.h
   SatCounter.h
+  SatCounter.cpp
   SharedPointerSlot.h
   SlotInformation.cpp
   SlotInformation.h

--- a/src/autowiring/ConfigRegistry.cpp
+++ b/src/autowiring/ConfigRegistry.cpp
@@ -2,6 +2,7 @@
 #include "stdafx.h"
 #include "ConfigRegistry.h"
 #include "AutoConfigParser.hpp"
+#include "demangle.h"
 
 // Head of a linked list which will have node for every event type
 const ConfigRegistryEntry* g_pFirstConfigEntry = nullptr;
@@ -18,4 +19,10 @@ ConfigRegistryEntry::ConfigRegistryEntry(const std::type_info& tinfo, bool has_v
 
 bool ConfigRegistryEntry::is(const std::string& key) const {
   return m_key == key;
+}
+
+void autowiring::ThrowFailedTypeParseException(const std::string& str, const std::type_info& ti) {
+  std::stringstream msg;
+  msg << "Failed to parse '" << str << "' as type '" << autowiring::demangle(ti) << "'";
+  throw autowiring_error(msg.str());
 }

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -3,16 +3,16 @@
 #include "CoreContext.h"
 #include "AutoInjectable.h"
 #include "AutoPacketFactory.h"
-#include "BoltBase.h"
+#include "CoreContextStateBlock.h"
 #include "CoreThread.h"
 #include "demangle.h"
 #include "GlobalCoreContext.h"
 #include "JunctionBox.h"
 #include "MicroBolt.h"
 #include "NewAutoFilter.h"
-#include <algorithm>
-#include <stack>
 #include "thread_specific_ptr.h"
+#include <sstream>
+#include <stack>
 
 /// <summary>
 /// A pointer to the current context, specific to the current thread.

--- a/src/autowiring/CoreThreadWin.cpp
+++ b/src/autowiring/CoreThreadWin.cpp
@@ -3,6 +3,7 @@
 #include "BasicThread.h"
 #include "BasicThreadStateBlock.h"
 #include CHRONO_HEADER
+#include <stdexcept>
 #include <Windows.h>
 #include <Avrt.h>
 

--- a/src/autowiring/GlobalCoreContext.cpp
+++ b/src/autowiring/GlobalCoreContext.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "GlobalCoreContext.h"
+#include <cassert>
 
 GlobalCoreContext::GlobalCoreContext(void):
   CoreContextT<GlobalCoreContext>(std::shared_ptr<CoreContext>(), t_childList::iterator(), std::shared_ptr<CoreContext>())

--- a/src/autowiring/JunctionBoxBase.cpp
+++ b/src/autowiring/JunctionBoxBase.cpp
@@ -5,10 +5,10 @@
 
 JunctionBoxBase::~JunctionBoxBase(void) {}
 
-void JunctionBoxBase::TerminateAll(const std::vector<std::weak_ptr<CoreContext>>& teardown) {
-  for(size_t i = teardown.size(); i--;) {
-    auto curContext = teardown[i].lock();
-    if(curContext)
+void JunctionBoxBase::TerminateAll(const std::list<std::weak_ptr<CoreContext>>& teardown) {
+  for (auto teardownWeak : teardown) {
+    auto curContext = teardownWeak.lock();
+    if (curContext)
       curContext->SignalTerminate(false);
   }
 }

--- a/src/autowiring/JunctionBoxManager.cpp
+++ b/src/autowiring/JunctionBoxManager.cpp
@@ -5,6 +5,7 @@
 #include "AutowiringEvents.h"
 #include "JunctionBox.h"
 #include "EventRegistry.h"
+#include <cassert>
 
 template class RegEvent<AutowiringEvents>;
 template class TypeUnifierComplex<AutowiringEvents>;

--- a/src/autowiring/SatCounter.cpp
+++ b/src/autowiring/SatCounter.cpp
@@ -1,0 +1,10 @@
+// Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "SatCounter.h"
+#include <sstream>
+
+void SatCounter::ThrowRepeatedCallException(void) const {
+  std::stringstream ss;
+  ss << "Repeated call to " << autowiring::demangle(m_pType);
+  throw std::runtime_error(ss.str());
+}

--- a/src/autowiring/TypeRegistry.cpp
+++ b/src/autowiring/TypeRegistry.cpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TypeRegistry.h"
-#include "JunctionBox.h"
 
 // Head of a linked list which will have node for every event type
 const TypeRegistryEntry* g_pFirstTypeEntry = nullptr;
@@ -14,3 +13,4 @@ TypeRegistryEntry::TypeRegistryEntry(const std::type_info& ti) :
   g_typeEntryCount++;
   g_pFirstTypeEntry = this;
 }
+

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -5,6 +5,7 @@
 #include <autowiring/AutoPacketFactory.h>
 #include <autowiring/Deferred.h>
 #include <autowiring/NewAutoFilter.h>
+#include <autowiring/ObjectPool.h>
 #include <autowiring/DeclareAutoFilter.h>
 #include <autowiring/AutoSelfUpdate.h>
 #include <autowiring/AutoTimeStamp.h>


### PR DESCRIPTION
Eliminating #include statements where they are no longer necessary.  Refactoring some functions to source-level where doing so allows an include to be eliminated from a header file.

20% build time speedup
