### PR TITLE
Add support for delayed Initiate

### DIFF
--- a/autowiring/AutoRestarter.h
+++ b/autowiring/AutoRestarter.h
@@ -114,6 +114,10 @@ protected:
   /// Called by the monitor context member when a context has been stopped
   /// </summary>
   virtual void OnContextStopped(const ContextMember& monitor) {
+    // If our context is shut down already, we can take no action
+    if (AutoCurrentContext()->IsShutdown())
+      return;
+
     {
       std::lock_guard<std::mutex> lk(m_lock);
       if(m_context != monitor.GetContext())

--- a/src/autotesting/gtest-all-guard.cpp
+++ b/src/autotesting/gtest-all-guard.cpp
@@ -7,6 +7,9 @@ using namespace std;
 
 int autotesting_main(int argc, const char* argv[])
 {
+  // Always start the global context
+  AutoGlobalContext()->Initiate();
+
   auto& listeners = testing::UnitTest::GetInstance()->listeners();
   listeners.Append(new AutowiringEnclosure);
   testing::InitGoogleTest(&argc, (char**)argv);

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -31,8 +31,7 @@ CoreContext::CoreContext(std::shared_ptr<CoreContext> pParent, t_childList::iter
   m_backReference(backReference),
   m_stateBlock(new CoreContextStateBlock),
   m_beforeRunning(false),
-  m_initiated(false),
-  m_isShutdown(false),
+  m_state(State::NotStarted),
   m_junctionBoxManager(
     pPeer ? pPeer->m_junctionBoxManager : std::make_shared<JunctionBoxManager>()
   )
@@ -76,7 +75,7 @@ std::shared_ptr<CoreContext> CoreContext::CreateInternal(t_pfnCreate pfnCreate, 
 std::shared_ptr<CoreContext> CoreContext::CreateInternal(t_pfnCreate pfnCreate, std::shared_ptr<CoreContext> pPeer, AutoInjectable&& inj)
 {
   // don't allow new children if shutting down
-  if(m_isShutdown)
+  if(IsShutdown())
     throw autowiring_error("Cannot create a child context; this context is already shut down");
     
   t_childList::iterator childIterator;
@@ -98,19 +97,24 @@ std::shared_ptr<CoreContext> CoreContext::CreateInternal(t_pfnCreate pfnCreate, 
   // Remainder of operations need to happen with the created context made current
   CurrentContextPusher pshr(retVal);
 
+  // If we're currently running, we would like the child context to know that it can optionally
+  // transition directly to the running state without having to wait in Initiated
+  if (IsRunning())
+    retVal->m_state = State::CanRun;
+
   // Inject before broadcasting the creation notice
   inj();
 
   // Fire all explicit bolts if not an "anonymous" context (has void sigil type)
   BroadcastContextCreationNotice(retVal->GetSigilType());
 
-  std::lock_guard<std::mutex> lk(m_stateBlock->m_lock);
   // We only consider the context to be completely constructed at this point, after all bolts
   // have been fired, the injection has taken place, and we're about to return.  We delay
   // finalizing the introduction of the return value into the list to this point for that
   // reason.
+  std::lock_guard<std::mutex> lk(m_stateBlock->m_lock);
   *childIterator = retVal;
-  if(m_isShutdown)
+  if(IsShutdown())
     retVal->SignalShutdown();
   return retVal;
 }
@@ -169,11 +173,16 @@ const std::type_info& CoreContext::GetAutoTypeId(const AnySharedPointer& ptr) co
 }
 
 std::shared_ptr<Object> CoreContext::IncrementOutstandingThreadCount(void) {
+  // Optimistic check
   std::shared_ptr<Object> retVal = m_outstanding.lock();
   if(retVal)
     return retVal;
 
-  auto self = shared_from_this();
+  // Double-check
+  std::lock_guard<std::mutex> lk(m_stateBlock->m_lock);
+  retVal = m_outstanding.lock();
+  if (retVal)
+    return retVal;
 
   // Increment the parent's outstanding count as well.  This will be held by the lambda, and will cause the enclosing
   // context's outstanding thread count to be incremented by one as long as we have any threads still running in our
@@ -182,6 +191,7 @@ std::shared_ptr<Object> CoreContext::IncrementOutstandingThreadCount(void) {
   if(m_pParent)
     parentCount = m_pParent->IncrementOutstandingThreadCount();
 
+  auto self = shared_from_this();
   retVal.reset(
     (Object*)1,
     [this, self, parentCount](Object*) {
@@ -196,6 +206,7 @@ std::shared_ptr<Object> CoreContext::IncrementOutstandingThreadCount(void) {
       m_stateBlock->m_stateChanged.notify_all();
     }
   );
+
   m_outstanding = retVal;
   return retVal;
 }
@@ -343,49 +354,76 @@ std::vector<std::shared_ptr<BasicThread>> CoreContext::CopyBasicThreadList(void)
 void CoreContext::Initiate(void) {
   // First-pass check, used to prevent recursive deadlocks traceable to here that might
   // result from entities trying to initiate subcontexts from CoreRunnable::Start
-  if(m_initiated || m_isShutdown)
+  if (IsInitiated())
     return;
 
-  {
-    std::lock_guard<std::mutex> lk(m_stateBlock->m_lock);
-    if(m_initiated)
-      // Already running
-      return;
+  // Get the beginning of the thread list that we have at the time of lock acquisition
+  // New threads are added to the front of the thread list, which means that objects
+  // after this iterator are the ones that will need to be started
+  t_threadList::iterator beginning;
 
-    // Short-return if our stop flag has already been set:
-    if(m_isShutdown)
-      return;
+  std::unique_lock<std::mutex> lk(m_stateBlock->m_lock);
 
-    // Update flag value
-    m_initiated = true;
+  // Now we can transition to initiated or running:
+  switch (m_state) {
+  case State::Initiated:
+  case State::Running:
+    // Double-check
+    return;
+  case State::NotStarted:
+    if (IsGlobalContext())
+      // Global context is permitted to transition directly to running
+      m_state = State::Running;
+    else
+      // Transition to initiated state, can't start threads yet
+      m_state = State::Initiated;
+    break;
+  case State::CanRun:
+    // Parent already started, we can run if we want to
+    m_state = State::Running;
+    break;
+  case State::Shutdown:
+  case State::Abandoned:
+    // Already in a terminal state
+    return;
   }
 
-  if(m_pParent)
-    // Start parent threads first
-    m_pParent->Initiate();
+  // State change has taken place, we can signal
+  m_stateBlock->m_stateChanged.notify_all();
 
   // Now we can add the event receivers we haven't been able to add because the context
   // wasn't yet started:
-  AddEventReceivers(m_delayedEventReceivers);
+  AddEventReceiversUnsafe(std::move(m_delayedEventReceivers));
   m_delayedEventReceivers.clear();
+
+  // Spin up the junction box before starting threads
   m_junctionBoxManager->Initiate();
 
-  // Reacquire the lock to prevent m_threads from being modified while we sit on it
-  auto outstanding = IncrementOutstandingThreadCount();
-  
-  // Get the beginning of the thread list that we have at the time of lock acquisition
-  t_threadList::iterator beginning;
-  
-  {
-    std::lock_guard<std::mutex> lk(m_stateBlock->m_lock);
-    beginning = m_threads.begin();
-    
-    // Signal our condition variable
-    m_stateBlock->m_stateChanged.notify_all();
-  }
+  // Notify all child contexts that they can start if they want
+  if (!IsRunning())
+    return;
 
-  for (auto q = beginning; q != m_threads.end(); ++q)
-    (*q)->Start(outstanding);
+  // Now we can recover the first thread that will need to be started
+  beginning = m_threads.begin();
+
+  // Start our threads before starting any child contexts:
+  lk.unlock();
+  {
+    auto outstanding = IncrementOutstandingThreadCount();
+    for (auto q = beginning; q != m_threads.end(); ++q)
+      (*q)->Start(outstanding);
+  }
+  lk.lock();
+
+  for (auto childWeak : m_children) {
+    // Obtain child pointer and lock it down so our iterator stays stable
+    auto child = childWeak.lock();
+
+    // Cannot hold a lock safely if we hand off control to a child context
+    lk.unlock();
+    child->TryTransitionToRunState();
+    lk.lock();
+  }
 }
 
 void CoreContext::InitiateCoreThreads(void) {
@@ -397,11 +435,32 @@ void CoreContext::SignalShutdown(bool wait, ShutdownMode shutdownMode) {
   // then we will skip that thread as we signal the list of threads to shutdown.
   t_threadList::iterator firstThreadToStop;
   
+  // Trivial return check
+  if (IsShutdown())
+    return;
+
   // Wipe out the junction box manager, notify anyone waiting on the state condition:
   {
     std::lock_guard<std::mutex> lk(m_stateBlock->m_lock);
+
+    switch (m_state) {
+    case State::NotStarted:
+    case State::CanRun:
+      // User never initiated
+      m_state = State::Abandoned;
+      break;
+    case State::Initiated:
+    case State::Running:
+      // Initiate called, move to the shutdown state
+      m_state = State::Shutdown;
+      break;
+    case State::Shutdown:
+    case State::Abandoned:
+      // Already shut down, no further work need be done
+      return;
+    }
+
     UnregisterEventReceiversUnsafe();
-    m_isShutdown = true;
     
     firstThreadToStop = m_threads.begin();
     if (m_beforeRunning)
@@ -465,18 +524,18 @@ void CoreContext::SignalShutdown(bool wait, ShutdownMode shutdownMode) {
 
 void CoreContext::Wait(void) {
   std::unique_lock<std::mutex> lk(m_stateBlock->m_lock);
-  m_stateBlock->m_stateChanged.wait(lk, [this] {return m_isShutdown && this->m_outstanding.expired(); });
+  m_stateBlock->m_stateChanged.wait(lk, [this] {return IsShutdown() && this->m_outstanding.expired(); });
 }
 
 bool CoreContext::Wait(const std::chrono::nanoseconds duration) {
   std::unique_lock<std::mutex> lk(m_stateBlock->m_lock);
-  return m_stateBlock->m_stateChanged.wait_for(lk, duration, [this] {return m_isShutdown && this->m_outstanding.expired(); });
+  return m_stateBlock->m_stateChanged.wait_for(lk, duration, [this] {return IsShutdown() && this->m_outstanding.expired(); });
 }
 
 bool CoreContext::DelayUntilInitiated(void) {
   std::unique_lock<std::mutex> lk(m_stateBlock->m_lock);
-  m_stateBlock->m_stateChanged.wait(lk, [this] {return m_initiated || m_isShutdown;});
-  return !m_isShutdown;
+  m_stateBlock->m_stateChanged.wait(lk, [this] {return IsInitiated();});
+  return !IsShutdown();
 }
 
 std::shared_ptr<CoreContext> CoreContext::CurrentContext(void) {
@@ -499,7 +558,7 @@ void CoreContext::AddCoreRunnable(const std::shared_ptr<CoreRunnable>& ptr) {
     m_threads.push_front(ptr.get());
     
     // Check if we're already running, this means we're late to the party and need to start _now_.
-    shouldRun = m_initiated;
+    shouldRun = IsRunning();
     
     // Signal that we are in the "running"
     m_beforeRunning = true;
@@ -520,7 +579,7 @@ void CoreContext::AddCoreRunnable(const std::shared_ptr<CoreRunnable>& ptr) {
     m_beforeRunning = false;
     
     // If SignalShutdown() was invoked while we were "running", then we will need to stop this thread ourselves
-    shouldStopHere = m_isShutdown;
+    shouldStopHere = IsShutdown();
   }
 
   if(shouldStopHere)
@@ -745,7 +804,7 @@ void CoreContext::AddEventReceiver(const JunctionBoxEntry<Object>& entry) {
   {
     std::lock_guard<std::mutex> lk(m_stateBlock->m_lock);
 
-    if (!m_initiated) {
+    if (!IsInitiated()) {
       // Delay adding receiver until context is initialized
       m_delayedEventReceivers.insert(entry);
       return;
@@ -761,17 +820,26 @@ void CoreContext::AddEventReceiver(const JunctionBoxEntry<Object>& entry) {
 }
 
 
-void CoreContext::AddEventReceivers(const t_rcvrSet& receivers) {
-  // Must be initiated
-  assert(m_initiated);
+void CoreContext::AddEventReceiversUnsafe(t_rcvrSet&& receivers) {
+  if (IsInitiated()) {
+    // Context is initiated, we can safely attach these receivers to our own junction box
+    for (const auto& q : receivers)
+      m_junctionBoxManager->AddEventReceiver(q);
 
-  for(const auto& q : receivers)
-    m_junctionBoxManager->AddEventReceiver(q);
-
-  // Delegate ascending resolution, where possible.  This ensures that the parent context links
-  // this event receiver to compatible senders in the parent context itself.
-  if(m_pParent)
-    m_pParent->AddEventReceivers(receivers);
+    // Delegate ascending resolution, where possible.  This ensures that the parent context links
+    // this event receiver to compatible senders in the parent context itself.
+    if (m_pParent) {
+      std::lock_guard<std::mutex> lk(m_pParent->m_stateBlock->m_lock);
+      m_pParent->AddEventReceiversUnsafe(std::forward<t_rcvrSet&&>(receivers));
+    }
+  }
+  else {
+    // Context not initiated, we need to add the receivers to our own deferred collection
+    if (m_delayedEventReceivers.empty())
+      m_delayedEventReceivers = std::move(receivers);
+    else
+      m_delayedEventReceivers.insert(receivers.begin(), receivers.end());
+  }
 }
 
 void CoreContext::RemoveEventReceivers(const t_rcvrSet& receivers) {
@@ -885,6 +953,33 @@ void CoreContext::AddContextMember(const std::shared_ptr<ContextMember>& ptr) {
 
 void CoreContext::AddPacketSubscriber(const AutoFilterDescriptor& rhs) {
   Inject<AutoPacketFactory>()->AddSubscriber(rhs);
+}
+
+void CoreContext::TryTransitionToRunState(void) {
+  std::unique_lock<std::mutex> lk(m_stateBlock->m_lock);
+  switch (m_state) {
+  case State::Initiated:
+    // Can transition to the running state now
+    {
+      auto q = m_threads.begin();
+      m_state = State::Running;
+      lk.unlock();
+
+      auto outstanding = IncrementOutstandingThreadCount();
+      while (q != m_threads.end()) {
+        (*q)->Start(outstanding);
+        q++;
+      }
+    }
+    break;
+  case State::CanRun:
+  case State::NotStarted:
+  case State::Running:
+  case State::Shutdown:
+  case State::Abandoned:
+    // No action need be taken for these states
+    return;
+  }
 }
 
 void CoreContext::UnsnoopAutoPacket(const ObjectTraits& traits) {

--- a/src/autowiring/test/AutoPacketFactoryTest.cpp
+++ b/src/autowiring/test/AutoPacketFactoryTest.cpp
@@ -94,6 +94,8 @@ public:
 };
 
 TEST_F(AutoPacketFactoryTest, AutoPacketFactoryCycle) {
+  AutoCurrentContext()->Initiate();
+
   std::weak_ptr<CoreContext> ctxtWeak;
   std::weak_ptr<HoldsAutoPacketFactoryReference> hapfrWeak;
   std::shared_ptr<AutoPacket> packet;
@@ -150,10 +152,9 @@ public:
 
 TEST_F(AutoPacketFactoryTest, AutoPacketStatistics) {
   // Create a context, fill it up, kick it off:
-  AutoCreateContext ctxt;
-  CurrentContextPusher pshr(ctxt);
-  AutoRequired<DelaysAutoPacketsOneMS> dapoms(ctxt);
-  AutoRequired<AutoPacketFactory> factory(ctxt);
+  AutoCurrentContext ctxt;
+  AutoRequired<DelaysAutoPacketsOneMS> dapoms;
+  AutoRequired<AutoPacketFactory> factory;
   ctxt->Initiate();
 
   int numPackets = 20;
@@ -177,9 +178,8 @@ TEST_F(AutoPacketFactoryTest, AutoPacketStatistics) {
 }
 
 TEST_F(AutoPacketFactoryTest, AddSubscriberTest) {
-  AutoCreateContext ctxt;
-  CurrentContextPusher pshr(ctxt);
-  AutoRequired<AutoPacketFactory> factory(ctxt);
+  AutoCurrentContext ctxt;
+  AutoRequired<AutoPacketFactory> factory;
   ctxt->Initiate();
 
   bool first_called = false;
@@ -197,5 +197,4 @@ TEST_F(AutoPacketFactoryTest, AddSubscriberTest) {
 
   ASSERT_TRUE(first_called) << "Normal subscriber never called";
   ASSERT_TRUE(second_called) << "Subscriber added with operator+= never called";
-
 }

--- a/src/autowiring/test/ContextCreatorTest.cpp
+++ b/src/autowiring/test/ContextCreatorTest.cpp
@@ -91,6 +91,8 @@ TEST_F(ContextCreatorTest, ValidateSimpleEviction) {
 }
 
 TEST_F(ContextCreatorTest, ValidateMultipleEviction) {
+  AutoCurrentContext()->Initiate();
+
   // Number of dependent contexts to be created
   const size_t count = 100;
 
@@ -139,7 +141,7 @@ TEST_F(ContextCreatorTest, ValidateMultipleEviction) {
   // Wait for all contexts to be destroyed
   std::unique_lock<std::mutex> lk(lock);
   bool wait_status = cond.wait_for(lk, std::chrono::seconds(1), [&counter] {return counter == 0;});
-  ASSERT_TRUE(wait_status) << "All teardown listeners didn't trigger";
+  ASSERT_TRUE(wait_status) << "All teardown listeners didn't trigger, counter still at " << counter;
 
   // Validate that everything expires:
   EXPECT_EQ(static_cast<size_t>(0), creator->GetSize()) << "Not all contexts were evicted as expected";

--- a/src/autowiring/test/ContextMapTest.cpp
+++ b/src/autowiring/test/ContextMapTest.cpp
@@ -39,6 +39,8 @@ TEST_F(ContextMapTest, VerifySimple) {
 }
 
 TEST_F(ContextMapTest, VerifyWithThreads) {
+  AutoCurrentContext()->Initiate();
+
   ContextMap<string> mp;
   std::shared_ptr<SimpleThreaded> threaded;
   std::weak_ptr<CoreContext> weakContext;

--- a/src/autowiring/test/CoreJobTest.cpp
+++ b/src/autowiring/test/CoreJobTest.cpp
@@ -156,6 +156,8 @@ TEST_F(CoreJobTest, RecursiveAdd) {
 }
 
 TEST_F(CoreJobTest, RaceCondition) {
+  AutoCurrentContext()->Initiate();
+
   for (int i=0; i<5; i++) {
     AutoCreateContext ctxt;
     CurrentContextPusher pshr(ctxt);

--- a/src/autowiring/test/CoreRunnableTest.cpp
+++ b/src/autowiring/test/CoreRunnableTest.cpp
@@ -23,3 +23,19 @@ TEST_F(CoreRunnableTest, CanStartSubcontextWhileInitiating) {
   AutoRequired<StartsSubcontextWhileStarting>();
   AutoCurrentContext()->Initiate();
 }
+
+TEST_F(CoreRunnableTest, InnerContextInitiateNoRecurse) {
+  AutoCurrentContext ctxt;
+
+  // Create and initiate a child context
+  AutoCreateContext child;
+  child->Initiate();
+
+  // Verify state
+  ASSERT_FALSE(ctxt->IsInitiated()) << "Parent context incorrectly initiated as a result of a child context being initiated";
+  ASSERT_FALSE(child->IsRunning()) << "Parent context not initiated yet, child context should not be considered running";
+
+  // Now start the outer context, verify the child context transitions to the "running" state
+  ctxt->Initiate();
+  ASSERT_TRUE(child->IsRunning()) << "Child context did not transition to the running state when the parent context was initiated";
+}

--- a/src/autowiring/test/CoreThreadTest.cpp
+++ b/src/autowiring/test/CoreThreadTest.cpp
@@ -92,6 +92,8 @@ TEST_F(CoreThreadTest, VerifyIndefiniteDelay) {
 
 TEST_F(CoreThreadTest, VerifyNestedTermination) {
   AutoCurrentContext ctxt;
+  ctxt->Initiate();
+
   std::shared_ptr<SimpleThreaded> st;
 
   // Insert a thread into a second-order subcontext:
@@ -164,8 +166,7 @@ TEST_F(CoreThreadTest, AUTOTHROW_VerifyDispatchQueueShutdown) {
 }
 
 TEST_F(CoreThreadTest, AUTOTHROW_VerifyNoLeakOnExecptions) {
-  AutoCreateContext ctxt;
-  CurrentContextPusher pshr(ctxt);
+  AutoCurrentContext ctxt;
 
   AutoRequired<ListenThread> listener;
   auto value = std::make_shared<std::string>("sentinal");

--- a/src/autowiring/test/ExceptionFilterTest.cpp
+++ b/src/autowiring/test/ExceptionFilterTest.cpp
@@ -147,6 +147,9 @@ TEST_F(ExceptionFilterTest, SimpleFilterCheck) {
 }
 
 TEST_F(ExceptionFilterTest, FireContainmentCheck) {
+  // Initiate parent context first
+  AutoCurrentContext()->Initiate();
+
   // Firing will occur at the parent context scope:
   AutoFired<ThrowingListener> broadcaster;
 
@@ -166,6 +169,8 @@ TEST_F(ExceptionFilterTest, FireContainmentCheck) {
 }
 
 TEST_F(ExceptionFilterTest, AUTOTHROW_EnclosedThrowCheck) {
+  AutoCurrentContext()->Initiate();
+
   // Create our listener:
   AutoRequired<GenericFilter> filter;
 
@@ -178,7 +183,7 @@ TEST_F(ExceptionFilterTest, AUTOTHROW_EnclosedThrowCheck) {
   subCtxt->Initiate();
 
   // Wait for the exception to get thrown:
-  subCtxt->Wait();
+  ASSERT_TRUE(subCtxt->Wait(std::chrono::seconds(5))) << "Context did not terminate in a timely fashion";
 
   // Verify that the filter caught the exception:
   EXPECT_TRUE(filter->m_hit) << "Filter operating in a superior context did not catch an exception thrown from a child context";

--- a/src/autowiring/test/ObjectPoolTest.cpp
+++ b/src/autowiring/test/ObjectPoolTest.cpp
@@ -263,6 +263,7 @@ TEST_F(ObjectPoolTest, EmptyPoolIssuance) {
 
   // Now see if we can delay for the thread to back out:
   ctxt->Initiate();
+  ASSERT_TRUE(ctxt->IsRunning());
   pool.Rundown();
 
   // Verify that it got released as expected:

--- a/src/autowiring/test/SnoopTest.cpp
+++ b/src/autowiring/test/SnoopTest.cpp
@@ -156,10 +156,15 @@ TEST_F(SnoopTest, AmbiguousReciept) {
 }
 
 TEST_F(SnoopTest, AvoidDoubleReciept) {
+  AutoCurrentContext()->Initiate();
+
   AutoCreateContext sibCtxt;
   
   AutoCreateContext parentCtxt;
   CurrentContextPusher parentPshr(parentCtxt);
+
+  sibCtxt->Initiate();
+  parentCtxt->Initiate();
   
   // Create the parent listener:
   AutoRequired<ParentMember> parentMember;
@@ -181,8 +186,8 @@ TEST_F(SnoopTest, AvoidDoubleReciept) {
     firer(&UpBroadcastListener::SimpleCall)();
 
     // Verify that the child and parent got the message once
-    EXPECT_EQ(1, childMember->m_callCount) << "Message not received by another member of the same context";
-    EXPECT_EQ(1, parentMember->m_callCount) << "Parent context snooper didn't receive a message broadcast by the child context";
+    ASSERT_EQ(1, childMember->m_callCount) << "Message not received by another member of the same context";
+    ASSERT_EQ(1, parentMember->m_callCount) << "Parent context snooper didn't receive a message broadcast by the child context";
     
     
     // Test sibling context
@@ -192,24 +197,26 @@ TEST_F(SnoopTest, AvoidDoubleReciept) {
     
     firer(&UpBroadcastListener::SimpleCall)();
     
-    EXPECT_EQ(2, childMember->m_callCount) << "Message not received by another member of the same context";
-    EXPECT_EQ(2, parentMember->m_callCount) << "Parent context snooper didn't receive a message broadcast by the child context";
-    EXPECT_EQ(1, alsoInParent->m_callCount) << "Parent context member didn't receive message";
-    EXPECT_EQ(1, sibMember->m_callCount) << "Sibling context member didn't receive message";
+    ASSERT_EQ(2, childMember->m_callCount) << "Message not received by another member of the same context";
+    ASSERT_EQ(2, parentMember->m_callCount) << "Parent context snooper didn't receive a message broadcast by the child context";
+    ASSERT_EQ(1, alsoInParent->m_callCount) << "Parent context member didn't receive message";
+    ASSERT_EQ(1, sibMember->m_callCount) << "Sibling context member didn't receive message";
     
     // Make sure unsnoop cleans up everything
     child->Unsnoop(sibMember);
     firer(&UpBroadcastListener::SimpleCall)();
     
-    EXPECT_EQ(3, childMember->m_callCount) << "Message not received by another member of the same context";
-    EXPECT_EQ(3, parentMember->m_callCount) << "Parent context snooper didn't receive a message broadcast by the child context";
-    EXPECT_EQ(2, alsoInParent->m_callCount) << "Parent context member didn't receive message";
-    EXPECT_EQ(1, sibMember->m_callCount) << "Sibling context member didn't unsnoop";
+    ASSERT_EQ(3, childMember->m_callCount) << "Message not received by another member of the same context";
+    ASSERT_EQ(3, parentMember->m_callCount) << "Parent context snooper didn't receive a message broadcast by the child context";
+    ASSERT_EQ(2, alsoInParent->m_callCount) << "Parent context member didn't receive message";
+    ASSERT_EQ(1, sibMember->m_callCount) << "Sibling context member didn't unsnoop";
   }
 }
 
 TEST_F(SnoopTest, MultiSnoop) {
   AutoCurrentContext base;
+  base->Initiate();
+
   auto ctxt1 = base->Create<int>();
   auto ctxt2 = ctxt1->Create<double>();
 
@@ -225,16 +232,20 @@ TEST_F(SnoopTest, MultiSnoop) {
   ctxt1->Invoke(&UpBroadcastListener::SimpleCall)();
   ctxt2->Invoke(&UpBroadcastListener::SimpleCall)();
   
-  EXPECT_EQ(1, member->m_callCount) << "Received events from child contexts";
+  ASSERT_EQ(1, member->m_callCount) << "Received events from child contexts";
+  member->m_callCount = 0;
   
-  // Snoop both
+  // Snoop both.  Invocation in an uninitialized context should not cause any handlers to be raised.
   ctxt1->Snoop(member);
   ctxt2->Snoop(member);
   base->Invoke(&UpBroadcastListener::SimpleCall)();
   ctxt1->Invoke(&UpBroadcastListener::SimpleCall)();
   ctxt2->Invoke(&UpBroadcastListener::SimpleCall)();
   
-  EXPECT_EQ(4, member->m_callCount) << "Didn't receive all events";
+  ASSERT_EQ(2, member->m_callCount) << "Didn't receive all events";
+  member->m_callCount = 0;
+  member1->m_callCount = 0;
+  member2->m_callCount = 0;
   
   // Unsnoop one
   ctxt2->Unsnoop(member);
@@ -242,9 +253,9 @@ TEST_F(SnoopTest, MultiSnoop) {
   ctxt1->Invoke(&UpBroadcastListener::SimpleCall)();
   ctxt2->Invoke(&UpBroadcastListener::SimpleCall)();
   
-  EXPECT_EQ(6, member->m_callCount) << "Unsnooped both!";
-  EXPECT_EQ(6, member1->m_callCount) << "Native context member didn't receive correct number of events";
-  EXPECT_EQ(9, member2->m_callCount) << "Native context member didn't receive correct number of events";
+  ASSERT_EQ(1, member->m_callCount) << "Unsnooped both!";
+  ASSERT_EQ(0, member1->m_callCount) << "Native context member didn't receive correct number of events";
+  ASSERT_EQ(1, member2->m_callCount) << "Native context member didn't receive correct number of events";
 }
 
 TEST_F(SnoopTest, AntiCyclicRemoval) {
@@ -268,6 +279,8 @@ TEST_F(SnoopTest, AntiCyclicRemoval) {
 
 
 TEST_F(SnoopTest, SimplePackets) {
+  AutoCurrentContext()->Initiate();
+
   AutoCreateContext Pipeline;
   AutoCreateContext Tracking;
   Pipeline->Initiate();


### PR DESCRIPTION
This change alters the way that startup occurs on child contexts whose parents are not yet started.  Formerly, invoking `CoreContext::Initiate` on a child context where `Initiate` was not called on the parent would result in recursive initiation of all parents up to the global context.  Now, the child will be transitioned into an initiated metastate where it is ready to run but not yet started.