### PR TITLE
Adding a `get` operation on auto_out

### DIFF
--- a/autowiring/auto_out.h
+++ b/autowiring/auto_out.h
@@ -31,6 +31,11 @@ protected:
 
 public:
   /// <summary>
+  /// Returns the dumb pointer to the underlying output value
+  /// </summary>
+  T* get(void) const { return m_value.get(); }
+
+  /// <summary>
   /// Releases the internal shared pointer, preventing it from being decorated on the packet
   /// </summary>
   void reset(void) {


### PR DESCRIPTION
Just for convenience for users that are interested in the underlying dumb pointer