### PR TITLE
Deprecate `AutowiringEvents::EventFired`

### DIFF
--- a/autowiring/AutoPacketGraph.h
+++ b/autowiring/AutoPacketGraph.h
@@ -97,7 +97,6 @@ protected:
   /// AutowiringEvents overrides
   virtual void NewContext(CoreContext&) override {}
   virtual void ExpiredContext(CoreContext&) override {}
-  virtual void EventFired(CoreContext&, const std::type_info&) override {}
   virtual void NewObject(CoreContext&, const ObjectTraits&) override;
   
   /// CoreRunnable overrides

--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -391,13 +391,10 @@ public:
   template<class MemFn>
   InvokeRelay<MemFn> operator()(MemFn pfn) const {
     auto box = m_junctionBox.lock();
-    if(!box)
-      // Context has been destroyed
-      return InvokeRelay<MemFn>();
-
-    AutoGlobalContext()->Invoke(&AutowiringEvents::EventFired)(*CoreContext::CurrentContext(),typeid(typename Decompose<MemFn>::type));
-
-    return MakeInvokeRelay(box, pfn);
+    return
+      box ?
+      MakeInvokeRelay(box, pfn) :
+      InvokeRelay<MemFn>();
   }
 
   template<class MemFn>

--- a/autowiring/AutowiringEvents.h
+++ b/autowiring/AutowiringEvents.h
@@ -18,7 +18,6 @@ public:
   virtual void NewContext(CoreContext&)=0;
   virtual void ExpiredContext(CoreContext&)=0;
   virtual void NewObject(CoreContext&, const ObjectTraits&)=0;
-  virtual void EventFired(CoreContext&, const std::type_info&)=0;
 };
 
 // Extern explicit template instantiation declarations added to prevent

--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -652,10 +652,6 @@ public:
   template<typename MemFn>
   InvokeRelay<MemFn> Invoke(MemFn memFn){
     typedef typename Decompose<MemFn>::type EventType;
-
-    if (!std::is_same<AutowiringEvents,EventType>::value)
-      GetGlobal()->Invoke(&AutowiringEvents::EventFired)(*this, typeid(EventType));
-
     return MakeInvokeRelay(GetJunctionBox<EventType>(), memFn);
   }
 

--- a/src/autonet/AutoNetServerImpl.cpp
+++ b/src/autonet/AutoNetServerImpl.cpp
@@ -230,15 +230,6 @@ void AutoNetServerImpl::NewObject(CoreContext& ctxt, const ObjectTraits& object)
   };
 }
 
-void AutoNetServerImpl::EventFired(CoreContext& context, const std::type_info& info){
-  int contextID = ResolveContextID(&context);
-  std::string name = autowiring::demangle(info);
-
-  *this += [this, contextID, name] {
-    BroadcastMessage("eventFired", contextID, Json::object{{"name", name}});
-  };
-}
-
 void AutoNetServerImpl::HandleSubscribe(websocketpp::connection_hdl hdl) {
   m_Subscribers.insert(hdl);
 

--- a/src/autonet/AutoNetServerImpl.hpp
+++ b/src/autonet/AutoNetServerImpl.hpp
@@ -68,13 +68,6 @@ public:
   /// <param name="obj">The object</param>
   virtual void NewObject(CoreContext& ctxt, const ObjectTraits& obj) override;
 
-  /// <summary>
-  /// Updates server when a context has expired
-  /// </summary>
-  /// <param name="ctxt">The expired context</param>
-  /// <param name="evtInfo">The event type</param>
-  virtual void EventFired(CoreContext& ctxt, const std::type_info& evtInfo) override;
-
 protected:
   /// <summary>
   /// Sends a message to specified client.


### PR DESCRIPTION
While this is a nice concept, we can't actually use it because of performance limitations on the client side.  Deprecating it for now.