### PR TITLE
Make use of an explicit linked list to improve flexibility

### DIFF
--- a/autowiring/AutoPacketFactory.h
+++ b/autowiring/AutoPacketFactory.h
@@ -66,6 +66,12 @@ public:
     container.insert(container.end(), m_autoFilters.begin(), m_autoFilters.end());
   }
 
+  /// <summary>
+  /// Creates a linked list of saturation counters
+  /// </summary>
+  /// <returns>The first element in the list, or nullptr if the list is empty</returns>
+  SatCounter* CreateSatCounterList(void) const;
+
   // CoreRunnable overrides:
   bool OnStart(void) override;
   void OnStop(bool graceful) override;

--- a/autowiring/SatCounter.h
+++ b/autowiring/SatCounter.h
@@ -11,18 +11,28 @@ struct SatCounter:
   public AutoFilterDescriptor
 {
   SatCounter(void):
+    flink(nullptr),
+    blink(nullptr),
     remaining(0)
   {}
 
   SatCounter(const AutoFilterDescriptor& source):
     AutoFilterDescriptor(source),
+    flink(nullptr),
+    blink(nullptr),
     remaining(m_requiredCount)
   {}
 
   SatCounter(const SatCounter& source):
     AutoFilterDescriptor(static_cast<const AutoFilterDescriptor&>(source)),
+    flink(nullptr),
+    blink(nullptr),
     remaining(source.remaining)
   {}
+
+  // Forward and backward linked list pointers
+  SatCounter* flink;
+  SatCounter* blink;
 
   // The number of inputs remaining to this counter:
   size_t remaining;

--- a/src/autowiring/AutoPacketInternal.cpp
+++ b/src/autowiring/AutoPacketInternal.cpp
@@ -16,17 +16,17 @@ void AutoPacketInternal::Initialize(bool isFirstPacket) {
   this->m_initTime = std::chrono::high_resolution_clock::now();
 
   // Traverse all descendant contexts, adding their packet subscriber vectors one at a time:
-  m_parentFactory->AppendAutoFiltersTo(m_satCounters);
+  m_firstCounter = m_parentFactory->CreateSatCounterList();
   
   // Find all subscribers with no required or optional arguments:
   std::vector<SatCounter*> callCounters;
-  for (auto& satCounter : m_satCounters) {
+  for (auto* satCounter = m_firstCounter; satCounter; satCounter = satCounter->flink) {
     
     // Prime the satisfaction graph for element:
-    AddSatCounter(satCounter);
+    AddSatCounter(*satCounter);
     
-    if (!satCounter.remaining)
-      callCounters.push_back(&satCounter);
+    if (!satCounter->remaining)
+      callCounters.push_back(satCounter);
   }
   
   // Mark timeshifted decorations as unsatisfiable on the first packet

--- a/src/autowiring/test/AutoFilterFunctionTest.cpp
+++ b/src/autowiring/test/AutoFilterFunctionTest.cpp
@@ -97,13 +97,13 @@ TEST_F(AutoFilterFunctionalTest, RecipientRemovalTest) {
 
   // Add a recipient and then remove it, verify it doesn't get called
   auto packet = factory->NewPacket();
-  AutoPacket::Recipient recipient =
+  const auto recipient =
     (
       *packet += [called] (const Decoration<0>&) {
         *called = true;
       }
     );
-  packet->RemoveRecipient(std::move(recipient));
+  packet->RemoveRecipient(*recipient);
 
   ASSERT_FALSE(*called) << "A recipient that should have been removed was called";
 }


### PR DESCRIPTION
This will be necessary to support some of the optimizations that are intended to be conducted on AutoPacket.  This unfortunately does require explicit destructors, but the added flexibility should make this change worthwhile.