### PR TITLE
Fix AutoPacket destructor satisfaction

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -99,7 +99,12 @@ protected:
   /// <summary>
   /// Marks the specified entry as being unsatisfiable
   /// </summary>
-  void MarkUnsatisfiable(const DecorationKey& key, bool recursiveCall=false);
+  void MarkUnsatisfiable(const DecorationKey& key);
+  
+  /// <summary>
+  /// Marks timeshifted decorations on successor packets as unsatisfiable
+  /// </summary>
+  void MarkSuccessorsUnsatisfiable(DecorationKey type);
 
   /// <summary>
   /// Updates subscriber statuses given that the specified type information has been satisfied

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -25,14 +25,12 @@ AutoPacket::~AutoPacket(void) {
     )
   );
   
-  // Trigger AutoFilter functions with unsatisfied auto_prev's
-  // We now know they will never be satisfied
+  // Mark decorations of successor packets that use decorations
+  // originating from this packet as unsatisfiable
   for (auto& pair : m_decorations) {
-    if (pair.second.m_state == DispositionState::PartlySatisfied) {
-      pair.second.m_state = DispositionState::Satisfied;
-      UpdateSatisfaction(pair.first);
-    } else if (pair.second.m_state != DispositionState::Satisfied) {
-      MarkUnsatisfiable(pair.first);
+    if (!pair.first.tshift &&
+        pair.second.m_state != DispositionState::Satisfied) {
+      MarkSuccessorsUnsatisfiable(DecorationKey(pair.first.ti, 0));
     }
   }
 
@@ -130,11 +128,7 @@ void AutoPacket::RemoveSatCounter(const SatCounter& satCounter) {
   }
 }
 
-void AutoPacket::MarkUnsatisfiable(const DecorationKey& key, bool recursiveCall) {
-  if (std::lock_guard<std::mutex>(m_lock), HasUnsafe(key)) {
-    return;
-  }
-  
+void AutoPacket::MarkUnsatisfiable(const DecorationKey& key) {
   // Perform unsatisfaction logic
   if (key.tshift) {
     {
@@ -145,23 +139,20 @@ void AutoPacket::MarkUnsatisfiable(const DecorationKey& key, bool recursiveCall)
     }
     UpdateSatisfaction(key);
   }
+}
 
-  // We're manually implementing tail-call optimization, so don't recurse more than once
-  if (recursiveCall) {
-    return;
-  }
-
-  // Recurse on successor packets
+void AutoPacket::MarkSuccessorsUnsatisfiable(DecorationKey key) {
   std::lock_guard<std::mutex> lk(m_lock);
-
+  
+  // Update key and successor
+  key.tshift++;
   auto successor = SuccessorUnsafe();
-  DecorationKey shiftedKey(key.ti, key.tshift + 1);
-
-  while (m_decorations.count(shiftedKey)) {
-    successor->MarkUnsatisfiable(shiftedKey, true);
-
+  
+  while (m_decorations.count(key)) {
+    successor->MarkUnsatisfiable(key);
+    
     // Update key and successor
-    shiftedKey.tshift++;
+    key.tshift++;
     successor = successor->Successor();
   }
 }

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -25,20 +25,6 @@ AutoPacket::~AutoPacket(void) {
     )
   );
   
-  // Create vector of all successor packets that will be destroyed
-  // This prevents recursive AutoPacket destructor calls
-  std::vector<std::shared_ptr<AutoPacket>> packets;  
-  
-  // Recurse through unique successors, storing them in our vector
-  for (AutoPacket* current = this; current->m_successor.unique();) {
-    packets.push_back(current->m_successor);
-    
-    // Reset and continue to next successor
-    AutoPacket* prev_current = current;
-    current = current->m_successor.get();
-    prev_current->m_successor.reset();
-  }
-  
   // Trigger AutoFilter functions with unsatisfied auto_prev's
   // We now know they will never be satisfied
   for (auto& pair : m_decorations) {
@@ -52,6 +38,20 @@ AutoPacket::~AutoPacket(void) {
 
   // Needed for the AutoPacketGraph
   NotifyTeardownListeners();
+  
+  // Create vector of all successor packets that will be destroyed
+  // This prevents recursive AutoPacket destructor calls
+  std::vector<std::shared_ptr<AutoPacket>> packets;
+  
+  // Recurse through unique successors, storing them in our vector
+  for (AutoPacket* current = this; current->m_successor.unique();) {
+    packets.push_back(current->m_successor);
+    
+    // Reset and continue to next successor
+    AutoPacket* prev_current = current;
+    current = current->m_successor.get();
+    prev_current->m_successor.reset();
+  }
 }
 
 DecorationDisposition& AutoPacket::DecorateImmediateUnsafe(const DecorationKey& key, const void* pvImmed)

--- a/src/autowiring/AutoPacketInternal.cpp
+++ b/src/autowiring/AutoPacketInternal.cpp
@@ -36,6 +36,7 @@ void AutoPacketInternal::Initialize(bool isFirstPacket) {
       auto& key = dec.first;
       if (key.tshift) {
         MarkUnsatisfiable(key);
+        MarkSuccessorsUnsatisfiable(key);
       }
     }
   }


### PR DESCRIPTION
It was previously possible for an `AutoFilter` to be satisfied in an `AutoPacket`'s destructor. This caused segfaults if the a `Deferred` `AutoFilter` was satisfied