### PR TITLE
Fixing an invalid default construction bug

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -359,6 +359,9 @@ public:
   /// <remarks>
   /// This decoration method has the additional benefit that it will make direct use of the passed
   /// shared pointer.
+  ///
+  /// If the passed value is null, the corresponding value will be marked unsatisfiable.  In this case,
+  /// the user is responsible for discarding the returned reference.
   /// </remarks>
   template<class T>
   const T& Decorate(std::shared_ptr<T> ptr) {
@@ -367,11 +370,12 @@ public:
     /// Injunction to prevent existential loops:
     static_assert(!std::is_same<T, AutoPacket>::value, "Cannot decorate a packet with another packet");
     
-    if(!ptr)
-      throw std::runtime_error("Cannot checkout with shared_ptr == nullptr");
-    
-    // This allows us to install correct entries for decorated input requests
-    Decorate(AnySharedPointer(ptr), key);
+    // Either decorate, or prevent anyone from decorating
+    if (ptr)
+      Decorate(AnySharedPointer(ptr), key);
+    else
+      MarkUnsatisfiable(key);
+
     return *ptr;
   }
 

--- a/autowiring/auto_arg.h
+++ b/autowiring/auto_arg.h
@@ -129,7 +129,22 @@ class auto_arg<std::shared_ptr<T>&>:
   public auto_arg<T&>
 {
 public:
-  typedef std::shared_ptr<T>& arg_type;
+  static const bool is_shared = true;
+
+  // Utility type, required to dereference the std::shared_ptr
+  struct arg_type {
+    arg_type(std::shared_ptr<T>& arg) :
+      arg(arg)
+    {}
+
+    std::shared_ptr<T>& arg;
+    operator std::shared_ptr<T>&() const { return arg; }
+  };
+
+  template<class C>
+  static std::shared_ptr<T> arg(C&) {
+    return std::shared_ptr<T>();
+  }
 };
 
 /// <summary>

--- a/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
+++ b/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
@@ -163,3 +163,21 @@ TEST_F(AutoFilterCollapseRulesTest, AutoFilterSharedAliasingRules) {
   ASSERT_TRUE(packet->Has<int>()) << "Filter producing a shared pointer of type int did not correctly collapse to the basic int type";
   ASSERT_EQ(55, std::get<0>(consumes->m_args)) << "Filter consuming a shared pointer output was not called as expected";
 }
+
+class CannotBeDefaultConstructed {
+  CannotBeDefaultConstructed(int) {}
+};
+
+class SharedPtrNoDefault
+{
+public:
+  void AutoFilter(std::shared_ptr<CannotBeDefaultConstructed>& out) {
+    ASSERT_EQ(nullptr, out) << "An argument that should have been provided null was incorrectly default constructed";
+  }
+};
+
+TEST_F(AutoFilterCollapseRulesTest, SharedPtrNoDefaultTest) {
+  AutoRequired<SharedPtrNoDefault> spnd;
+  AutoRequired<AutoPacketFactory> factory;
+  auto packet = factory->NewPacket();
+}


### PR DESCRIPTION
This bug attempted to default construct output arguments of the form `std::shared_ptr<T>&`.  The reason this output signature is supported is precisely to avoid requiring that Autowiring take responsibility for all construction events on `AutoPacket` decorations.  This bug has been fixed, and a test added to prevent future regressions.