### PR TITLE
Provide a default ctor for std::tuple

### DIFF
--- a/autowiring/C++11/boost_tuple.h
+++ b/autowiring/C++11/boost_tuple.h
@@ -8,6 +8,7 @@ namespace std {
   template<typename... Ts>
   class tuple {
   public:
+    tuple(void) {}
     tuple(const Ts&... ele):
       m_tuple(ele...)
     {}


### PR DESCRIPTION
This should be fine to add even if tuples are sometimes instantiated which contain types that cannot be default constructed, as members of a template type are not instantiated unless explicitly invoked.