### PR TITLE
Slight enhancement to the performance of auto_arg

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -519,7 +519,7 @@ template<class Fx>
 const AutoPacket& AutoPacket::operator+=(Fx&& fx) const
 {
   static_assert(
-    !CallExtractor<decltype(&Fx::operator())>::has_outputs,
+    !Decompose<decltype(&Fx::operator())>::template any<arg_is_out>::value,
     "Cannot add an AutoFilter to a const AutoPacket if any of its arguments are output types"
   );
   *const_cast<AutoPacket*>(this) += std::forward<Fx&&>(fx);

--- a/autowiring/CallExtractor.h
+++ b/autowiring/CallExtractor.h
@@ -1,9 +1,11 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "auto_arg.h"
+#include "auto_tuple.h"
 #include "AutoPacket.h"
 #include "CurrentContextPusher.h"
 #include "Decompose.h"
+#include "index_tuple.h"
 #include <assert.h>
 
 class Deferred;
@@ -11,14 +13,42 @@ class Deferred;
 // The type of the call centralizer
 typedef void(*t_extractedCall)(const AnySharedPointer& obj, AutoPacket&);
 
-template<class MemFn>
+template<class MemFn, class Index = typename make_index_tuple<Decompose<MemFn>::N>::type>
 struct CallExtractor;
+
+template<class... Args>
+struct CallExtractorSetup
+{
+  CallExtractorSetup(AutoPacket& packet):
+    packet(packet),
+    pshr(packet.GetContext()),
+    args(
+      (auto_arg<Args>::arg(packet))...
+    )
+  {}
+
+  AutoPacket& packet;
+  CurrentContextPusher pshr;
+  autowiring::tuple<typename auto_arg<Args>::type...> args;
+
+  template<int N>
+  typename std::enable_if<
+    auto_arg<typename autowiring::nth_type<N, Args...>::type>::is_output,
+    bool
+  >::type Commit(bool) {
+    packet.Decorate(autowiring::get<N>(args));
+    return true;
+  }
+
+  template<int N>
+  bool Commit(...) { return false; }
+};
 
 /// <summary>
 /// Specialization for nonmember function calls
 /// </summary>
-template<class RetType, class... Args>
-struct CallExtractor<RetType (*)(Args...)>:
+template<class RetType, class... Args, int... N>
+struct CallExtractor<RetType (*)(Args...), index_tuple<N...>>:
   Decompose<RetType(*)(Args...)>
 {
   static const bool has_outputs = is_any<auto_arg<Args>::is_output...>::value;
@@ -31,24 +61,23 @@ struct CallExtractor<RetType (*)(Args...)>:
   /// <summary>
   /// Binder struct, lets us refer to an instance of Call by type
   /// </summary>
-  static void Call(const AnySharedPointer& obj, AutoPacket& autoPacket) {
+  static void Call(const AnySharedPointer& obj, AutoPacket& packet) {
     const void* pfn = obj->ptr();
-
-    // Set the current context to this packet's context
-    CurrentContextPusher pshr(autoPacket.GetContext());
-
-    // Handoff
+    
+    // Setup, handoff, commit
+    CallExtractorSetup<Args...> extractor(packet);
     ((t_pfn)pfn)(
-      typename auto_arg<Args>::type(autoPacket)...
+      static_cast<typename auto_arg<Args>::arg_type>(autowiring::get<N>(extractor.args))...
     );
+    std::initializer_list<bool>{extractor.template Commit<N>(false)...};
   }
 };
 
 /// <summary>
 /// Specialization for member function AutoFilter functions
 /// </summary>
-template<class T, class... Args>
-struct CallExtractor<void (T::*)(Args...)>:
+template<class T, class... Args, int... N>
+struct CallExtractor<void (T::*)(Args...), index_tuple<N...>> :
   Decompose<void (T::*)(Args...)>
 {
   static const bool has_outputs = is_any<auto_arg<Args>::is_output...>::value;
@@ -59,7 +88,7 @@ struct CallExtractor<void (T::*)(Args...)>:
   /// Binder struct, lets us refer to an instance of Call by type
   /// </summary>
   template<void(T::*memFn)(Args...)>
-  static void Call(const AnySharedPointer& obj, AutoPacket& autoPacket) {
+  static void Call(const AnySharedPointer& obj, AutoPacket& packet) {
     const void* pObj = obj->ptr();
 
     // This exception type indicates that an attempt was made to construct an AutoFilterDescriptor with an
@@ -67,21 +96,20 @@ struct CallExtractor<void (T::*)(Args...)>:
     // to the correct foundation type before attempting to construct an AutoFilterDescriptor.
     assert(typeid(auto_id<T>) == obj->type());
 
-    // Set the current context to this packet's context
-    CurrentContextPusher pshr(autoPacket.GetContext());
-
-    // Handoff
+    // Extract, call, commit
+    CallExtractorSetup<Args...> extractor(packet);
     (((T*) pObj)->*memFn)(
-      typename auto_arg<Args>::type(autoPacket)...
+      static_cast<typename auto_arg<Args>::arg_type>(autowiring::get<N>(extractor.args))...
     );
+    std::initializer_list<bool>{extractor.template Commit<N>(false)...};
   }
 };
 
 /// <summary>
 /// Specialization for stateless member function AutoFilter routines
 /// </summary>
-template<class T, class... Args>
-struct CallExtractor<void (T::*)(Args...) const> :
+template<class T, class... Args, int... N>
+struct CallExtractor<void (T::*)(Args...) const, index_tuple<N...>> :
   Decompose<void (T::*)(Args...)>
 {
   static const bool has_outputs = is_any<auto_arg<Args>::is_output...>::value;
@@ -89,24 +117,23 @@ struct CallExtractor<void (T::*)(Args...) const> :
   static const bool deferred = false;
   
   template<void(T::*memFn)(Args...) const>
-  static void Call(const AnySharedPointer& obj, AutoPacket& autoPacket) {
+  static void Call(const AnySharedPointer& obj, AutoPacket& packet) {
     const void* pObj = obj->ptr();
 
-    // Set the current context to this packet's context
-    CurrentContextPusher pshr(autoPacket.GetContext());
-
-    // Handoff
+    // Extract, call, commit
+    CallExtractorSetup<Args...> extractor(packet);
     (((const T*) pObj)->*memFn)(
-      typename auto_arg<Args>::type(autoPacket)...
+      static_cast<typename auto_arg<Args>::arg_type>(autowiring::get<N>(extractor.args))...
     );
+    std::initializer_list<bool>{extractor.template Commit<N>(false)...};
   }
 };
 
 /// <summary>
 /// Specialization for deferred member function AutoFilter routines
 /// </summary>
-template<class T, class... Args>
-struct CallExtractor<Deferred (T::*)(Args...)>:
+template<class T, class... Args, int... N>
+struct CallExtractor<Deferred(T::*)(Args...), index_tuple<N...>> :
   Decompose<void (T::*)(Args...)>
 {
   static const bool has_outputs = is_any<auto_arg<Args>::is_output...>::value;
@@ -125,12 +152,12 @@ struct CallExtractor<Deferred (T::*)(Args...)>:
     // Pend the call to this object's dispatch queue:
     *(T*) pObj += [pObj, pAutoPacket] {
 
-      // Set the current context to this packet's context
-      CurrentContextPusher pshr(pAutoPacket->GetContext());
-
+      // Extract, call, commit
+      CallExtractorSetup<Args...> extractor(*pAutoPacket);
       (((T*) pObj)->*memFn)(
-        typename auto_arg<Args>::type(*pAutoPacket)...
+        static_cast<typename auto_arg<Args>::arg_type>(autowiring::get<N>(extractor.args))...
       );
+      std::initializer_list<bool>{extractor.template Commit<N>(false)...};
     };
   }
 };

--- a/autowiring/CallExtractor.h
+++ b/autowiring/CallExtractor.h
@@ -69,7 +69,7 @@ struct CallExtractor<RetType (*)(Args...), index_tuple<N...>>:
     ((t_pfn)pfn)(
       static_cast<typename auto_arg<Args>::arg_type>(autowiring::get<N>(extractor.args))...
     );
-    std::initializer_list<bool>{extractor.template Commit<N>(false)...};
+    (void)std::initializer_list<bool>{extractor.template Commit<N>(false)...};
   }
 };
 
@@ -101,7 +101,7 @@ struct CallExtractor<void (T::*)(Args...), index_tuple<N...>> :
     (((T*) pObj)->*memFn)(
       static_cast<typename auto_arg<Args>::arg_type>(autowiring::get<N>(extractor.args))...
     );
-    std::initializer_list<bool>{extractor.template Commit<N>(false)...};
+    (void)std::initializer_list<bool>{extractor.template Commit<N>(false)...};
   }
 };
 
@@ -125,7 +125,7 @@ struct CallExtractor<void (T::*)(Args...) const, index_tuple<N...>> :
     (((const T*) pObj)->*memFn)(
       static_cast<typename auto_arg<Args>::arg_type>(autowiring::get<N>(extractor.args))...
     );
-    std::initializer_list<bool>{extractor.template Commit<N>(false)...};
+    (void)std::initializer_list<bool>{extractor.template Commit<N>(false)...};
   }
 };
 
@@ -157,7 +157,7 @@ struct CallExtractor<Deferred(T::*)(Args...), index_tuple<N...>> :
       (((T*) pObj)->*memFn)(
         static_cast<typename auto_arg<Args>::arg_type>(autowiring::get<N>(extractor.args))...
       );
-      std::initializer_list<bool>{extractor.template Commit<N>(false)...};
+      (void)std::initializer_list<bool>{extractor.template Commit<N>(false)...};
     };
   }
 };

--- a/autowiring/Decompose.h
+++ b/autowiring/Decompose.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include "is_any.h"
 #include <typeinfo>
 
 template<class... Ts>
@@ -22,6 +23,14 @@ struct TemplatePack {
   struct Enumerate {
     static const T types[N + 1];
   };
+
+  /// <summary>
+  /// Evaluates the specified predicate on each argument in the pack
+  /// </summary>
+  template<template<typename> class is>
+  struct any {
+    static const bool value = is_any<is<Ts>::value...>::value;
+  };
 };
 
 template<class... Ts>
@@ -36,6 +45,16 @@ struct Decompose;
 
 template<class R, class W, class... Args>
 struct Decompose<R(W::*)(Args...)> :
+  TemplatePack<Args...>
+{
+  typedef R(W::*memType)(Args...);
+  typedef void fnType(Args...);
+  typedef W type;
+  typedef R retType;
+};
+
+template<class R, class W, class... Args>
+struct Decompose<R(W::*)(Args...) const> :
   TemplatePack<Args...>
 {
   typedef R(W::*memType)(Args...);

--- a/autowiring/auto_in.h
+++ b/autowiring/auto_in.h
@@ -1,8 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
-
-#include "AutoPacket.h"
 #include MEMORY_HEADER
+#include <vector>
 
 /// <summary>
 /// Fundamental type of required input arguments of AutoFilter methods.
@@ -15,13 +14,11 @@ public:
   static const bool is_input = true;
   static const bool is_output = false;
 
-  auto_in(AutoPacket& packet) :
-    packet(packet),
-    m_value(packet.Get<T>())
+  auto_in(const T& value) :
+    m_value(value)
   {}
 
 private:
-  const AutoPacket& packet;
   const T& m_value;
 
 public:
@@ -29,19 +26,10 @@ public:
     return true;
   }
 
-  const std::shared_ptr<const T>& get(void) const {
-    const std::shared_ptr<const T>* retVal;
-    if(!packet.Get(retVal))
-      throw std::runtime_error("Shared pointer not available on this type");
-    return *retVal;
-  }
-
   operator const T&() const { return m_value; }
-  operator std::shared_ptr<const T>() const { return get(); }
   const T& operator*(void) const { return m_value; }
   const T* operator->(void) const { return &m_value; }
 };
-
 
 template<>
 class auto_in<AutoPacket>
@@ -64,9 +52,8 @@ template<class T>
 class auto_in<T const **>
 {
 public:
-  auto_in(AutoPacket& packet) :
-    packet(packet),
-    m_values(packet.GetAll<T>())
+  auto_in(std::vector<const T*>&& values) :
+    m_values(std::move(values))
   {}
 
 private:

--- a/autowiring/auto_out.h
+++ b/autowiring/auto_out.h
@@ -1,7 +1,5 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
-
-#include "AutoPacket.h"
 #include MEMORY_HEADER
 
 /// <summary>
@@ -20,28 +18,16 @@ class auto_out
 public:
   typedef T id_type;
 
-  auto_out(const auto_out& rhs) = delete;
-  auto_out(auto_out&& rhs) :
-    m_packet(rhs.m_packet),
-    m_value(std::move(rhs.m_value))
-  {
-    rhs.m_value.reset();
-    rhs.m_packet = nullptr;
-  }
-
-  auto_out(AutoPacket& packet) :
-    m_packet(&packet)
+  auto_out(const auto_out<T>& rhs):
+    m_value(rhs.m_value)
   {}
 
-  /// <summary>Destruction of auto_out makes type data available</summary>
-  ~auto_out(void) {
-    if(m_packet && m_value)
-      m_packet->Decorate(m_value);
-  }
+  auto_out(std::shared_ptr<T>& value) :
+    m_value(value)
+  {}
 
 protected:
-  AutoPacket* m_packet;
-  std::shared_ptr<T> m_value;
+  std::shared_ptr<T>& m_value;
 
 public:
   /// <summary>
@@ -51,17 +37,11 @@ public:
     m_value.reset();
   }
 
-  T* get() {
-    if(!m_value)
-      m_value = std::make_shared<T>();
-    return m_value.get();
-  }
-
   // Convenience operator overloads
-  T& operator* () { return *get(); }
-  T* operator-> () { return get(); }
+  T& operator* () { return *m_value; }
+  T* operator-> () { return m_value.get(); }
   explicit operator bool() const { return m_value; }
-  operator T&(void) { return *get(); }
+  operator T&(void) { return *m_value; }
   operator std::shared_ptr<T>&(void) { return m_value; }
 
   /// <summary>Output will be shared data provided by rhs</summary>

--- a/autowiring/auto_prev.h
+++ b/autowiring/auto_prev.h
@@ -1,6 +1,5 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "AutoPacket.h"
 
 /// <summary>
 /// Identifier for AutoFilter inputs from the previous packet
@@ -12,22 +11,21 @@
 template<class T, int N = 1>
 struct auto_prev {
 public:
-  auto_prev(const AutoPacket& val)
-  {
-    val.Get(m_value, N);
-  }
+  auto_prev(const T* value) :
+    value(value)
+  {}
 
   operator bool(void) const {
-    return m_value.operator bool();
+    return !!value;
   }
 
   const T& operator*(void) const {
-    return *m_value;
+    return *value;
   }
   
   const T* operator->(void) const {
-    return m_value.get();
+    return value;
   }
 
-  std::shared_ptr<const T> m_value;
+  const T* const value;
 };

--- a/src/autowiring/test/ArgumentTypeTest.cpp
+++ b/src/autowiring/test/ArgumentTypeTest.cpp
@@ -66,42 +66,53 @@ TEST_F(ArgumentTypeTest, TestAutoIn) {
   AutoRequired<AutoPacketFactory> factory;
   std::shared_ptr<AutoPacket> packet = factory->NewPacket();
   packet->Decorate(Argument<0>(1));
-  auto_in<const Argument<0>> in(*packet);
-  ASSERT_TRUE(in.is_input) << "Incorrect orientation";
-  ASSERT_FALSE(in.is_output) << "Incorrect orientation";
-  ASSERT_EQ(1, in->i) << "Incorrect initialization";
+
+  typedef auto_arg<const Argument<0>> t_arg;
+  typedef auto_arg<std::shared_ptr<const Argument<0>>> t_argShared;
+
+  ASSERT_TRUE(t_arg::is_input) << "Incorrect orientation";
+  ASSERT_FALSE(t_arg::is_output) << "Incorrect orientation";
 
   // Base Cast
   {
-    const Argument<0>& base_in = *in;
-    ASSERT_EQ(1, base_in.i) << "Incorrect base cast";
+    const auto& in = t_arg::arg(*packet);
+    ASSERT_EQ(1, in.i) << "Incorrect initialization";
   }
 
   // Shared Cast
   {
-    std::shared_ptr<const Argument<0>> shared_in = in;
-    ASSERT_EQ(1, shared_in->i) << "Incorrect base cast";
+    auto shared_in = t_argShared::arg(*packet);
+    ASSERT_EQ(1, shared_in->i) << "Incorrect shared cast";
   }
 
   // Deduced Type
-  auto_arg<std::shared_ptr<const Argument<0>>>::type arg(*packet);
-  ASSERT_TRUE(in.get().unique()) << "AutoPacket should store the sole shared pointer reference";
+  const auto& arg = t_argShared::arg(*packet);
+  ASSERT_TRUE(arg.unique()) << "AutoPacket should store the sole shared pointer reference";
 }
 
 TEST_F(ArgumentTypeTest, TestAutoOut) {
   AutoRequired<AutoPacketFactory> factory;
   std::shared_ptr<AutoPacket> packet = factory->NewPacket();
+
+  std::shared_ptr<Argument<0>> a0;
   {
     typedef auto_arg<Argument<0>&> t_argType;
-    t_argType::type out(*packet);
+    std::shared_ptr<Argument<0>> out = t_argType::arg(*packet);
     ASSERT_FALSE(t_argType::is_input) << "Incorrect orientation";
     ASSERT_TRUE(t_argType::is_output) << "Incorrect orientation";
 
     // Implicit commitment to output
     out->i = 1;
+
+    // Normally this happens in CallExtractor, but we will do it here by hand
+    packet->Decorate(out);
+
+    // Track the shared pointer in order to ensure no copying takes place
+    a0 = out;
   }
 
   const Argument<0>* arg = nullptr;
   ASSERT_TRUE(packet->Get(arg)) << "Missing output";
+  ASSERT_EQ(a0, packet->GetShared<Argument<0>>()) << "Shared pointer copied incorrectly";
   ASSERT_EQ(1, arg->i) << "Output was not copied";
 }


### PR DESCRIPTION
This enhancement eliminates a double lookup in cases where `std::shared_ptr` is accepted as an input type to an AutoFilter.  It also reduces the size of auto_arg by eliminating an unneeded member variable.