### PR TITLE
Fixing include guard name collision

### DIFF
--- a/contrib/autoboost/autoboost/exception/detail/clone_current_exception.hpp
+++ b/contrib/autoboost/autoboost/exception/detail/clone_current_exception.hpp
@@ -3,8 +3,8 @@
 //Distributed under the Boost Software License, Version 1.0. (See accompanying
 //file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef UUID_81522C0EB56511DFAB613DB0DFD72085
-#define UUID_81522C0EB56511DFAB613DB0DFD72085
+#ifndef AB_UUID_81522C0EB56511DFAB613DB0DFD72085
+#define AB_UUID_81522C0EB56511DFAB613DB0DFD72085
 #if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(AUTOBOOST_EXCEPTION_ENABLE_WARNINGS)
 #pragma GCC system_header
 #endif

--- a/contrib/autoboost/autoboost/thread/pthread/thread_heap_alloc.hpp
+++ b/contrib/autoboost/autoboost/thread/pthread/thread_heap_alloc.hpp
@@ -2,8 +2,8 @@
 // accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 // (C) Copyright 2008 Anthony Williams
-#ifndef THREAD_HEAP_ALLOC_PTHREAD_HPP
-#define THREAD_HEAP_ALLOC_PTHREAD_HPP
+#ifndef AB_THREAD_HEAP_ALLOC_PTHREAD_HPP
+#define AB_THREAD_HEAP_ALLOC_PTHREAD_HPP
 
 #include <autoboost/config/abi_prefix.hpp>
 


### PR DESCRIPTION
- [x] Ensure there are no other header guards that are in obvious need of update for the same reason
