### PR TITLE
Minimum _required_ version is only 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.0)
 include(version.cmake)
 project(autowiring VERSION ${autowiring_VERSION})
 


### PR DESCRIPTION
While we do want the build server to be using the latest version of CMake, there is nothing specifically requiring that we mandate users make use of version 3.1 as well.  Thus, roll 3.0 is the minimum required, while 3.1 is merely the preference.
