### PR TITLE
Fix a warning in MSVC

### DIFF
--- a/autowiring/DecorationDisposition.h
+++ b/autowiring/DecorationDisposition.h
@@ -138,7 +138,7 @@ public:
   }
   
   operator bool() {
-    return bool(m_type);
+    return !!m_type;
   }
 
   void Reset(void) {


### PR DESCRIPTION
Use bang-bang syntax instead of casting to bool in order to avoid a performance warning in MSVC