### PR TITLE
Correct empty auto_prev satisfaction

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -73,7 +73,6 @@ protected:
   // NOTE: This is a disambiguation of function reference assignment, and avoids use of constexp.
   typedef std::unordered_map<DecorationKey, DecorationDisposition> t_decorationMap;
   t_decorationMap m_decorations;
-  std::unordered_map<std::type_index, int> m_maxTimeshift;
 
   mutable std::mutex m_lock;
 
@@ -394,9 +393,8 @@ public:
       DecorateUnsafe(&any_ptr, key);
     }
     
-    if (m_decorations[key]) {
-      UpdateSatisfaction(key);
-    }
+    // Call AutoFilters that are now satisfied
+    UpdateSatisfaction(key);
 
     return *ptr;
   }

--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -99,7 +99,7 @@ protected:
   /// <summary>
   /// Marks the specified entry as being unsatisfiable
   /// </summary>
-  void MarkUnsatisfiable(const DecorationKey& key);
+  void MarkUnsatisfiable(const DecorationKey& key, bool recursiveCall=false);
 
   /// <summary>
   /// Updates subscriber statuses given that the specified type information has been satisfied
@@ -125,7 +125,7 @@ protected:
   bool HasUnsafe(const DecorationKey& key) const;
 
   /// <summary>Un-templated & locked component of Checkout</summary>
-  void DecorateUnsafe(AnySharedPointer* ptr, const DecorationKey& key);
+  void DecorateUnsafe(AnySharedPointer* ptr, const DecorationKey& key, bool recursiveCall=false);
 
   /// <summary>
   /// Invoked from a checkout when a checkout has completed

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -129,6 +129,10 @@ void AutoPacket::RemoveSatCounter(const SatCounter& satCounter) {
 }
 
 void AutoPacket::MarkUnsatisfiable(const DecorationKey& key, bool recursiveCall) {
+  if (std::lock_guard<std::mutex>(m_lock), HasUnsafe(key)) {
+    return;
+  }
+  
   // Perform unsatisfaction logic
   if (key.tshift) {
     {

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -80,33 +80,33 @@ void AutoPacket::AddSatCounter(SatCounter& satCounter) {
   for(auto pCur = satCounter.GetAutoFilterInput(); *pCur; pCur++) {
     DecorationKey key(*pCur->ti, pCur->tshift);
 
-    // Update maximum timeshift for this type
-    if (m_maxTimeshift.count(*pCur->ti))
-      m_maxTimeshift[*pCur->ti] = std::max(m_maxTimeshift[*pCur->ti], pCur->tshift);
-    else
-      m_maxTimeshift[*pCur->ti] = pCur->tshift;
-
-    DecorationDisposition* entry = &m_decorations[key];
-    entry->SetKey(key);
+    DecorationDisposition& entry = m_decorations[key];
+    entry.SetKey(key);
 
     // Decide what to do with this entry:
     if (pCur->is_input) {
-      if (entry->m_publishers.size() > 1) {
+      if (entry.m_publishers.size() > 1) {
         std::stringstream ss;
         ss << "Cannot add listener for multi-broadcast type " << autowiring::demangle(pCur->ti);
         throw std::runtime_error(ss.str());
       }
-      entry->m_subscribers.push_back(&satCounter);
-      if (entry->satisfied)
+      entry.m_subscribers.push_back(&satCounter);
+      if (entry.satisfied)
         satCounter.Decrement();
     }
     if (pCur->is_output) {
-      if(entry->m_publishers.size() > 0 && entry->m_subscribers.size() > 0) {
+      if(entry.m_publishers.size() > 0 && entry.m_subscribers.size() > 0) {
         std::stringstream ss;
         ss << "Added identical data broadcasts of type " << autowiring::demangle(pCur->ti) << "with existing subscriber.";
         throw std::runtime_error(ss.str());
       }
-      entry->m_publishers.push_back(&satCounter);
+      entry.m_publishers.push_back(&satCounter);
+    }
+
+    // Make sure decorations exist for timeshifts less that key's timeshift
+    for (int tshift = 0; tshift < key.tshift; ++tshift) {
+      DecorationKey shiftKey(key.ti, tshift);
+      m_decorations[shiftKey].SetKey(shiftKey);
     }
   }
 }
@@ -237,16 +237,13 @@ void AutoPacket::DecorateUnsafe(AnySharedPointer* ptr, const DecorationKey& key)
   assert(entry); // UnsafeComplete must be for an initialized DecorationDisposition
   assert(entry.isCheckedOut); // UnsafeComplete must follow Checkout
 
-  int maxTShift;
-
   // Reset the checkout flag before releasing the lock:
   entry.isCheckedOut = false;
   entry.satisfied = true;
 
   // This allows us to retrieve correct entries for decorated input requests
   AnySharedPointer decoration(entry.m_decorations[0]);
-  maxTShift = m_maxTimeshift[key.ti];
-
+  
   // Exit now if this is a timeshifted decoration.
   if (key.tshift) {
     return;
@@ -254,18 +251,18 @@ void AutoPacket::DecorateUnsafe(AnySharedPointer* ptr, const DecorationKey& key)
 
   // If there are any filters on _this_ packet that desire to know the prior packet, then
   // we must proactively preserve the value of this decoration for our successor.
-  auto successorPacket = shared_from_this();
-  for (int tshift = 1; tshift <= maxTShift; ++tshift) {
-    DecorationKey successorPrior(key.ti, tshift);
-    successorPacket = successorPacket->SuccessorUnsafe();
-
-    if (m_decorations.count(successorPrior)) {
-      // Checkout, satisfy:
-      {
-        std::lock_guard<std::mutex> lk(successorPacket->m_lock);
-        successorPacket->DecorateUnsafe(&decoration, successorPrior);
-      }
-    }
+  auto successor = SuccessorUnsafe();
+  DecorationKey shiftedKey(key.ti, key.tshift + 1);
+  
+  while (m_decorations.count(shiftedKey)) {
+    // Decorate and satisfy
+    (std::lock_guard<std::mutex>)successor->m_lock,
+    successor->DecorateUnsafe(ptr, shiftedKey);
+    successor->UpdateSatisfaction(shiftedKey);
+    
+    // Update key and successor
+    shiftedKey.tshift++;
+    successor = successor->Successor();
   }
 }
 

--- a/src/autowiring/AutoPacketFactory.cpp
+++ b/src/autowiring/AutoPacketFactory.cpp
@@ -21,10 +21,12 @@ std::shared_ptr<AutoPacket> AutoPacketFactory::NewPacket(void) {
     throw autowiring_error("Cannot create a packet until the AutoPacketFactory is started");
   
   std::shared_ptr<AutoPacketInternal> retVal;
+  bool isFirstPacket;
   {
     std::lock_guard<std::mutex> lk(m_lock);
     
     // New packet issued
+    isFirstPacket = !m_packetCount;
     ++m_packetCount;
   
     // Create a new next packet
@@ -32,7 +34,7 @@ std::shared_ptr<AutoPacket> AutoPacketFactory::NewPacket(void) {
     m_nextPacket = retVal->SuccessorInternal();
   }
   
-  retVal->Initialize();
+  retVal->Initialize(isFirstPacket);
   return retVal;
 }
 

--- a/src/autowiring/AutoPacketInternal.cpp
+++ b/src/autowiring/AutoPacketInternal.cpp
@@ -23,7 +23,7 @@ void AutoPacketInternal::Initialize(void) {
     AddSatCounter(satCounter);
   
   // Find all subscribers with no required or optional arguments:
-  std::list<SatCounter*> callCounters;
+  std::vector<SatCounter*> callCounters;
   for (auto& satCounter : m_satCounters)
     if (satCounter)
       callCounters.push_back(&satCounter);

--- a/src/autowiring/AutoPacketInternal.hpp
+++ b/src/autowiring/AutoPacketInternal.hpp
@@ -24,7 +24,7 @@ public:
   /// It is not called when the Packet is created since that could result in
   /// spurious calls when no packet is issued.
   /// </remarks>
-  void Initialize(void);
+  void Initialize(bool isFirstPacket);
 
   /// <summary>
   /// 

--- a/src/autowiring/test/AutoFilterSequencing.cpp
+++ b/src/autowiring/test/AutoFilterSequencing.cpp
@@ -214,6 +214,24 @@ TEST_F(AutoFilterSequencing, OnlyPrev) {
   ASSERT_EQ(10, filter->m_called) << "Filter not called for every packet decoration";
 }
 
+TEST_F(AutoFilterSequencing, FirstPrev) {
+  AutoRequired<AutoPacketFactory> factory;
+  AutoRequired<OnlyPrev> filter;
+  
+  int prev2 = 0;
+  *factory += [&prev2] (auto_prev<int, 2> prev){
+    prev2++;
+  };
+
+  auto packet = factory->NewPacket();
+
+  ASSERT_EQ(1, filter->m_called) << "First packet doesn't have auto_prev value satisfied";
+  ASSERT_EQ(1, prev2) << "Filter called incorrect number of times";
+  
+  auto packet2 = factory->NewPacket();
+  ASSERT_EQ(2, prev2) << "Filter called incorrect number of times";
+}
+
 class PrevPrevFilter {
 public:
   PrevPrevFilter(void):

--- a/src/autowiring/test/AutoFilterSequencing.cpp
+++ b/src/autowiring/test/AutoFilterSequencing.cpp
@@ -190,6 +190,30 @@ TEST_F(AutoFilterSequencing, UnsatisfiedPrev) {
   }
 }
 
+struct OnlyPrev {
+  OnlyPrev():
+    m_called(0)
+  {}
+  
+  void AutoFilter(auto_prev<int> p) {
+    ++m_called;
+  }
+  
+  int m_called;
+};
+
+TEST_F(AutoFilterSequencing, OnlyPrev) {
+  AutoRequired<AutoPacketFactory> factory;
+  AutoRequired<OnlyPrev> filter;
+  
+  for (int i=10; i<20; ++i) {
+    auto packet = factory->NewPacket();
+    packet->Decorate(i);
+  }
+  
+  ASSERT_EQ(10, filter->m_called) << "Filter not called for every packet decoration";
+}
+
 class PrevPrevFilter {
 public:
   PrevPrevFilter(void):

--- a/src/autowiring/test/AutoFilterSequencing.cpp
+++ b/src/autowiring/test/AutoFilterSequencing.cpp
@@ -166,6 +166,30 @@ TEST_F(AutoFilterSequencing, SimplePrev) {
   ASSERT_EQ(1, filter->m_num_empty_prev) << "Prev should only be null for the first call";
 }
 
+TEST_F(AutoFilterSequencing, UnsatisfiedPrev) {
+  AutoRequired<AutoPacketFactory> factory;
+  AutoRequired<PrevFilter> filter;
+
+  {
+    auto packet = factory->NewPacket();
+    packet->Decorate(42);
+
+    // Don't decorate this packet
+    auto emptyPacket = factory->NewPacket();
+  }
+
+  ASSERT_EQ(1, filter->m_called);
+
+  {
+    auto packet = factory->NewPacket();
+
+    // Prev from previous packet should have been marked unsatisfiable
+    packet->Decorate(1337);
+    ASSERT_EQ(2, filter->m_called) << "auto_prev<int> not marked unsatisfiable on this packet";
+    ASSERT_EQ(2, filter->m_num_empty_prev);
+  }
+}
+
 class PrevPrevFilter {
 public:
   PrevPrevFilter(void):


### PR DESCRIPTION
`auto_prev`s are now correctly satisfied with an empty value when the previous packet can no longer satisfy the type.

Also, for each decoration for type `T` with timeshift `N`, decorations for type `T` and timeshifts `< N` are guaranteed to exist