### PR TITLE
Make use of a template template type instead of rebind

### DIFF
--- a/autowiring/AutoFilterDescriptor.h
+++ b/autowiring/AutoFilterDescriptor.h
@@ -178,7 +178,7 @@ struct AutoFilterDescriptor:
         std::static_pointer_cast<typename Decompose<decltype(&T::AutoFilter)>::type>(subscriber)
       ),
       &typeid(T),
-      Decompose<decltype(&T::AutoFilter)>::template Enumerate<AutoFilterDescriptorInput>::types,
+      Decompose<decltype(&T::AutoFilter)>::template Enumerate<AutoFilterDescriptorInput, AutoFilterDescriptorInputT>::types,
       CallExtractor<decltype(&T::AutoFilter)>::deferred,
       &CallExtractor<decltype(&T::AutoFilter)>::template Call<&T::AutoFilter>
     )
@@ -195,7 +195,7 @@ struct AutoFilterDescriptor:
     AutoFilterDescriptor(
       AnySharedPointer(std::make_shared<Fn>(std::forward<Fn>(fn))),
       &typeid(Fn),
-      CallExtractor<decltype(&Fn::operator())>::template Enumerate<AutoFilterDescriptorInput>::types,
+      CallExtractor<decltype(&Fn::operator())>::template Enumerate<AutoFilterDescriptorInput, AutoFilterDescriptorInputT>::types,
       false,
       &CallExtractor<decltype(&Fn::operator())>::template Call<&Fn::operator()>
     )
@@ -240,7 +240,7 @@ struct AutoFilterDescriptor:
       // The remainder is fairly straightforward
       &typeid(pfn),
 
-      CallExtractor<decltype(pfn)>::template Enumerate<AutoFilterDescriptorInput>::types,
+      CallExtractor<decltype(pfn)>::template Enumerate<AutoFilterDescriptorInput, AutoFilterDescriptorInputT>::types,
       false,
       CallExtractor<decltype(pfn)>::Call
     )

--- a/autowiring/AutoFilterDescriptorInput.h
+++ b/autowiring/AutoFilterDescriptorInput.h
@@ -16,14 +16,20 @@ struct AutoFilterDescriptorInput {
     tshift(0)
   {}
 
-  template<class T>
-  AutoFilterDescriptorInput(auto_arg<T>*) :
-    is_input(auto_arg<T>::is_input),
-    is_output(auto_arg<T>::is_output),
-    is_shared(auto_arg<T>::is_shared),
-    is_multi(auto_arg<T>::is_multi),
-    ti(&typeid(typename auto_arg<T>::id_type)),
-    tshift(auto_arg<T>::tshift)
+  AutoFilterDescriptorInput(
+    bool is_input,
+    bool is_output,
+    bool is_shared,
+    bool is_multi,
+    const std::type_info* ti,
+    int tshift
+  ) :
+    is_input(is_input),
+    is_output(is_output),
+    is_shared(is_shared),
+    is_multi(is_multi),
+    ti(ti),
+    tshift(tshift)
   {}
 
   const bool is_input;
@@ -36,11 +42,20 @@ struct AutoFilterDescriptorInput {
   operator bool(void) const {
     return !!ti;
   }
+};
 
-  template<class T>
-  struct rebind {
-    operator AutoFilterDescriptorInput() {
-      return AutoFilterDescriptorInput((auto_arg<T>*)nullptr);
-    }
-  };
+template<typename T>
+struct AutoFilterDescriptorInputT:
+  AutoFilterDescriptorInput
+{
+  AutoFilterDescriptorInputT(void) :
+    AutoFilterDescriptorInput(
+      auto_arg<T>::is_input,
+      auto_arg<T>::is_output,
+      auto_arg<T>::is_shared,
+      auto_arg<T>::is_multi,
+      &typeid(typename auto_arg<T>::id_type),
+      auto_arg<T>::tshift
+    )
+  {}
 };

--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -562,7 +562,7 @@ public:
 
     // Add the filter that will ultimately be invoked
     *this += std::move(autoFilter);
-    return Wait(cv, Decompose<decltype(&Fx::operator())>::template Enumerate<AutoFilterDescriptorInput>::types, duration);
+    return Wait(cv, Decompose<decltype(&Fx::operator())>::template Enumerate<AutoFilterDescriptorInput, AutoFilterDescriptorInputT>::types, duration);
   }
 
   /// <summary>
@@ -586,7 +586,7 @@ public:
   bool Wait(std::chrono::nanoseconds duration, std::condition_variable& cv)
   {
     static const AutoFilterDescriptorInput inputs [] = {
-      static_cast<auto_arg<Args>*>(nullptr)...,
+      AutoFilterDescriptorInputT<Args>()...,
       AutoFilterDescriptorInput()
     };
 

--- a/autowiring/Decompose.h
+++ b/autowiring/Decompose.h
@@ -15,11 +15,11 @@ struct TemplatePack {
   ///
   /// The returned array contains one more element than the arity of the decomposed member function
   /// type.  Each element in the array is initialized based on the type of the corresponding argument
-  /// in the decomposed function.  Elements in the array are constructed using the "rebind" structure
+  /// in the decomposed function.  Elements in the array are constructed using the "Generator" type
   /// which must be an interior type to type T.  An instance of type rebind should be castable to the
   /// base type T, or it must be a function returning a value of type T.
   /// </remarks>
-  template<class T>
+  template<class T, template<typename> class Generator>
   struct Enumerate {
     static const T types[N + 1];
   };
@@ -34,8 +34,8 @@ struct TemplatePack {
 };
 
 template<class... Ts>
-template<class T>
-const T TemplatePack<Ts...>::Enumerate<T>::types[] = {typename T::template rebind<Ts>()..., T()};
+template<class T, template<typename> class Generator>
+const T TemplatePack<Ts...>::Enumerate<T, Generator>::types[] = {Generator<Ts>()..., T()};
 
 /// <summary>
 /// Provides some static reflection support for member function pointers


### PR DESCRIPTION
Template template types are more readable and easily understood than std::rebind