### PR TITLE
Fixing issue where the AutoPacketGraph CoreRunnable is dying when OnStart is called

### DIFF
--- a/src/autowiring/AutoPacketGraph.cpp
+++ b/src/autowiring/AutoPacketGraph.cpp
@@ -74,7 +74,7 @@ void AutoPacketGraph::NewObject(CoreContext&, const ObjectTraits&) {
 bool AutoPacketGraph::OnStart(void) {
   LoadEdges();
   
-  return false;
+  return true;
 }
 
 void AutoPacketGraph::AutoFilter(AutoPacket& packet) {


### PR DESCRIPTION
From CoreRunnable documentation: CoreRunnable::OnStart(): This method will be called at most once.  Returning false from this method will result in an immediate invocation of the OnStop(false).