### PR TITLE
Relax AnySharedPointer ctor constraint

### DIFF
--- a/autowiring/AnySharedPointer.h
+++ b/autowiring/AnySharedPointer.h
@@ -6,7 +6,7 @@ struct AnySharedPointer {
 public:
   AnySharedPointer(void);
   AnySharedPointer(AnySharedPointer&& rhs);
-  explicit AnySharedPointer(const AnySharedPointer& rhs);
+  AnySharedPointer(const AnySharedPointer& rhs);
 
   template<class T>
   explicit AnySharedPointer(const std::shared_ptr<T>& rhs) {


### PR DESCRIPTION
Copy ctor does not need to be made explicit, here; this guard was originally intended to prevent unintentional copying of this type back when it was expensive to copy it, but now copying is cheap enough to not be a significant problem.