### PR TITLE
Simplify AutoPacket satisfaction

### DIFF
--- a/autowiring/AutoFilterDescriptor.h
+++ b/autowiring/AutoFilterDescriptor.h
@@ -303,11 +303,6 @@ public:
     m_autoFilter->reset();
   }
 
-  /// <returns>
-  /// True if this subscriber instance is not empty.
-  /// </returns>
-  operator bool(void) const { return !empty(); }
-
   /// <returns>True when both the AutoFilter method and subscriber instance are equal.</returns>
   bool operator==(const AutoFilterDescriptor& rhs) const {
     // AutoFilter methods are the same for all instances of a class,

--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -766,7 +766,7 @@ public:
       AddEventReceiver(JunctionBoxEntry<Object>(this, traits.pObject));
     
     // Add PacketSubscriber;
-    if(traits.subscriber)
+    if(!traits.subscriber.empty())
       AddPacketSubscriber(traits.subscriber);
   }
 
@@ -797,7 +797,7 @@ public:
       UnsnoopEvents(oSnooper.get(), JunctionBoxEntry<Object>(this, traits.pObject));
     
     // Cleanup if its a packet listener
-    if(traits.subscriber)
+    if(!traits.subscriber.empty())
       UnsnoopAutoPacket(traits);
   }
   

--- a/autowiring/SatCounter.h
+++ b/autowiring/SatCounter.h
@@ -11,24 +11,18 @@ struct SatCounter:
   public AutoFilterDescriptor
 {
   SatCounter(void):
-    called(false),
     remaining(0)
   {}
 
   SatCounter(const AutoFilterDescriptor& source):
     AutoFilterDescriptor(source),
-    called(false),
     remaining(m_requiredCount)
   {}
 
   SatCounter(const SatCounter& source):
     AutoFilterDescriptor(static_cast<const AutoFilterDescriptor&>(source)),
-    called(source.called),
     remaining(source.remaining)
   {}
-
-  // The number of times the AutoFilter is called
-  bool called;
 
   // The number of inputs remaining to this counter:
   size_t remaining;
@@ -40,16 +34,6 @@ private:
   void ThrowRepeatedCallException(void) const;
 
 public:
-  /// <summary>
-  /// Calls the underlying AutoFilter method with the specified AutoPacketAdapter as input
-  /// </summary>
-  void CallAutoFilter(AutoPacket& packet) {
-    if (called)
-      ThrowRepeatedCallException();
-    called = true;
-    GetCall()(GetAutoFilter(), packet);
-  }
-
   /// <summary>
   /// Conditionally decrements AutoFilter argument satisfaction.
   /// </summary>
@@ -64,7 +48,4 @@ public:
   void Increment(void) {
     ++remaining;
   }
-
-  /// <returns>False if there are any inputs still outstanding</returns>
-  operator bool(void) const { return !remaining; }
 };

--- a/src/autowiring/AutoPacketGraph.cpp
+++ b/src/autowiring/AutoPacketGraph.cpp
@@ -83,7 +83,7 @@ void AutoPacketGraph::AutoFilter(AutoPacket& packet) {
       auto type = &decoration.GetKey().ti;
 
       for (auto& publisher : decoration.m_publishers) {
-        if (publisher->called) {
+        if (!publisher->remaining) {
           RecordDelivery(type, *publisher, false);
         }
       }
@@ -95,7 +95,7 @@ void AutoPacketGraph::AutoFilter(AutoPacket& packet) {
           continue;
         }
         
-        if (subscriber->called) {
+        if (subscriber->remaining) {
           RecordDelivery(type, *subscriber, true);
         }
       }

--- a/src/autowiring/AutoPacketInternal.cpp
+++ b/src/autowiring/AutoPacketInternal.cpp
@@ -25,9 +25,8 @@ void AutoPacketInternal::Initialize(bool isFirstPacket) {
     // Prime the satisfaction graph for element:
     AddSatCounter(satCounter);
     
-    if (satCounter) {
+    if (!satCounter.remaining)
       callCounters.push_back(&satCounter);
-    }
   }
   
   // Mark timeshifted decorations as unsatisfiable on the first packet
@@ -44,7 +43,7 @@ void AutoPacketInternal::Initialize(bool isFirstPacket) {
   // Call all subscribers with no required or optional arguments:
   // NOTE: This may result in decorations that cause other subscribers to be called.
   for (SatCounter* call : callCounters)
-    call->CallAutoFilter(*this);
+    call->GetCall()(call->GetAutoFilter(), *this);
 
   // First-call indicated by argumument type AutoPacket&:
   UpdateSatisfaction(DecorationKey(typeid(auto_arg<AutoPacket&>::id_type)));

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -254,7 +254,7 @@ void CoreContext::AddInternal(const ObjectTraits& traits) {
 
   // Subscribers, if applicable:
   const auto& stump = traits.stump;
-  if(traits.subscriber) {
+  if(!traits.subscriber.empty()) {
     AddPacketSubscriber(traits.subscriber);
 
     // Ancilliary subscribers, if present:


### PR DESCRIPTION
A few branch instructions are simplified here, also shortened the call depth between `Decorate` and `AutoFilter` by one