### PR TITLE
Add a overload of Decorate for object of type shared_ptr<const T>

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ before_script:
 
 script:
   # Build Autowriring, run unit tests, and install
-  - ulimit -c unlimited
   - make -j 8 || make
   - ctest --output-on-failure
   - sudo make install
@@ -66,7 +65,4 @@ script:
     && cd ..
 
 after_failure:
-  - if [ -e core ]; then
-      gdb --core=core;
-    fi
   - cat Testing/Temporary/LastTest.log 2> /dev/null

--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -373,6 +373,18 @@ public:
   }
 
   /// <summary>
+  /// Decoration method specialized for const shared pointer types
+  /// </summary>
+  /// <remarks>
+  /// This decoration method has the additional benefit that it will make direct use of the passed
+  /// shared pointer.
+  /// </remarks>
+  template<class T>
+  const T& Decorate(std::shared_ptr<const T> ptr) {
+    return Decorate(std::const_pointer_cast<T>(ptr));
+  }
+
+  /// <summary>
   /// Subscribers respond to the decoration arguments immediately or never for this packet.
   /// Optional argument resolution is forced for any subscriber requiring at least one
   /// argument of this method


### PR DESCRIPTION
Without this, decorating an object of that type generates a decoration for type "const T" which everyone wisely ignores.