### PR TITLE
Mere use of `fast_pointer_cast` does not imply the availability of a blind cast

### DIFF
--- a/autowiring/AutowirableSlot.h
+++ b/autowiring/AutowirableSlot.h
@@ -146,7 +146,7 @@ public:
     // of this type MUST be available.  The reason for this is that, if the user wishes to know if a
     // type is autowired, they are required at a minimum to know what that type's inheritance relations
     // are to other types in the system.
-    (void) autowiring::fast_pointer_cast_initializer<Object, T>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<T, Object>::sc_init;
     return !!get();
   }
 
@@ -155,7 +155,7 @@ public:
   /// </remarks>
   T* get(void) const {
     // For now, we require that the full type be available to use this method
-    (void) autowiring::fast_pointer_cast_initializer<Object, T>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<T, Object>::sc_init;
     return get_unsafe();
   }
 
@@ -184,14 +184,14 @@ public:
     // Initialize any blind fast casts to the actually desired type.  This is one of a few points
     // where we can guarantee that the type will be completely defined, because the user is about
     // to make use of this type.
-    (void) autowiring::fast_pointer_cast_initializer<Object, T>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<T, Object>::sc_init;
     return get();
   }
 
   T& operator*(void) const {
     // We have to initialize here, in the operator context, because we don't actually know if the
     // user will be making use of this type.
-    (void) autowiring::fast_pointer_cast_initializer<Object, T>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<T, Object>::sc_init;
 
     return *get();
   }

--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -270,14 +270,14 @@ public:
 
   // !!!!! Read comment in AutoRequired if you get a compiler error here !!!!!
   AutowiredFast(const std::shared_ptr<CoreContext>& ctxt = CoreContext::CurrentContext()) {
-    (void) autowiring::fast_pointer_cast_initializer<Object, T>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<T, Object>::sc_init;
 
     if (ctxt)
       ctxt->FindByTypeRecursive(*this);
   }
 
   AutowiredFast(const CoreContext* pCtxt) {
-    (void) autowiring::fast_pointer_cast_initializer<Object, T>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<T, Object>::sc_init;
 
     pCtxt->FindByTypeRecursive(*this);
   }

--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -1047,6 +1047,7 @@ T* autowiring::crh<autowiring::construction_strategy::foreign_factory, T, Args..
   // We need to ensure that we can perform a find-by-type cast correctly, so
   // the dynamic caster entry is added to the registry
   (void) autowiring::fast_pointer_cast_initializer<Object, CoreContext::AutoFactory<T>>::sc_init;
+  (void) autowiring::fast_pointer_cast_initializer<CoreContext::AutoFactory<T>, Object>::sc_init;
 
   // Now we can go looking for this type:
   AnySharedPointerT<CoreContext::AutoFactory<T>> af;

--- a/autowiring/ObjectTraits.h
+++ b/autowiring/ObjectTraits.h
@@ -43,7 +43,13 @@ struct ObjectTraits {
         return false;
       }()
     )
-  {}
+  {
+    // We can instantiate casts to Object here at the point where object traits are being generated
+    (void) autowiring::fast_pointer_cast_initializer<Object, TActual>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<TActual, Object>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<Object, T>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<T, Object>::sc_init;
+  }
 
   // The type of the passed pointer
   const std::type_info& type;

--- a/autowiring/fast_pointer_cast.h
+++ b/autowiring/fast_pointer_cast.h
@@ -19,8 +19,6 @@ namespace autowiring {
     std::is_base_of<T, U>::value && !std::is_same<T, U>::value,
     typename std::shared_ptr<T>
   >::type fast_pointer_cast(const std::shared_ptr<U>& Other) {
-    (void) fast_pointer_cast_initializer<T, U>::sc_init;
-    (void) fast_pointer_cast_initializer<U, T>::sc_init;
     return std::static_pointer_cast<T, U>(Other);
   };
 
@@ -31,8 +29,6 @@ namespace autowiring {
     std::is_class<T>::value,
     std::shared_ptr<T>
   >::type fast_pointer_cast(const std::shared_ptr<U>& Other) {
-    (void) fast_pointer_cast_initializer<T, U>::sc_init;
-    (void) fast_pointer_cast_initializer<U, T>::sc_init;
     return std::dynamic_pointer_cast<T, U>(Other);
   }
 
@@ -44,8 +40,6 @@ namespace autowiring {
     ) && !std::is_same<T, U>::value,
     std::shared_ptr<T>
   >::type fast_pointer_cast(const std::shared_ptr<U>&) {
-    (void) fast_pointer_cast_initializer<T, U>::sc_init;
-    (void) fast_pointer_cast_initializer<U, T>::sc_init;
     return std::shared_ptr<T>();
   }
 


### PR DESCRIPTION
This is necessary to keep object file sizes to a managable level.  Registries like this one can wind up costing a lot of object space.  This adjustment by itself results in a 3MB object file size difference in AutoFilterTest.
