### PR TITLE
Fix incorrect const collapse in AutoPacket

### DIFF
--- a/autowiring/auto_id.h
+++ b/autowiring/auto_id.h
@@ -1,5 +1,7 @@
 // Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include TYPE_TRAITS_HEADER
+#include TYPE_INDEX_HEADER
 
 /// <summary>
 /// Identifier sigil structure
@@ -9,4 +11,10 @@
 /// It's only used in cases where typeid(T) would have been used alone.
 /// </remarks>
 template<class T>
-struct auto_id {};
+struct auto_id {
+  
+  // Return this type_info for this type with 'const' and 'volitile' removed
+  static const std::type_info& key(void) {
+    return typeid(auto_id<typename std::remove_cv<T>::type>);
+  }
+};

--- a/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
+++ b/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
@@ -107,6 +107,28 @@ TEST_F(AutoFilterCollapseRulesTest, CanAcceptUndefinedSharedPointerInput) {
 }
 
 #if AUTOWIRING_USE_LIBCXX
+TEST_F(AutoFilterCollapseRulesTest, ConstCollapse) {
+  CurrentContextPusher pshr((AutoCreateContext()));
+  AutoRequired<AutoPacketFactory> factory;
+  AutoRequired<AcceptsConstReference> filter;
+  
+  // Test const shared_ptr
+  auto packet1 = factory->NewPacket();
+  
+  std::shared_ptr<const int> dec1 = std::make_shared<const int>(42);
+  packet1->Decorate(dec1);
+  
+  ASSERT_EQ(1, filter->m_called) << "'const T' decoration didn't resolve to 'T'";
+  
+  // Test const value
+  auto packet2 = factory->NewPacket();
+  
+  const int dec2 = 42;
+  packet2->Decorate(dec2);
+  
+  ASSERT_EQ(2, filter->m_called) << "'const T' decoration didn't resolve to 'T'";
+}
+
 TEST_F(AutoFilterCollapseRulesTest, SharedPointerAliasingRules) {
   AutoRequired<AutoPacketFactory> factory;
   AutoRequired<FilterGen<std::shared_ptr<const int>>> genFilter1;

--- a/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
+++ b/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
@@ -108,7 +108,6 @@ TEST_F(AutoFilterCollapseRulesTest, CanAcceptUndefinedSharedPointerInput) {
 
 #if AUTOWIRING_USE_LIBCXX
 TEST_F(AutoFilterCollapseRulesTest, ConstCollapse) {
-  CurrentContextPusher pshr((AutoCreateContext()));
   AutoRequired<AutoPacketFactory> factory;
   AutoRequired<AcceptsConstReference> filter;
   


### PR DESCRIPTION
`auto_id` now has a `key()` function that returns the `type_info` of the collapsed type.