### PR TITLE
Allowing tests to build on LIBCXX again

### DIFF
--- a/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
+++ b/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
@@ -106,7 +106,6 @@ TEST_F(AutoFilterCollapseRulesTest, CanAcceptUndefinedSharedPointerInput) {
   AutoRequired<AcceptsUnnamedExternalClassSharedPtr> auecsp;
 }
 
-#if AUTOWIRING_USE_LIBCXX
 TEST_F(AutoFilterCollapseRulesTest, SharedPointerAliasingRules) {
   AutoRequired<AutoPacketFactory> factory;
   AutoRequired<FilterGen<std::shared_ptr<const int>>> genFilter1;
@@ -143,4 +142,3 @@ TEST_F(AutoFilterCollapseRulesTest, AutoFilterSharedAliasingRules) {
   ASSERT_TRUE(packet->Has<int>()) << "Filter producing a shared pointer of type int did not correctly collapse to the basic int type";
   ASSERT_EQ(55, std::get<0>(consumes->m_args)) << "Filter consuming a shared pointer output was not called as expected";
 }
-#endif

--- a/src/autowiring/test/TestFixtures/Decoration.hpp
+++ b/src/autowiring/test/TestFixtures/Decoration.hpp
@@ -136,7 +136,6 @@ public:
 /// <summary>
 /// A generic filter which accepts templated input types
 /// </summary>
-#if AUTOWIRING_USE_LIBCXX
 template<class... Args>
 class FilterGen {
 public:
@@ -162,7 +161,6 @@ public:
   int m_called;
   std::tuple<typename std::decay<Args>::type...> m_args;
 };
-#endif
 
 /// <summary>
 /// A filter that should trigger a static_assert in AutoRequire<BadFilterA>


### PR DESCRIPTION
- [ ] Verify LibCXX unit tests still pass