### PR TITLE
Fixing some linker warnings

### DIFF
--- a/autowiring/AutoPacketFactory.h
+++ b/autowiring/AutoPacketFactory.h
@@ -184,3 +184,5 @@ extern template struct SlotInformationStump<AutoPacketFactory, false>;
 extern template const std::shared_ptr<AutoPacketFactory>& SharedPointerSlot::as<AutoPacketFactory>(void) const;
 extern template std::shared_ptr<AutoPacketFactory> autowiring::fast_pointer_cast<AutoPacketFactory, Object>(const std::shared_ptr<Object>& Other);
 extern template class RegType<AutoPacketFactory>;
+extern template struct autowiring::fast_pointer_cast_blind<Object, AutoPacketFactory>;
+extern template struct autowiring::fast_pointer_cast_initializer<Object, AutoPacketFactory>;

--- a/autowiring/fast_pointer_cast.h
+++ b/autowiring/fast_pointer_cast.h
@@ -4,6 +4,9 @@
 #include MEMORY_HEADER
 #include TYPE_TRAITS_HEADER
 
+class AutoPacketFactory;
+class Object;
+
 namespace autowiring {
   template<class T, class U>
   struct fast_pointer_cast_blind;

--- a/src/autowiring/AutoPacketFactory.cpp
+++ b/src/autowiring/AutoPacketFactory.cpp
@@ -185,3 +185,5 @@ template struct SlotInformationStump<AutoPacketFactory, false>;
 template const std::shared_ptr<AutoPacketFactory>& SharedPointerSlot::as<AutoPacketFactory>(void) const;
 template std::shared_ptr<AutoPacketFactory> autowiring::fast_pointer_cast<AutoPacketFactory, Object>(const std::shared_ptr<Object>& Other);
 template class RegType<AutoPacketFactory>;
+template struct autowiring::fast_pointer_cast_blind<Object, AutoPacketFactory>;
+template struct autowiring::fast_pointer_cast_initializer<Object, AutoPacketFactory>;


### PR DESCRIPTION
Have to keep the instantiation of internally used templates internal to the library proper by making use of the "extern" trick.