### PR TITLE
Switching GetAll to make use of a temporary buffer

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -289,7 +289,7 @@ public:
   /// <summary>
   /// Returns a null-terminated temporary buffer containing all decorations
   /// </summary>
-  /// <returns>The buffer, or nullptr if no matching decorations exist</returns>
+  /// <returns>The null-terminated temporary buffer</returns>
   /// <remarks>
   /// The returned buffer must be freed with std::return_temporary_buffer
   /// </remarks>
@@ -297,8 +297,13 @@ public:
   const T** GetAll(int tshift = 0) const {
     std::lock_guard<std::mutex> lk(m_lock);
     auto q = m_decorations.find(DecorationKey(auto_id<T>::key(), tshift));
-    if (q == m_decorations.end())
-      return nullptr;
+
+    // If decoration doesn't exist, return empty null-terminated buffer
+    if (q == m_decorations.end()) {
+      const T** retVal = std::get_temporary_buffer<const T*>(1).first;
+      retVal[0] = nullptr;
+      return retVal;
+    }
 
     const auto& decorations = q->second.m_decorations;
     const T** retVal = std::get_temporary_buffer<const T*>(decorations.size() + 1).first;

--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -287,17 +287,25 @@ public:
   }
 
   /// <summary>
-  /// Returns a vector with a pointer to each decoration of type T, adding a nullptr to the end.
+  /// Returns a null-terminated temporary buffer containing all decorations
   /// </summary>
+  /// <returns>The buffer, or nullptr if no matching decorations exist</returns>
+  /// <remarks>
+  /// The returned buffer must be freed with std::return_temporary_buffer
+  /// </remarks>
   template<class T>
-  std::vector<const T*> GetAll(int tshift = 0) {
-    std::vector<const T*> retval;
-    auto deco = m_decorations.find(DecorationKey(auto_id<T>::key(), tshift));
-    for (auto& dispo : deco->second.m_decorations) {
-      retval.push_back(dispo.as<T>().get().get());
-    }
-    retval.push_back(nullptr);
-    return retval;
+  const T** GetAll(int tshift = 0) const {
+    std::lock_guard<std::mutex> lk(m_lock);
+    auto q = m_decorations.find(DecorationKey(auto_id<T>::key(), tshift));
+    if (q == m_decorations.end())
+      return nullptr;
+
+    const auto& decorations = q->second.m_decorations;
+    const T** retVal = std::get_temporary_buffer<const T*>(decorations.size() + 1).first;
+    for (size_t i = 0; i < decorations.size(); i++)
+      retVal[i] = static_cast<const T*>(decorations[i]->ptr());
+    retVal[decorations.size()] = nullptr;
+    return retVal;
   }
 
   /// <summary>Shares all broadcast data from this packet with the recipient packet</summary>

--- a/autowiring/auto_arg.h
+++ b/autowiring/auto_arg.h
@@ -224,17 +224,21 @@ template<class T>
 class auto_arg<T const **>
 {
 public:
-  typedef std::vector<const T*> type;
+  typedef const T** type;
 
   // Another compositional structure, used to coerce a vector to a data item
   struct arg_type {
-    arg_type(type& value) :
-      value(value.data())
+    arg_type(const T** value) :
+      value(value)
     {}
 
-    T const ** value;
+    ~arg_type(void) {
+      std::return_temporary_buffer(value);
+    }
 
-    operator T const **(void) const { return value; }
+    const T** value;
+
+    operator const T**(void) const { return value; }
   };
 
   typedef auto_id<T> id_type;
@@ -245,7 +249,7 @@ public:
   static const int tshift = 0;
 
   template<class C>
-  static std::vector<const T*> arg(C& packet) {
+  static const T** arg(C& packet) {
     return packet.template GetAll<T>();
   }
 };


### PR DESCRIPTION
`std::get_temporary_buffer` is provided precisely for cases like these where small amounts of memory are required for short periods of time.  We might as well make use of it.