### PR TITLE
Set the NEW policy for CMP0054

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.0)
 include(version.cmake)
 project(autowiring VERSION ${autowiring_VERSION})
 
+# We don't care if variables are not dereferenced when quoted
+cmake_policy(SET CMP0054 NEW)
+
 include(CTest)
 include(CheckTypeSize)
 


### PR DESCRIPTION
This makes cmake less chatty when configuring on CMake 3.1 or later.
- [ ] Confirm that CMake 3.0 doesn't shit itself
