### PR TITLE
Eliminate some snapshot-oriented member functions on AutoPacket

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -8,7 +8,6 @@
 #include "is_any.h"
 #include "is_shared_ptr.h"
 #include "TeardownNotifier.h"
-#include <list>
 #include <typeinfo>
 #include CHRONO_HEADER
 #include MEMORY_HEADER
@@ -157,22 +156,25 @@ protected:
   /// </remarks>
   const SatCounter& GetSatisfaction(const std::type_info& subscriber) const;
 
-  /// <returns>All subscribers to the specified data</returns>
-  std::list<SatCounter> GetSubscribers(const DecorationKey& key) const;
-
-  /// <returns>All decoration dispositions associated with the data type</returns>
-  /// <remarks>
-  /// This method is useful for determining whether flow conditions (broadcast, pipes
-  /// immediate decorations) resulted in missed data.
-  /// </remarks>
-  std::list<DecorationDisposition> GetDispositions(const DecorationKey& key) const;
-
   /// <summary>
   /// Throws a formatted runtime error corresponding to the case where an absent decoration was demanded
   /// </summary>
   static void ThrowNotDecoratedException(const DecorationKey& key);
 
 public:
+  /// <returns>
+  /// The number of distinct decoration types on this packet
+  /// </returns>
+  size_t GetDecorationTypeCount(void) const;
+
+  /// <returns>
+  /// A copy of the decoration dispositions collection
+  /// </returns>
+  /// <remarks>
+  /// This is a diagnostic method, users are recommended to avoid the use of this routine where possible
+  /// </remarks>
+  t_decorationMap GetDecorations(void) const;
+
   /// <returns>
   /// True if this packet posesses a decoration of the specified type
   /// </returns>
@@ -470,28 +472,6 @@ public:
   /// </remarks>
   template<class T>
   inline const SatCounter& GetSatisfaction(void) const { return GetSatisfaction(auto_id<T>::key()); }
-
-  /// <returns>All subscribers to the specified data</returns>
-  template<class T>
-  inline std::list<SatCounter> GetSubscribers(void) const {
-    return GetSubscribers(DecorationKey(auto_id<T>::key()));
-  }
-
-  /// <returns>All decoration dispositions</returns>
-  /// <remarks>
-  /// This method is useful for getting a picture of the entire disposition graph
-  /// </remarks>
-  std::list<DecorationDisposition> GetDispositions() const;
-
-  /// <returns>All decoration dispositions associated with the data type</returns>
-  /// <remarks>
-  /// This method is useful for determining whether flow conditions (broadcast, pipes
-  /// immediate decorations) resulted in missed data.
-  /// </remarks>
-  template<class T>
-  inline std::list<DecorationDisposition> GetDispositions(void) const {
-    return GetDispositions(DecorationKey(auto_id<T>::key()));
-  }
 
   /// <summary>
   /// Returns the next packet that will be issued by the packet factory in this context relative to this context

--- a/src/autowiring/AutoPacketGraph.cpp
+++ b/src/autowiring/AutoPacketGraph.cpp
@@ -79,7 +79,8 @@ bool AutoPacketGraph::OnStart(void) {
 
 void AutoPacketGraph::AutoFilter(AutoPacket& packet) {
   packet.AddTeardownListener([this, &packet] () {
-    for (auto& decoration : packet.GetDispositions()) {
+    for (auto& cur : packet.GetDecorations()) {
+      auto& decoration = cur.second;
       auto type = &decoration.GetKey().ti;
 
       for (auto& publisher : decoration.m_publishers) {

--- a/src/autowiring/test/AutoFilterDiagnosticsTest.cpp
+++ b/src/autowiring/test/AutoFilterDiagnosticsTest.cpp
@@ -22,10 +22,10 @@ TEST_F(AutoFilterDiagnosticsTest, CanGetExpectedTrueType) {
   AutoRequired<AutoPacketFactory> factory;
 
   auto packet = factory->NewPacket();
-  auto dispositions = packet->GetDispositions();
-  ASSERT_EQ(1UL, dispositions.size()) << "Dispositions collection contained an unexpected AutoFilter";
+  auto decorations = packet->GetDecorations();
+  ASSERT_EQ(1UL, decorations.size()) << "Dispositions collection contained an unexpected AutoFilter";
 
-  auto& disposition = dispositions.front();
+  auto& disposition = decorations.begin()->second;
   ASSERT_EQ(1UL, disposition.m_subscribers.size()) << "Expected exactly one subscriber for the sole present type";
 
   const SatCounter* descriptor = disposition.m_subscribers.front();

--- a/src/autowiring/test/DecoratorTest.cpp
+++ b/src/autowiring/test/DecoratorTest.cpp
@@ -81,17 +81,13 @@ TEST_F(DecoratorTest, VerifyDecoratorAwareness) {
 
   // Verify the first packet still does not have subscriptions:
   ASSERT_THROW(packet1->GetSatisfaction<FilterA>(), autowiring_error) << "Subscription was incorrectly, retroactively added to a packet";
-  ASSERT_TRUE(packet1->GetSubscribers<Decoration<0>>().empty()) << "Subscription was incorrectly, retroactively added to a packet";
-  ASSERT_TRUE(packet1->GetDispositions<Decoration<0>>().empty()) << "Subscription was incorrectly, retroactively added to a packet";
+  ASSERT_FALSE(packet1->HasSubscribers<Decoration<0>>()) << "Subscription was incorrectly, retroactively added to a packet";
+  ASSERT_EQ(0UL, packet1->GetDecorationTypeCount()) << "Subscription was incorrectly, retroactively added to a packet";
   ASSERT_FALSE(packet1->HasSubscribers<Decoration<0>>()) << "Subscription was incorrectly, retroactively added to a packet";
 
   // Verify the second one does:
   ASSERT_THROW(packet2->GetSatisfaction<FilterA>(), autowiring_error) << "Packet lacked an expected subscription";
-  auto subs = packet2->GetSubscribers<Decoration<0>>();
-  ASSERT_EQ(1UL, subs.size()) << "Incorrect subscriber count";
-  auto disps = packet2->GetDispositions<Decoration<0>>();
-  ASSERT_EQ(1UL, disps.size()) << "Incorrect count of expected decorations";
-  ASSERT_FALSE(disps.front().m_state == DispositionState::Satisfied) << "Incorrect satisfaction status";
+  ASSERT_EQ(2UL, packet2->GetDecorationTypeCount()) << "Incorrect count of expected decorations";
   ASSERT_TRUE(packet2->HasSubscribers<Decoration<0>>()) << "Packet lacked an expected subscription";
 }
 


### PR DESCRIPTION
These member functions are unsafe in any case, and were only ever used internally.  Removing them simplifies the interface of `AutoPacket` and also allows the `std::list` header to be removed.