### PR TITLE
Putting throw_rethrowable through a deprecation policy

### DIFF
--- a/autowiring/C++11/cpp11.h
+++ b/autowiring/C++11/cpp11.h
@@ -15,6 +15,10 @@
   #define STL11_ALLOWED 1
 #endif
 
+// Deprecated macros, provided here until we can be sure that they aren't used downstream
+#define throw_rethrowable throw
+#define EXCEPTION_PTR_HEADER <stdexcept>
+
 // If Autowiring is currently being built, we want to use the "autoboost" namespace in order to
 // avoid requiring a dependency on Boost.
 #ifdef AUTOWIRING_IS_BEING_BUILT


### PR DESCRIPTION
I'd rather not break everyone still on branches upstream.  This might have to hang around for a few months before we can actually get rid of it.
