### PR TITLE
Fix libstdc problems

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -374,12 +374,14 @@ public:
     static_assert(!std::is_same<T, AutoPacket>::value, "Cannot decorate a packet with another packet");
     
     // Either decorate, or prevent anyone from decorating
-    if (ptr)
+    if (ptr) {
       Decorate(AnySharedPointer(ptr), key);
-    else
+      return *ptr;
+    }
+    else {
       MarkUnsatisfiable(key);
-
-    return *ptr;
+      return *static_cast<T*>(nullptr);
+    }
   }
 
   /// <summary>

--- a/autowiring/C++11/boost_tuple.h
+++ b/autowiring/C++11/boost_tuple.h
@@ -22,6 +22,12 @@ namespace std {
       return *this;
     }
 
+    template<class... OtherTs>
+    tuple& operator=(const tuple<OtherTs...>& other) {
+      m_tuple = other;
+      return *this;
+    }
+
     bool operator==(const tuple<T, Ts...>& other) const {
       return m_tuple == other.m_tuple;
     }

--- a/autowiring/CallExtractor.h
+++ b/autowiring/CallExtractor.h
@@ -16,6 +16,11 @@ typedef void(*t_extractedCall)(const AnySharedPointer& obj, AutoPacket&);
 template<class MemFn, class Index = typename make_index_tuple<Decompose<MemFn>::N>::type>
 struct CallExtractor;
 
+namespace autowiring {
+  template<class... Args>
+  void noop(Args...) {}
+}
+
 template<class... Args>
 struct CallExtractorSetup
 {
@@ -69,7 +74,7 @@ struct CallExtractor<RetType (*)(Args...), index_tuple<N...>>:
     ((t_pfn)pfn)(
       static_cast<typename auto_arg<Args>::arg_type>(autowiring::get<N>(extractor.args))...
     );
-    (void)std::initializer_list<bool>{extractor.template Commit<N>(false)...};
+    autowiring::noop(extractor.template Commit<N>(false)...);
   }
 };
 
@@ -101,7 +106,7 @@ struct CallExtractor<void (T::*)(Args...), index_tuple<N...>> :
     (((T*) pObj)->*memFn)(
       static_cast<typename auto_arg<Args>::arg_type>(autowiring::get<N>(extractor.args))...
     );
-    (void)std::initializer_list<bool>{extractor.template Commit<N>(false)...};
+    autowiring::noop(extractor.template Commit<N>(false)...);
   }
 };
 
@@ -125,7 +130,7 @@ struct CallExtractor<void (T::*)(Args...) const, index_tuple<N...>> :
     (((const T*) pObj)->*memFn)(
       static_cast<typename auto_arg<Args>::arg_type>(autowiring::get<N>(extractor.args))...
     );
-    (void)std::initializer_list<bool>{extractor.template Commit<N>(false)...};
+    autowiring::noop(extractor.template Commit<N>(false)...);
   }
 };
 
@@ -157,7 +162,7 @@ struct CallExtractor<Deferred(T::*)(Args...), index_tuple<N...>> :
       (((T*) pObj)->*memFn)(
         static_cast<typename auto_arg<Args>::arg_type>(autowiring::get<N>(extractor.args))...
       );
-      (void)std::initializer_list<bool>{extractor.template Commit<N>(false)...};
+      autowiring::noop(extractor.template Commit<N>(false)...);
     };
   }
 };

--- a/autowiring/TypeUnifier.h
+++ b/autowiring/TypeUnifier.h
@@ -2,6 +2,7 @@
 #pragma once
 #include "Object.h"
 #include RVALUE_HEADER
+#include TYPE_TRAITS_HEADER
 
 class TypeUnifier: public Object {};
 

--- a/autowiring/auto_arg.h
+++ b/autowiring/auto_arg.h
@@ -3,7 +3,6 @@
 #include "auto_in.h"
 #include "auto_out.h"
 #include "auto_prev.h"
-#include <initializer_list>
 
 class AutoPacket;
 

--- a/autowiring/member_new_type.h
+++ b/autowiring/member_new_type.h
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Decompose.h"
+#include STL_TUPLE_HEADER
 
 namespace autowiring {
 

--- a/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
+++ b/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
@@ -161,7 +161,7 @@ TEST_F(AutoFilterCollapseRulesTest, AutoFilterSharedAliasingRules) {
   // Decorate the packet, verify attribute presence:
   auto packet = factory->NewPacket();
   ASSERT_TRUE(packet->Has<int>()) << "Filter producing a shared pointer of type int did not correctly collapse to the basic int type";
-  ASSERT_EQ(55, std::get<0>(consumes->m_args)) << "Filter consuming a shared pointer output was not called as expected";
+  ASSERT_EQ(55, autowiring::get<0>(consumes->m_args)) << "Filter consuming a shared pointer output was not called as expected";
 }
 
 class CannotBeDefaultConstructed {

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -497,7 +497,7 @@ TEST_F(AutoFilterTest, SingleImmediate) {
     packet->DecorateImmediate(dec);
 
     ASSERT_TRUE(fgp->m_called == 1) << "Filter should called " << fgp->m_called << " times, expected 1";
-    ASSERT_TRUE(std::get<0>(fgp->m_args).i == pattern) << "Filter argument yielded " << std::get<0>(fgp->m_args).i << "expected " << pattern;
+    ASSERT_TRUE(autowiring::get<0>(fgp->m_args).i == pattern) << "Filter argument yielded " << autowiring::get<0>(fgp->m_args).i << "expected " << pattern;
   }
   ASSERT_EQ(0, factory->GetOutstandingPacketCount()) << "Destroyed packet remains outstanding";
 

--- a/src/autowiring/test/TestFixtures/Decoration.hpp
+++ b/src/autowiring/test/TestFixtures/Decoration.hpp
@@ -1,7 +1,9 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <autowiring/CoreThread.h>
+#include <autowiring/auto_tuple.h>
 #include <autowiring/has_autofilter.h>
+#include STL_TUPLE_HEADER
 
 /// <summary>
 /// A simple "decoration" class which will be added to a variety of sample packets
@@ -155,11 +157,11 @@ public:
       ASSERT_FALSE(cur) << "Packet was already decorated with at least one output-only type";
 
     ++m_called;
-    m_args = std::tie(args...);
+    m_args = autowiring::tie(args...);
   }
 
   int m_called;
-  std::tuple<typename std::decay<Args>::type...> m_args;
+  autowiring::tuple<typename std::remove_cv<typename std::decay<Args>::type>::type...> m_args;
 };
 
 /// <summary>


### PR DESCRIPTION
* Eliminate use of `initializer_list`, not supported by libstdc, make use of `autowiring::noop` instead
* Rewrote `#include STL_TUPLE_HEADER` so that certain overloads will work
* Eliminate other uses of std::tuple where possible
* Fixed a null `std::shared_ptr` dereference