### PR TITLE
Adding a packet `Wait` routine

### DIFF
--- a/autowiring/AutoFilterDescriptor.h
+++ b/autowiring/AutoFilterDescriptor.h
@@ -1,8 +1,8 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AnySharedPointer.h"
-#include "AutoPacket.h"
 #include "auto_arg.h"
+#include "AutoFilterDescriptorInput.h"
 #include "CallExtractor.h"
 #include "Decompose.h"
 #include "has_autofilter.h"
@@ -11,48 +11,6 @@
 
 class AutoPacket;
 class Deferred;
-
-/// <summary>
-/// AutoFilter argument disposition
-/// </summary>
-struct AutoFilterDescriptorInput {
-  AutoFilterDescriptorInput(void) :
-    is_input(false),
-    is_output(false),
-    is_shared(false),
-    is_multi(false),
-    ti(nullptr),
-    tshift(0)
-  {}
-
-  template<class T>
-  AutoFilterDescriptorInput(auto_arg<T>*) :
-    is_input(auto_arg<T>::is_input),
-    is_output(auto_arg<T>::is_output),
-    is_shared(auto_arg<T>::is_shared),
-    is_multi(auto_arg<T>::is_multi),
-    ti(&typeid(typename auto_arg<T>::id_type)),
-    tshift(auto_arg<T>::tshift)
-  {}
-
-  const bool is_input;
-  const bool is_output;
-  const bool is_shared;
-  const bool is_multi;
-  const std::type_info* const ti;
-  const int tshift;
-
-  operator bool(void) const {
-    return !!ti;
-  }
-
-  template<class T>
-  struct rebind {
-    operator AutoFilterDescriptorInput() {
-      return AutoFilterDescriptorInput((auto_arg<T>*)nullptr);
-    }
-  };
-};
 
 /// <summary>
 /// The unbound part of an AutoFilter, includes everything except the AnySharedPointer representing the filter proper

--- a/autowiring/AutoFilterDescriptorInput.h
+++ b/autowiring/AutoFilterDescriptorInput.h
@@ -1,0 +1,46 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "auto_arg.h"
+#include <typeinfo>
+
+/// <summary>
+/// AutoFilter argument disposition
+/// </summary>
+struct AutoFilterDescriptorInput {
+  AutoFilterDescriptorInput(void) :
+    is_input(false),
+    is_output(false),
+    is_shared(false),
+    is_multi(false),
+    ti(nullptr),
+    tshift(0)
+  {}
+
+  template<class T>
+  AutoFilterDescriptorInput(auto_arg<T>*) :
+    is_input(auto_arg<T>::is_input),
+    is_output(auto_arg<T>::is_output),
+    is_shared(auto_arg<T>::is_shared),
+    is_multi(auto_arg<T>::is_multi),
+    ti(&typeid(typename auto_arg<T>::id_type)),
+    tshift(auto_arg<T>::tshift)
+  {}
+
+  const bool is_input;
+  const bool is_output;
+  const bool is_shared;
+  const bool is_multi;
+  const std::type_info* const ti;
+  const int tshift;
+
+  operator bool(void) const {
+    return !!ti;
+  }
+
+  template<class T>
+  struct rebind {
+    operator AutoFilterDescriptorInput() {
+      return AutoFilterDescriptorInput((auto_arg<T>*)nullptr);
+    }
+  };
+};

--- a/autowiring/DecorationDisposition.h
+++ b/autowiring/DecorationDisposition.h
@@ -100,6 +100,7 @@ struct DecorationDisposition
     m_state = source.m_state;
     return *this;
   }
+
 private:
   // Destructured key for this decoration. Use accessor functions to access
   // This is needed because DecorationKey doesn't have a default constructor

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -22,6 +22,7 @@ set(Autowiring_SRCS
   AutoConfigParser.cpp
   AutoConfigParser.hpp
   AutoFilterDescriptor.h
+  AutoFilterDescriptorInput.h
   AutoFuture.cpp
   AutoFuture.h
   AutoInjectable.cpp

--- a/src/autowiring/test/AutoPacketTest.cpp
+++ b/src/autowiring/test/AutoPacketTest.cpp
@@ -1,0 +1,45 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include <autowiring/CoreThread.h>
+#include "TestFixtures/Decoration.hpp"
+
+class AutoPacketTest:
+  public testing::Test
+{
+public:
+  AutoPacketTest(void) {
+    AutoCurrentContext()->Initiate();
+  }
+  AutoRequired<AutoPacketFactory> factory;
+};
+
+TEST_F(AutoPacketTest, SimpleCallTest) {
+  auto packet = factory->NewPacket();
+  packet->Decorate(Decoration<0>());
+  std::condition_variable cv;
+
+  // Factory call:
+  ASSERT_TRUE(packet->Wait<Decoration<0>>(std::chrono::milliseconds(0), cv)) << "Unexpected timeout";
+}
+
+TEST_F(AutoPacketTest, FactoryCallTest) {
+  AutoRequired<FilterGen<const Decoration<0>&, Decoration<1>&>> fg;
+  auto packet = factory->NewPacket();
+
+  // Blocking factory call:
+  std::condition_variable cv;
+  bool bCalled = false;
+  packet->Decorate(Decoration<0>());
+  
+  ASSERT_TRUE(
+    packet->Wait(
+      cv,
+      [&bCalled](const Decoration<1>&) {
+        bCalled = true;
+      },
+      std::chrono::nanoseconds(0)
+    )
+  );
+
+  ASSERT_TRUE(bCalled);
+}

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -6,6 +6,7 @@ set(AutowiringTest_SRCS
   AutoFilterCollapseRulesTest.cpp
   AutoFilterDiagnosticsTest.cpp
   AutoInjectableTest.cpp
+  AutoPacketTest.cpp
   AutoPacketFactoryTest.cpp
   AutoParameterTest.cpp
   AutoRestarterTest.cpp


### PR DESCRIPTION
This routine allows consumers to block for a packet to contain a specific set of desired decorations.  This method will work even if processing on this packet crosses thread boundaries.  A `CallFast` variant is provided which provides the same services, but requires users to allocate storage for a `condition_variable` type, and also requires that all passed decorations specified as a `shared_ptr` type.