### PR TITLE
Modify DispositionState to use an enum to describe it's level of satisfaction

### DIFF
--- a/src/autowiring/test/DecoratorTest.cpp
+++ b/src/autowiring/test/DecoratorTest.cpp
@@ -91,7 +91,7 @@ TEST_F(DecoratorTest, VerifyDecoratorAwareness) {
   ASSERT_EQ(1UL, subs.size()) << "Incorrect subscriber count";
   auto disps = packet2->GetDispositions<Decoration<0>>();
   ASSERT_EQ(1UL, disps.size()) << "Incorrect count of expected decorations";
-  ASSERT_FALSE(disps.front().satisfied) << "Incorrect satisfaction status";
+  ASSERT_FALSE(disps.front().m_state == DispositionState::Satisfied) << "Incorrect satisfaction status";
   ASSERT_TRUE(packet2->HasSubscribers<Decoration<0>>()) << "Packet lacked an expected subscription";
 }
 


### PR DESCRIPTION
The PartlySatisfied state is intended for use with the upcoming multi-decorate feature, to distinguish the state between Unsatisfied and Satisfied, where we know that not every provider of a decoration has given us one.