### PR TITLE
Eliminate `AutoPacket::Put`

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -284,38 +284,6 @@ public:
     return *retVal;
   }
 
-  /// <summary>
-  /// De-templated placement method
-  /// </summary>
-  void Put(const DecorationKey& key, SharedPointerSlot&& in);
-
-  /// <summary>
-  /// Transfers ownership of argument to AutoPacket
-  /// </summary>
-  /// <remarks>
-  /// This method may throw an exception.  Ownership is unconditionally transferred to this class
-  /// even in the event an exception is thrown, thus the passed pointer is guaranteed to be cleaned
-  /// up properly in all cases.
-  /// </remarks>
-  template<class T>
-  void Put(T* in) {
-    Put(auto_id<T>::key(), SharedPointerSlotT<T, false>(std::shared_ptr<T>(in)));
-  }
-
-  /// <summary>
-  /// Shares ownership of argument with AutoPacket
-  /// </summary>
-  /// <remarks>
-  /// This can be used to:
-  /// - place data on the AutoPack from an ObjectPool
-  /// - move data from one AutoPacket to another without copying
-  /// - alias the type of a decoration on AutoPacket
-  /// </remarks>
-  template<class T>
-  void Put(std::shared_ptr<T> in) {
-    Put(DecorationKey(auto_id<T>::key()), SharedPointerSlotT<T, false>(std::move(in)));
-  }
-
   /// <summary>Shares all broadcast data from this packet with the recipient packet</summary>
   /// <remarks>
   /// This method should ONLY be called during the final-call sequence.

--- a/autowiring/auto_out.h
+++ b/autowiring/auto_out.h
@@ -36,7 +36,7 @@ public:
   /// <summary>Destruction of auto_out makes type data available</summary>
   ~auto_out(void) {
     if(m_packet && m_value)
-      m_packet->Put(m_value);
+      m_packet->Decorate(m_value);
   }
 
 protected:

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -326,25 +326,6 @@ void AutoPacket::ThrowNotDecoratedException(const DecorationKey& key) {
   throw std::runtime_error(ss.str());
 }
 
-void AutoPacket::Put(const DecorationKey& key, SharedPointerSlot&& in) {
-  auto& entry = m_decorations[key];
-  if(entry.m_state != DispositionState::Unsatisfied) {
-    std::stringstream ss;
-    ss << "Cannot put type " << autowiring::demangle(in.type())
-      << " on AutoPacket, the requested type already exists";
-    throw std::runtime_error(ss.str());
-  }
-
-  entry.SetKey(key);
-  if (entry.m_decorations.empty()) {
-    entry.m_decorations.push_back(AnySharedPointer());
-  }
-  entry.m_decorations[0] = in;
-  entry.m_state = DispositionState::Satisfied;
-
-  UpdateSatisfaction(key);
-}
-
 void AutoPacket::ForwardAll(std::shared_ptr<AutoPacket> recipient) const {
   // Copy decorations into an internal decorations maintenance collection.  The values
   // in this collection are guaranteed to be stable in memory, and there are stable states


### PR DESCRIPTION
This method was originally provided for use with `auto_out`, but it is now redundant due to changes in the implementation of `AutoPacket::Decorate`