### PR TITLE
Adding an explicit tuple type

### DIFF
--- a/autowiring/auto_tuple.h
+++ b/autowiring/auto_tuple.h
@@ -1,0 +1,60 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+
+namespace autowiring {
+  /// <summary>
+  /// Autowiring specialized tuple type
+  /// </summary>
+  template<class... Args>
+  struct tuple {};
+
+  template<int N, class... Args>
+  struct nth_type;
+
+  template<class Head, class... Tail>
+  struct nth_type<0, Head, Tail...> {
+    typedef Head type;
+  };
+
+  template<int N, class Head, class... Tail>
+  struct nth_type<N, Head, Tail...>:
+    nth_type<N - 1, Tail...>
+  {};
+
+  template<int N, class T>
+  struct tuple_value {
+    tuple_value(void) = default;
+
+    tuple_value(T&& value) :
+      value(std::forward<T&&>(value))
+    {}
+
+    T value;
+  };
+
+  template<int N, class... Args>
+  typename nth_type<N, Args...>::type& get(tuple<Args...>& val) {
+    static_assert(N < sizeof...(Args), "Requested tuple index is out of bounds");
+    return
+      static_cast<
+        tuple_value<
+          sizeof...(Args) - N - 1,
+          typename nth_type<N, Args...>::type
+        >&
+      >(val).value;
+  }
+
+  template<class Arg, class... Args>
+  struct tuple<Arg, Args...>:
+    tuple<Args...>,
+    tuple_value<sizeof...(Args), Arg>
+  {
+    tuple(void) = default;
+
+    template<class T, class... Ts>
+    tuple(T&& arg, Ts&&... args) :
+      tuple_value<sizeof...(Ts), Arg>(std::forward<T&&>(arg)),
+      tuple<Args...>(std::forward<Ts&&>(args)...)
+    {}
+  };
+}

--- a/autowiring/index_tuple.h
+++ b/autowiring/index_tuple.h
@@ -3,6 +3,7 @@
 
 /// <summary>
 /// Utility type which enables the composition of a sequence [0, sizeof...(Ts))
+/// </summary>
 template<int ...>
 struct index_tuple {};
 

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -55,6 +55,7 @@ set(Autowiring_SRCS
   auto_in.h
   auto_out.h
   auto_prev.h
+  auto_tuple.h
   BasicThread.cpp
   BasicThread.h
   BasicThreadStateBlock.cpp

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -46,6 +46,7 @@ set(AutowiringTest_SRCS
   TypeRegistryTest.cpp
   ScopeTest.cpp
   SnoopTest.cpp
+  TupleTest.cpp
   TestFixtures/custom_exception.hpp
   TestFixtures/ExitRaceThreaded.hpp
   TestFixtures/SimpleInterface.hpp

--- a/src/autowiring/test/TupleTest.cpp
+++ b/src/autowiring/test/TupleTest.cpp
@@ -1,0 +1,22 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include <autowiring/auto_tuple.h>
+#include <string>
+
+class TupleTest:
+  public testing::Test
+{};
+
+TEST_F(TupleTest, CallTest) {
+  autowiring::tuple<int, int, std::string> t(101, 102, "Hello world!");
+
+  ASSERT_EQ(101, autowiring::get<0>(t)) << "First tuple value was invalid";
+  ASSERT_EQ(102, autowiring::get<1>(t)) << "Second tuple value was invalid";
+}
+
+TEST_F(TupleTest, TieTest) {
+  std::unique_ptr<int> val(new int(22));
+
+  autowiring::tuple<std::unique_ptr<int>&> tup(val);
+  ASSERT_EQ(22, *autowiring::get<0>(tup)) << "Tied tuple did not retrieve the expected value";
+}


### PR DESCRIPTION
std::tuple has too many strange behaviors on our target platform and has insufficient support.