### PR TITLE
Generalizing InvokeRelay to support arbitrary return types

### DIFF
--- a/autowiring/InvokeRelay.h
+++ b/autowiring/InvokeRelay.h
@@ -12,10 +12,10 @@ class JunctionBox;
 template<class FnPtr>
 class InvokeRelay {};
 
-template<class T, typename... Args>
-class InvokeRelay<void (T::*)(Args...)> {
+template<class RetType, class T, typename... Args>
+class InvokeRelay<RetType (T::*)(Args...)> {
 public:
-  InvokeRelay(std::shared_ptr<JunctionBox<T>> erp, void (T::*fnPtr)(Args...)) :
+  InvokeRelay(std::shared_ptr<JunctionBox<T>> erp, RetType (T::*fnPtr)(Args...)) :
     erp(erp),
     fnPtr(fnPtr)
   {}
@@ -29,7 +29,7 @@ public:
 
 private:
   std::shared_ptr<JunctionBox<T>> erp;
-  void (T::*fnPtr)(Args...);
+  RetType (T::*fnPtr)(Args...);
 
 public:
   /// <summary>

--- a/src/autowiring/test/EventReceiverTest.cpp
+++ b/src/autowiring/test/EventReceiverTest.cpp
@@ -485,3 +485,27 @@ TEST_F(EventReceiverTest, EventChain){
   AutoCurrentContext ctxt;
   ctxt->Invoke(&MyReceiver::MyEvent)();
 }
+
+class HasAWeirdReturnType {
+public:
+  HasAWeirdReturnType(void) :
+    bCalled(false)
+  {}
+
+  bool bCalled;
+
+  int FiredMethod(void) {
+    bCalled = true;
+    return 1010;
+  }
+};
+
+/// <summary>
+/// Syntax verification to ensure 
+TEST_F(EventReceiverTest, OddReturnTypeTest) {
+  AutoRequired<HasAWeirdReturnType> hawrt;
+  AutoFired<HasAWeirdReturnType> af;
+  af(&HasAWeirdReturnType::FiredMethod)();
+
+  ASSERT_TRUE(hawrt->bCalled) << "Method with a strange fired return type did not get invoked as expected";
+}


### PR DESCRIPTION
Even though we have deprecated the use of Deferred event types, this signature is still used in platform and elsewhere.  It would be nice if we just support this syntax changeover cleanly.