### PR TITLE
Eliminate the use of throw_rethrowable and exception_ptr everywhere

### DIFF
--- a/autowiring/C++11/cpp11.h
+++ b/autowiring/C++11/cpp11.h
@@ -95,16 +95,6 @@
 #endif
 
 /*********************
- * exception_ptr availability
- *********************/
-#if (defined(__APPLE__) && !defined(_LIBCPP_VERSION))
-  #define EXCEPTION_PTR_HEADER <autowiring/C++11/boost_exception_ptr.h>
-#else
-  #define EXCEPTION_PTR_HEADER <stdexcept>
-  #define throw_rethrowable throw
-#endif
-
-/*********************
  * system error availability
  *********************/
 #if STL11_ALLOWED

--- a/autowiring/ContextMap.h
+++ b/autowiring/ContextMap.h
@@ -84,7 +84,7 @@ public:
     std::lock_guard<std::mutex> lk(m_lk);
     auto& rhs = m_contexts[key];
     if(!rhs.expired())
-      throw_rethrowable autowiring_error("Specified key is already associated with another context");
+      throw autowiring_error("Specified key is already associated with another context");
 
     rhs = context;
 

--- a/src/autowiring/test/TestFixtures/ThrowsWhenFired.hpp
+++ b/src/autowiring/test/TestFixtures/ThrowsWhenFired.hpp
@@ -16,6 +16,6 @@ public:
 
   void DoThrow(void) override {
     hit = true;
-    throw_rethrowable Ex(i);
+    throw Ex(i);
   }
 };

--- a/src/autowiring/test/TestFixtures/ThrowsWhenRun.hpp
+++ b/src/autowiring/test/TestFixtures/ThrowsWhenRun.hpp
@@ -9,8 +9,8 @@ class ThrowsWhenRun:
 {
 public:
   // This convoluted syntax is required to evade warnings on Mac
-  decltype(throw_rethrowable Ex(100)) MakeException() {
-    return throw_rethrowable Ex(100);
+  decltype(throw Ex(100)) MakeException() {
+    return throw Ex(100);
   }
 
   void Run(void) override {


### PR DESCRIPTION
This concept doesn't work that well and isn't necessary anyway
