### PR TITLE
Correct current context in AutoFilter calls

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -21,6 +21,7 @@ class AutoPacketInternal;
 class AutoPacketFactory;
 class AutoPacketProfiler;
 struct AutoFilterDescriptor;
+class CoreContext;
 
 /// <summary>
 /// A decorator-style processing packet
@@ -477,6 +478,9 @@ public:
   bool HasSubscribers(void) const {
     return HasSubscribers(DecorationKey(auto_id<T>::key()));
   }
+
+  /// Get the context of this packet (The context of the AutoPacketFactory that created this context)
+  std::shared_ptr<CoreContext> GetContext(void) const;
 };
 
 #include "CallExtractor.h"

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -412,3 +412,6 @@ std::shared_ptr<AutoPacket> AutoPacket::SuccessorUnsafe(void) {
   return m_successor;
 }
 
+std::shared_ptr<CoreContext> AutoPacket::GetContext(void) const {
+  return m_parentFactory->GetContext();
+}

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -863,7 +863,7 @@ struct ContextChecker:
 
   void AutoFilter(int i) {
     ++m_called;
-    ASSERT_EQ(AutoCurrentContext(), GetContext()) << "AutoFilter not called CurrentContext set to packet's context";
+    ASSERT_EQ(AutoCurrentContext(), GetContext()) << "AutoFilter not called with the current context set to packet's context";
   }
 
   int m_called;


### PR DESCRIPTION
Guarantee that the current context is set to the packet's originating context in AutoFilter calls.