### PR TITLE
Adding a forward-only type as an AutoFilter output argument

### DIFF
--- a/src/autowiring/test/CommonUseCasesTest.cpp
+++ b/src/autowiring/test/CommonUseCasesTest.cpp
@@ -13,4 +13,5 @@ class CUCTSample {};
 // only take place with great attention paid to a proper deprecation strategy.
 TEST_F(CommonUseCasesTest, AutowiredForwardType) {
   HasForwardOnlyType f;
+  AutoRequired<HasForwardOnlyType> fp;
 }

--- a/src/autowiring/test/HasForwardOnlyType.cpp
+++ b/src/autowiring/test/HasForwardOnlyType.cpp
@@ -8,3 +8,7 @@ class MyForwardedType {};
 
 // And then we provide the ctor
 HasForwardOnlyType::HasForwardOnlyType(void) {}
+
+void HasForwardOnlyType::AutoFilter(std::shared_ptr<MyForwardedType>& output) {
+
+}

--- a/src/autowiring/test/HasForwardOnlyType.hpp
+++ b/src/autowiring/test/HasForwardOnlyType.hpp
@@ -9,4 +9,6 @@ public:
   HasForwardOnlyType(void);
 
   Autowired<MyForwardedType> forwarded;
+
+  void AutoFilter(std::shared_ptr<MyForwardedType>& output);
 };


### PR DESCRIPTION
This should guard against regressions where we are attempting to make use of a type that we don't absolutely need to make use of.