### PR TITLE
Cleaner fix to "has no symbols" warning on Mac

### DIFF
--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -147,6 +147,7 @@ set(Autowiring_SRCS
   TypeUnifier.h
   unlock_object.h
   uuid.h
+  uuid.cpp
   var_logic.h
 )
 
@@ -170,14 +171,6 @@ add_conditional_sources(
   ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/thread/src/pthread/thread.cpp
   ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/thread/src/future.cpp
 )
-
-if(NOT APPLE)
-  # avoid warning: has no symbols
-  set(Autowiring_SRCS
-    ${Autowiring_SRCS}
-    uuid.cpp
-  )
-endif()
 
 add_windows_sources(Autowiring_SRCS
   CoreThreadWin.cpp

--- a/src/autowiring/uuid.cpp
+++ b/src/autowiring/uuid.cpp
@@ -1,3 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "uuid.h"
+
+// Avoid warning "has no symbols"
+int autowiring_dummy = 0;


### PR DESCRIPTION
Dummy variables are used often to correct issues like this one.  At some point, however, we should consider either deprecating or making use of the uuid concept rather than just patching it like this.