### PR TITLE
Rename 'Object' to 'CoreObject'

### DIFF
--- a/autowiring/AutoPacketFactory.h
+++ b/autowiring/AutoPacketFactory.h
@@ -182,7 +182,7 @@ public:
 // exterior instantation of internally used template instances
 extern template struct SlotInformationStump<AutoPacketFactory, false>;
 extern template const std::shared_ptr<AutoPacketFactory>& SharedPointerSlot::as<AutoPacketFactory>(void) const;
-extern template std::shared_ptr<AutoPacketFactory> autowiring::fast_pointer_cast<AutoPacketFactory, Object>(const std::shared_ptr<Object>& Other);
+extern template std::shared_ptr<AutoPacketFactory> autowiring::fast_pointer_cast<AutoPacketFactory, CoreObject>(const std::shared_ptr<CoreObject>& Other);
 extern template class RegType<AutoPacketFactory>;
-extern template struct autowiring::fast_pointer_cast_blind<Object, AutoPacketFactory>;
-extern template struct autowiring::fast_pointer_cast_initializer<Object, AutoPacketFactory>;
+extern template struct autowiring::fast_pointer_cast_blind<CoreObject, AutoPacketFactory>;
+extern template struct autowiring::fast_pointer_cast_initializer<CoreObject, AutoPacketFactory>;

--- a/autowiring/AutoRestarter.h
+++ b/autowiring/AutoRestarter.h
@@ -135,7 +135,7 @@ protected:
       GenerateContext();
   }
 
-  void Filter(const JunctionBoxBase* pJunctionBox, Object* pRecipient) override {
+  void Filter(const JunctionBoxBase* pJunctionBox, CoreObject* pRecipient) override {
     Filter();
   }
 

--- a/autowiring/AutowirableSlot.h
+++ b/autowiring/AutowirableSlot.h
@@ -9,7 +9,7 @@
 class CoreContext;
 class DeferrableAutowiring;
 class GlobalCoreContext;
-class Object;
+class CoreObject;
 
 // Utility routine, for users who need a function that does nothing
 template<class T>
@@ -146,7 +146,7 @@ public:
     // of this type MUST be available.  The reason for this is that, if the user wishes to know if a
     // type is autowired, they are required at a minimum to know what that type's inheritance relations
     // are to other types in the system.
-    (void) autowiring::fast_pointer_cast_initializer<T, Object>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<T, CoreObject>::sc_init;
     return !!get();
   }
 
@@ -155,7 +155,7 @@ public:
   /// </remarks>
   T* get(void) const {
     // For now, we require that the full type be available to use this method
-    (void) autowiring::fast_pointer_cast_initializer<T, Object>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<T, CoreObject>::sc_init;
     return get_unsafe();
   }
 
@@ -184,14 +184,14 @@ public:
     // Initialize any blind fast casts to the actually desired type.  This is one of a few points
     // where we can guarantee that the type will be completely defined, because the user is about
     // to make use of this type.
-    (void) autowiring::fast_pointer_cast_initializer<T, Object>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<T, CoreObject>::sc_init;
     return get();
   }
 
   T& operator*(void) const {
     // We have to initialize here, in the operator context, because we don't actually know if the
     // user will be making use of this type.
-    (void) autowiring::fast_pointer_cast_initializer<T, Object>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<T, CoreObject>::sc_init;
 
     return *get();
   }

--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -311,14 +311,14 @@ public:
 
   // !!!!! Read comment in AutoRequired if you get a compiler error here !!!!!
   AutowiredFast(const std::shared_ptr<CoreContext>& ctxt = CoreContext::CurrentContext()) {
-    (void) autowiring::fast_pointer_cast_initializer<T, Object>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<T, CoreObject>::sc_init;
 
     if (ctxt)
       ctxt->FindByTypeRecursive(*this);
   }
 
   AutowiredFast(const CoreContext* pCtxt) {
-    (void) autowiring::fast_pointer_cast_initializer<T, Object>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<T, CoreObject>::sc_init;
 
     pCtxt->FindByTypeRecursive(*this);
   }

--- a/autowiring/BasicThread.h
+++ b/autowiring/BasicThread.h
@@ -102,13 +102,13 @@ protected:
   /// shared pointer passed to it, typically as a last step before return, potentially
   /// triggering the case described above.
   /// </remarks>
-  virtual void DoRun(std::shared_ptr<Object>&& refTracker);
+  virtual void DoRun(std::shared_ptr<CoreObject>&& refTracker);
 
   /// <summary>
   /// Performs all cleanup operations that must take place after DoRun
   /// </summary>
   /// <param name="pusher">The last reference to the enclosing context held by this thread</param>
-  virtual void DoRunLoopCleanup(std::shared_ptr<CoreContext>&& ctxt, std::shared_ptr<Object>&& refTracker);
+  virtual void DoRunLoopCleanup(std::shared_ptr<CoreContext>&& ctxt, std::shared_ptr<CoreObject>&& refTracker);
 
   void DEPRECATED(Ready(void) const, "Do not call this method, the concept of thread readiness is now deprecated") {}
 

--- a/autowiring/ContextMember.h
+++ b/autowiring/ContextMember.h
@@ -1,6 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "Object.h"
+#include "CoreObject.h"
 #include "TeardownNotifier.h"
 #include MEMORY_HEADER
 
@@ -10,7 +10,7 @@ class CoreContext;
 /// A class that must be inherited in order to be a member of a context heriarchy
 /// </summary>
 class ContextMember:
-  public Object,
+  public CoreObject,
   public TeardownNotifier,
   public std::enable_shared_from_this<ContextMember>
 {

--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -234,14 +234,14 @@ protected:
   std::vector<ExceptionFilter*> m_filters;
 
   // All known event receivers and receiver proxies originating from this context:
-  typedef std::set<JunctionBoxEntry<Object>> t_rcvrSet;
+  typedef std::set<JunctionBoxEntry<CoreObject>> t_rcvrSet;
   t_rcvrSet m_eventReceivers;
 
   // List of eventReceivers to be added when this context in initiated
   t_rcvrSet m_delayedEventReceivers;
   
   // Context members from other contexts that have snooped this context
-  std::set<Object*> m_snoopers;
+  std::set<CoreObject*> m_snoopers;
 
   // Manages events for this context. One JunctionBoxManager is shared between peer contexts
   const std::shared_ptr<JunctionBoxManager> m_junctionBoxManager;
@@ -252,7 +252,7 @@ protected:
 
   // Clever use of shared pointer to expose the number of outstanding CoreRunnable instances.
   // Destructor does nothing; this is by design.
-  std::weak_ptr<Object> m_outstanding;
+  std::weak_ptr<CoreObject> m_outstanding;
 
   // Creation rules are allowed to refer to private methods in this type
   template<autowiring::construction_strategy, class T, class... Args>
@@ -329,7 +329,7 @@ protected:
   /// Adds the named event receiver to the collection of known receivers
   /// </summary>
   /// <param name="pRecvr">The junction box entry corresponding to the receiver type</param>
-  void AddEventReceiver(const JunctionBoxEntry<Object>& pRecvr);
+  void AddEventReceiver(const JunctionBoxEntry<CoreObject>& pRecvr);
 
   /// \internal
   /// <summary>
@@ -387,7 +387,7 @@ protected:
   ///
   /// The caller is responsible for exterior synchronization
   /// </remarks>
-  std::shared_ptr<Object> IncrementOutstandingThreadCount(void);
+  std::shared_ptr<CoreObject> IncrementOutstandingThreadCount(void);
 
   /// \internal
   /// <summary>
@@ -427,13 +427,13 @@ protected:
   /// <summary>
   /// Adds a snooper to the snoopers set
   /// </summary>
-  void InsertSnooper(std::shared_ptr<Object> snooper);
+  void InsertSnooper(std::shared_ptr<CoreObject> snooper);
 
   /// \internal
   /// <summary>
   /// Removes a snooper to the snoopers set
   /// </summary>
-  void RemoveSnooper(std::shared_ptr<Object> snooper);
+  void RemoveSnooper(std::shared_ptr<CoreObject> snooper);
   
   /// \internal
   /// <summary>
@@ -443,7 +443,7 @@ protected:
   /// This method has no effect if the passed value is presently a snooper in this context; the
   /// snooper collection must therefore be updated prior to the call to this method.
   /// </remarks>
-  void UnsnoopEvents(Object* snooper, const JunctionBoxEntry<Object>& traits);
+  void UnsnoopEvents(CoreObject* snooper, const JunctionBoxEntry<CoreObject>& traits);
   
   /// \internal
   /// <summary>
@@ -628,13 +628,13 @@ public:
     typedef autowiring::CreationRules<T, Args...> CreationRules;
 
     // Add this type to the TypeRegistry, also ensure that we initialize support for blind
-    // fast pointer cast to Object.
+    // fast pointer cast to CoreObject.
     (void) RegType<T>::r;
-    (void) autowiring::fast_pointer_cast_initializer<Object, T>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<CoreObject, T>::sc_init;
 
     // First see if the base object type has already been injected.  This is also necessary to
     // ensure that a memo slot is created for the type by itself, in cases where the injected
-    // member does not inherit Object and this member is eventually satisfied by one that does.
+    // member does not inherit CoreObject and this member is eventually satisfied by one that does.
     {
       std::shared_ptr<T> pure;
       FindByType(pure);
@@ -917,7 +917,7 @@ public:
   /// </summary>
   /// <param name="pProxy">The sender of the event</param>
   /// <param name="pRecipient">The recipient of the event</param>
-  void FilterFiringException(const JunctionBoxBase* pProxy, Object* pRecipient);
+  void FilterFiringException(const JunctionBoxBase* pProxy, CoreObject* pRecipient);
 
   /// <summary>
   /// Registers the specified event receiver to receive messages broadcast within this context.
@@ -939,7 +939,7 @@ public:
 
     // Add EventReceiver
     if(traits.receivesEvents)
-      AddEventReceiver(JunctionBoxEntry<Object>(this, traits.pObject));
+      AddEventReceiver(JunctionBoxEntry<CoreObject>(this, traits.pCoreObject));
     
     // Add PacketSubscriber;
     if(!traits.subscriber.empty())
@@ -966,11 +966,11 @@ public:
     
     RemoveSnooper(pSnooper);
     
-    auto oSnooper = std::static_pointer_cast<Object>(pSnooper);
+    auto oSnooper = std::static_pointer_cast<CoreObject>(pSnooper);
     
     // Cleanup if its an EventReceiver
     if(traits.receivesEvents)
-      UnsnoopEvents(oSnooper.get(), JunctionBoxEntry<Object>(this, traits.pObject));
+      UnsnoopEvents(oSnooper.get(), JunctionBoxEntry<CoreObject>(this, traits.pCoreObject));
     
     // Cleanup if its a packet listener
     if(!traits.subscriber.empty())
@@ -1192,7 +1192,7 @@ public:
 
 template<class T, class Fn>
 class CoreContext::AutoFactoryFn :
-  public Object,
+  public CoreObject,
   public CoreContext::AutoFactory<T>
 {
 public:
@@ -1207,7 +1207,7 @@ public:
 
 template<class... Ts, class Fn>
 class CoreContext::AutoFactoryFn<std::tuple<Ts...>, Fn> :
-  public Object,
+  public CoreObject,
   CoreContext::AutoFactory<Ts>...
 {
 public:
@@ -1222,8 +1222,8 @@ template<typename T, typename... Args>
 T* autowiring::crh<autowiring::construction_strategy::foreign_factory, T, Args...>::New(CoreContext& ctxt, Args&&... args) {
   // We need to ensure that we can perform a find-by-type cast correctly, so
   // the dynamic caster entry is added to the registry
-  (void) autowiring::fast_pointer_cast_initializer<Object, CoreContext::AutoFactory<T>>::sc_init;
-  (void) autowiring::fast_pointer_cast_initializer<CoreContext::AutoFactory<T>, Object>::sc_init;
+  (void) autowiring::fast_pointer_cast_initializer<CoreObject, CoreContext::AutoFactory<T>>::sc_init;
+  (void) autowiring::fast_pointer_cast_initializer<CoreContext::AutoFactory<T>, CoreObject>::sc_init;
 
   // Now we can go looking for this type:
   AnySharedPointerT<CoreContext::AutoFactory<T>> af;

--- a/autowiring/CoreJob.h
+++ b/autowiring/CoreJob.h
@@ -4,7 +4,7 @@
 #include "CoreRunnable.h"
 #include "DispatchQueue.h"
 
-class Object;
+class CoreObject;
 
 class CoreJob:
   public ContextMember,

--- a/autowiring/CoreObject.h
+++ b/autowiring/CoreObject.h
@@ -10,3 +10,6 @@ public:
   CoreObject(void);
   virtual ~CoreObject(void);
 };
+
+// Temporarily typedef to old name of 'CoreObject' until all users of Autowiring have been updated
+typedef CoreObject Object;

--- a/autowiring/CoreObject.h
+++ b/autowiring/CoreObject.h
@@ -5,8 +5,8 @@
 /// General object base, used to make conversions possible between various shared pointer implementations.
 /// Withouat an object base, there is no way to do generic autowiring.
 /// </summary>
-class Object {
+class CoreObject {
 public:
-  Object(void);
-  virtual ~Object(void);
+  CoreObject(void);
+  virtual ~CoreObject(void);
 };

--- a/autowiring/CoreRunnable.h
+++ b/autowiring/CoreRunnable.h
@@ -4,7 +4,7 @@
 #include MEMORY_HEADER
 #include MUTEX_HEADER
 
-class Object;
+class CoreObject;
 
 class CoreRunnable {
 public:
@@ -19,7 +19,7 @@ private:
   bool m_shouldStop;
 
   // The outstanding count, held for as long as processing is underway
-  std::shared_ptr<Object> m_outstanding;
+  std::shared_ptr<CoreObject> m_outstanding;
 
 protected:
   std::mutex m_lock;
@@ -28,7 +28,7 @@ protected:
   /// <returns>
   /// A reference to the current outstanding counter
   /// </returns>
-  const std::shared_ptr<Object>& GetOutstanding(void) const;
+  const std::shared_ptr<CoreObject>& GetOutstanding(void) const;
 
   /// <summary>
   /// Method invoked from Start when this class is being asked to begin processing
@@ -74,7 +74,7 @@ public:
   /// Callers should strongly prefer not to override Start if possible.  Instead, override OnStart and
   /// obtain an instance of the outstanding pointer via GetOutstanding
   /// </remarks>
-  virtual bool Start(std::shared_ptr<Object> outstanding);
+  virtual bool Start(std::shared_ptr<CoreObject> outstanding);
 
   /// <summary>
   /// Stops this runnable, optionally performing graceful cleanup if requested

--- a/autowiring/CoreThread.h
+++ b/autowiring/CoreThread.h
@@ -27,7 +27,7 @@ protected:
   /// <summary>
   /// Overridden here so we can rundown the dispatch queue
   /// </summary>
-  virtual void DoRunLoopCleanup(std::shared_ptr<CoreContext>&& ctxt, std::shared_ptr<Object>&& refTracker) override;
+  virtual void DoRunLoopCleanup(std::shared_ptr<CoreContext>&& ctxt, std::shared_ptr<CoreObject>&& refTracker) override;
 
 public:
   /// <summary>

--- a/autowiring/CreationRules.h
+++ b/autowiring/CreationRules.h
@@ -82,7 +82,7 @@ struct crh<construction_strategy::factory_new, T, Args...>
   typedef T TActual;
   
   static_assert(
-    std::is_base_of<Object, T>::value || !has_static_new<T>::value,
+    std::is_base_of<CoreObject, T>::value || !has_static_new<T>::value,
     "If type T provides a static New method, then the constructed type MUST directly inherit Object"
   );
 

--- a/autowiring/ExceptionFilter.h
+++ b/autowiring/ExceptionFilter.h
@@ -2,7 +2,7 @@
 #pragma once
 
 class JunctionBoxBase;
-class Object;
+class CoreObject;
 
 /// <summary>
 /// Implements an exception filter type, invoked when an unhandled exception is thrown
@@ -69,5 +69,5 @@ public:
   /// <remarks>
   /// Implementors can use "throw" with no arguments to trigger a rethrow of the originating exception.
   /// </remarks>
-  virtual void Filter(const JunctionBoxBase* pJunctionBox, Object* pRecipient) {}
+  virtual void Filter(const JunctionBoxBase* pJunctionBox, CoreObject* pRecipient) {}
 };

--- a/autowiring/JunctionBox.h
+++ b/autowiring/JunctionBox.h
@@ -50,14 +50,14 @@ public:
     return (std::lock_guard<std::mutex>)m_lock, !m_st.empty();
   }
 
-  void Add(const JunctionBoxEntry<Object>& rhs) override {
+  void Add(const JunctionBoxEntry<CoreObject>& rhs) override {
     auto casted = rhs.Rebind<T>();
     if(casted)
       // Proposed type is directly one of our receivers
       Add(casted);
   }
 
-  void Remove(const JunctionBoxEntry<Object>& rhs) override {
+  void Remove(const JunctionBoxEntry<CoreObject>& rhs) override {
     auto casted = rhs.Rebind<T>();
     if(casted)
       Remove(casted);
@@ -108,7 +108,7 @@ public:
       catch (...) {
         teardown.push_back(ContextDumbToWeak(currentEvent.m_owner));
 
-        // If T doesn't inherit Object, then we need to cast to a unifying type which does
+        // If T doesn't inherit CoreObject, then we need to cast to a unifying type which does
         typedef typename SelectTypeUnifier<T>::type TActual;
         this->FilterFiringException(currentEvent.m_ptr);
       }

--- a/autowiring/JunctionBoxBase.h
+++ b/autowiring/JunctionBoxBase.h
@@ -1,6 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "Object.h"
+#include "CoreObject.h"
 #include <list>
 #include MEMORY_HEADER
 
@@ -55,6 +55,6 @@ public:
   virtual bool HasListeners(void) const = 0;
 
   // Event attachment and detachment pure virtuals
-  virtual void Add(const JunctionBoxEntry<Object>& rhs) = 0;
-  virtual void Remove(const JunctionBoxEntry<Object>& rhs) = 0;
+  virtual void Add(const JunctionBoxEntry<CoreObject>& rhs) = 0;
+  virtual void Remove(const JunctionBoxEntry<CoreObject>& rhs) = 0;
 };

--- a/autowiring/JunctionBoxManager.h
+++ b/autowiring/JunctionBoxManager.h
@@ -6,7 +6,7 @@
 
 class CoreContext;
 class JunctionBoxBase;
-class Object;
+class CoreObject;
 
 template<class T>
 struct JunctionBoxEntry;
@@ -29,8 +29,8 @@ public:
   /// </summary>
   void Initiate(void);
 
-  void AddEventReceiver(JunctionBoxEntry<Object> receiver);
-  void RemoveEventReceiver(JunctionBoxEntry<Object> pRecvr);
+  void AddEventReceiver(JunctionBoxEntry<CoreObject> receiver);
+  void RemoveEventReceiver(JunctionBoxEntry<CoreObject> pRecvr);
 
 protected:
   // All junction boxes known by this manager:

--- a/autowiring/ObjectPool.h
+++ b/autowiring/ObjectPool.h
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "autowiring_error.h"
-#include "Object.h"
 #include "ObjectPoolMonitor.h"
 #include <cassert>
 #include <vector>

--- a/autowiring/ObjectTraits.h
+++ b/autowiring/ObjectTraits.h
@@ -8,7 +8,7 @@
 #include "BasicThread.h"
 #include "ExceptionFilter.h"
 #include "fast_pointer_cast.h"
-#include "Object.h"
+#include "CoreObject.h"
 #include <typeinfo>
 #include MEMORY_HEADER
 
@@ -23,7 +23,7 @@ struct ObjectTraits {
     stump(SlotInformationStump<T>::s_stump),
     value(value),
     subscriber(MakeAutoFilterDescriptor(value)),
-    pObject(autowiring::fast_pointer_cast<Object>(value)),
+    pCoreObject(autowiring::fast_pointer_cast<CoreObject>(value)),
     pContextMember(autowiring::fast_pointer_cast<ContextMember>(value)),
     pCoreRunnable(autowiring::fast_pointer_cast<CoreRunnable>(value)),
     pBasicThread(autowiring::fast_pointer_cast<BasicThread>(value)),
@@ -33,7 +33,7 @@ struct ObjectTraits {
       [this]{
         for (auto evt = g_pFirstEventEntry; evt; evt = evt->pFlink) {
           auto identifier = evt->NewTypeIdentifier();
-          if (identifier->IsSameAs(pObject.get()))
+          if (identifier->IsSameAs(pCoreObject.get()))
             return true;
         }
         // "T" not found in event registry
@@ -41,11 +41,11 @@ struct ObjectTraits {
       }()
     )
   {
-    // We can instantiate casts to Object here at the point where object traits are being generated
-    (void) autowiring::fast_pointer_cast_initializer<Object, TActual>::sc_init;
-    (void) autowiring::fast_pointer_cast_initializer<TActual, Object>::sc_init;
-    (void) autowiring::fast_pointer_cast_initializer<Object, T>::sc_init;
-    (void) autowiring::fast_pointer_cast_initializer<T, Object>::sc_init;
+    // We can instantiate casts to CoreObject here at the point where object traits are being generated
+    (void) autowiring::fast_pointer_cast_initializer<CoreObject, TActual>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<TActual, CoreObject>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<CoreObject, T>::sc_init;
+    (void) autowiring::fast_pointer_cast_initializer<T, CoreObject>::sc_init;
   }
 
   // The type of the passed pointer
@@ -94,7 +94,7 @@ struct ObjectTraits {
   const AutoFilterDescriptor subscriber;
 
   // There are a lot of interfaces we support, here they all are:
-  const std::shared_ptr<Object> pObject;
+  const std::shared_ptr<CoreObject> pCoreObject;
   const std::shared_ptr<ContextMember> pContextMember;
   const std::shared_ptr<CoreRunnable> pCoreRunnable;
   const std::shared_ptr<BasicThread> pBasicThread;

--- a/autowiring/SharedPointerSlot.h
+++ b/autowiring/SharedPointerSlot.h
@@ -3,7 +3,7 @@
 #include "auto_id.h"
 #include "autowiring_error.h"
 #include "fast_pointer_cast.h"
-#include "Object.h"
+#include "CoreObject.h"
 #include "SlotInformation.h"
 #include MEMORY_HEADER
 #include <stdexcept>
@@ -56,7 +56,7 @@ protected:
 
 public:
   operator bool(void) const { return !empty(); }
-  virtual operator std::shared_ptr<Object>(void) const { return std::shared_ptr<Object>(); }
+  virtual operator std::shared_ptr<CoreObject>(void) const { return std::shared_ptr<CoreObject>(); }
   virtual void* ptr(void) { return nullptr; }
   virtual const void* ptr(void) const { return nullptr; }
 
@@ -89,7 +89,7 @@ public:
   /// Attempts to dynamically assign this slot to the specified object without changing the current type
   /// </summary>
   /// <returns>True if the assignment succeeds</returns>
-  virtual bool try_assign(const std::shared_ptr<Object>& rhs) {
+  virtual bool try_assign(const std::shared_ptr<CoreObject>& rhs) {
     return false;
   }
 
@@ -197,10 +197,10 @@ public:
   }
 
   /// <summary>
-  /// Specialization for the Object base type
+  /// Specialization for the CoreObject base type
   /// </summary>
-  bool operator==(const std::shared_ptr<Object>& rhs) const {
-    return this->operator std::shared_ptr<Object>() == rhs;
+  bool operator==(const std::shared_ptr<CoreObject>& rhs) const {
+    return this->operator std::shared_ptr<CoreObject>() == rhs;
   }
 
   /// <summary>
@@ -344,9 +344,9 @@ struct SharedPointerSlotT<T, true>:
     new (pSpace) SharedPointerSlotT<T, true>(*this);
   }
 
-  bool try_assign(const std::shared_ptr<Object>& rhs) override {
+  bool try_assign(const std::shared_ptr<CoreObject>& rhs) override {
     // Just perform a dynamic cast:
-    auto casted = autowiring::fast_pointer_cast_blind<T, Object>::cast(rhs);
+    auto casted = autowiring::fast_pointer_cast_blind<T, CoreObject>::cast(rhs);
     if (!casted)
       return false;
 
@@ -354,8 +354,8 @@ struct SharedPointerSlotT<T, true>:
     return true;
   }
 
-  virtual operator std::shared_ptr<Object>(void) const override {
-    return autowiring::fast_pointer_cast_blind<Object, T>::cast(SharedPointerSlotT<T, false>::get());
+  virtual operator std::shared_ptr<CoreObject>(void) const override {
+    return autowiring::fast_pointer_cast_blind<CoreObject, T>::cast(SharedPointerSlotT<T, false>::get());
   }
 
   using SharedPointerSlotT<T, false>::operator=;

--- a/autowiring/SlotInformation.h
+++ b/autowiring/SlotInformation.h
@@ -75,7 +75,7 @@ struct use_unifier:
   std::integral_constant<
     bool,
     std::is_class<T>::value &&
-    !std::is_base_of<Object, T>::value
+    !std::is_base_of<CoreObject, T>::value
   >
 {};
 

--- a/autowiring/TypeIdentifier.h
+++ b/autowiring/TypeIdentifier.h
@@ -1,11 +1,11 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "Object.h"
+#include "CoreObject.h"
 #include <typeinfo>
 
 // Checks if an Object* listens to a event T;
 struct TypeIdentifierBase {
-  virtual bool IsSameAs(const Object* obj) = 0;
+  virtual bool IsSameAs(const CoreObject* obj) = 0;
   virtual const std::type_info& Type() = 0;
 };
 
@@ -14,7 +14,7 @@ template<typename T>
 public TypeIdentifierBase
 {
   // true if "obj" is an event receiver for T
-  bool IsSameAs(const Object* obj) override {
+  bool IsSameAs(const CoreObject* obj) override {
     return !!dynamic_cast<const T*>(obj);
   }
   

--- a/autowiring/TypeUnifier.h
+++ b/autowiring/TypeUnifier.h
@@ -1,10 +1,10 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "Object.h"
+#include "CoreObject.h"
 #include RVALUE_HEADER
 #include TYPE_TRAITS_HEADER
 
-class TypeUnifier: public Object {};
+class TypeUnifier: public CoreObject {};
 
 template<class T>
 class TypeUnifierComplex:
@@ -25,11 +25,11 @@ public:
 /// </summary>
 template<
   class T,
-  bool inheritsObject = std::is_base_of<Object, T>::value
+  bool inheritsCoreObject = std::is_base_of<CoreObject, T>::value
 >
 struct SelectTypeUnifier;
 
-// Anyone already inheriting Object can just use Object
+// Anyone already inheriting CoreObject can just use CoreObject
 template<class T>
 struct SelectTypeUnifier<T, true> {
   typedef T type;

--- a/autowiring/fast_pointer_cast.h
+++ b/autowiring/fast_pointer_cast.h
@@ -5,7 +5,7 @@
 #include TYPE_TRAITS_HEADER
 
 class AutoPacketFactory;
-class Object;
+class CoreObject;
 
 namespace autowiring {
   template<class T, class U>

--- a/src/autonet/AutoNetServerImpl.cpp
+++ b/src/autonet/AutoNetServerImpl.cpp
@@ -250,7 +250,7 @@ void AutoNetServerImpl::NewObject(CoreContext& ctxt, const ObjectTraits& object)
     {
       Json::array listenerTypes;
       for(const auto& event : m_EventTypes) {
-        if(event->IsSameAs(object.pObject.get()))
+        if(event->IsSameAs(object.pCoreObject.get()))
           listenerTypes.push_back(autowiring::demangle(event->Type()));
       }
 

--- a/src/autowiring/AutoPacketFactory.cpp
+++ b/src/autowiring/AutoPacketFactory.cpp
@@ -55,7 +55,7 @@ std::shared_ptr<void> AutoPacketFactory::GetInternalOutstanding(void) {
   if (retVal)
     return retVal;
 
-  std::shared_ptr<Object> outstanding = GetOutstanding();
+  std::shared_ptr<CoreObject> outstanding = GetOutstanding();
   retVal = std::shared_ptr<void>(
     (void*)1,
     [this, outstanding] (void*) mutable {
@@ -183,7 +183,7 @@ void AutoPacketFactory::ResetPacketStatistics(void) {
 
 template struct SlotInformationStump<AutoPacketFactory, false>;
 template const std::shared_ptr<AutoPacketFactory>& SharedPointerSlot::as<AutoPacketFactory>(void) const;
-template std::shared_ptr<AutoPacketFactory> autowiring::fast_pointer_cast<AutoPacketFactory, Object>(const std::shared_ptr<Object>& Other);
+template std::shared_ptr<AutoPacketFactory> autowiring::fast_pointer_cast<AutoPacketFactory, CoreObject>(const std::shared_ptr<CoreObject>& Other);
 template class RegType<AutoPacketFactory>;
-template struct autowiring::fast_pointer_cast_blind<Object, AutoPacketFactory>;
-template struct autowiring::fast_pointer_cast_initializer<Object, AutoPacketFactory>;
+template struct autowiring::fast_pointer_cast_blind<CoreObject, AutoPacketFactory>;
+template struct autowiring::fast_pointer_cast_initializer<CoreObject, AutoPacketFactory>;

--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -21,7 +21,7 @@ std::mutex& BasicThread::GetLock(void) {
   return m_state->m_lock;
 }
 
-void BasicThread::DoRun(std::shared_ptr<Object>&& refTracker) {
+void BasicThread::DoRun(std::shared_ptr<CoreObject>&& refTracker) {
   assert(m_running);
 
   // Make our own session current before we do anything else:
@@ -56,7 +56,7 @@ void BasicThread::DoRun(std::shared_ptr<Object>&& refTracker) {
   DoRunLoopCleanup(pusher.Pop(), std::move(refTracker));
 }
 
-void BasicThread::DoRunLoopCleanup(std::shared_ptr<CoreContext>&& ctxt, std::shared_ptr<Object>&& refTracker) {
+void BasicThread::DoRunLoopCleanup(std::shared_ptr<CoreContext>&& ctxt, std::shared_ptr<CoreObject>&& refTracker) {
   // Take a copy of our state condition shared pointer while we still hold a reference to
   // ourselves.  This is the only member out of our collection of members that we actually
   // need to hold a reference to.

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -81,6 +81,8 @@ set(Autowiring_SRCS
   CoreContextStateBlock.h
   CoreJob.cpp
   CoreJob.h
+  CoreObject.cpp
+  CoreObject.h
   CoreRunnable.cpp
   CoreRunnable.h
   CoreThread.cpp
@@ -127,8 +129,6 @@ set(Autowiring_SRCS
   MicroAutoFilter.h
   MicroBolt.h
   NewAutoFilter.h
-  Object.cpp
-  Object.h
   ObjectPool.h
   ObjectPoolMonitor.cpp
   ObjectPoolMonitor.h

--- a/src/autowiring/CoreObject.cpp
+++ b/src/autowiring/CoreObject.cpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
-#include "Object.h"
+#include "CoreObject.h"
 
-Object::Object(void) {}
+CoreObject::CoreObject(void){}
 
-Object::~Object(void) {}
+CoreObject::~CoreObject(void){}

--- a/src/autowiring/CoreRunnable.cpp
+++ b/src/autowiring/CoreRunnable.cpp
@@ -13,11 +13,11 @@ CoreRunnable::CoreRunnable(void):
 
 CoreRunnable::~CoreRunnable(void) {}
 
-const std::shared_ptr<Object>& CoreRunnable::GetOutstanding(void) const {
+const std::shared_ptr<CoreObject>& CoreRunnable::GetOutstanding(void) const {
   return m_outstanding;
 }
 
-bool CoreRunnable::Start(std::shared_ptr<Object> outstanding) {
+bool CoreRunnable::Start(std::shared_ptr<CoreObject> outstanding) {
   std::lock_guard<std::mutex> lk(m_lock);
   if(m_wasStarted || m_outstanding || m_shouldStop)
     // We have already been started or stopped, end here
@@ -46,7 +46,7 @@ void CoreRunnable::Stop(bool graceful) {
   }
 
   if (m_outstanding) {
-    std::shared_ptr<Object> outstanding;
+    std::shared_ptr<CoreObject> outstanding;
     std::lock_guard<std::mutex> lk(m_lock);
 
     // Ensure we do not invoke the outstanding count dtor while holding a lock

--- a/src/autowiring/CoreThread.cpp
+++ b/src/autowiring/CoreThread.cpp
@@ -10,7 +10,7 @@ CoreThread::CoreThread(const char* pName):
 
 CoreThread::~CoreThread(void){}
 
-void CoreThread::DoRunLoopCleanup(std::shared_ptr<CoreContext>&& ctxt, std::shared_ptr<Object>&& refTracker) {
+void CoreThread::DoRunLoopCleanup(std::shared_ptr<CoreContext>&& ctxt, std::shared_ptr<CoreObject>&& refTracker) {
   try {
     // If we are asked to rundown while we still have elements in our dispatch queue,
     // we must try to process them:

--- a/src/autowiring/JunctionBoxBase.cpp
+++ b/src/autowiring/JunctionBoxBase.cpp
@@ -15,7 +15,7 @@ void JunctionBoxBase::TerminateAll(const std::list<std::weak_ptr<CoreContext>>& 
 }
 
 void JunctionBoxBase::FilterFiringException(const AnySharedPointer& pRecipient) const {
-  std::shared_ptr<Object> obj = *pRecipient;
+  std::shared_ptr<CoreObject> obj = *pRecipient;
 
   // Obtain the current context and pass control:
   CoreContext::CurrentContext()->FilterFiringException(this, obj.get());

--- a/src/autowiring/JunctionBoxManager.cpp
+++ b/src/autowiring/JunctionBoxManager.cpp
@@ -36,13 +36,13 @@ void JunctionBoxManager::Initiate(void) {
     q.second->Initiate();
 }
 
-void JunctionBoxManager::AddEventReceiver(JunctionBoxEntry<Object> receiver) {
+void JunctionBoxManager::AddEventReceiver(JunctionBoxEntry<CoreObject> receiver) {
   // Notify all junctionboxes that there is a new event
   for(const auto& q: m_junctionBoxes)
     q.second->Add(receiver);
 }
 
-void JunctionBoxManager::RemoveEventReceiver(JunctionBoxEntry<Object> receiver) {
+void JunctionBoxManager::RemoveEventReceiver(JunctionBoxEntry<CoreObject> receiver) {
   // Notify all compatible senders that we're going away:
   for(const auto& q : m_junctionBoxes)
     q.second->Remove(receiver);

--- a/src/autowiring/test/ContextCleanupTest.cpp
+++ b/src/autowiring/test/ContextCleanupTest.cpp
@@ -74,7 +74,7 @@ TEST_F(ContextCleanupTest, VerifyContextDtor) {
       AutoRequired<SimpleObject> simple;
       objVerifier = simple;
 
-      // Each ObjectTraits instance holds 2 strong references to SimpleObject, as Object type and as ContextMember type.
+      // Each ObjectTraits instance holds 2 strong references to SimpleObject, as CoreObject type and as ContextMember type.
       // One instance is held in CoreContext::m_concreteTypes and the other in the CoreContext::m_typeMemos.
       // Finally, once more reference is held by the shared_ptr<SimpleObject> inheritance of simple.
       EXPECT_EQ(5, objVerifier.use_count()) << "Unexpected number of references to a newly constructed object";

--- a/src/autowiring/test/CoreThreadTest.cpp
+++ b/src/autowiring/test/CoreThreadTest.cpp
@@ -60,7 +60,7 @@ TEST_F(CoreThreadTest, VerifyStartSpam) {
   ctxt->Initiate();
 
   // This shouldn't cause another thread to be created:
-  instance->Start(std::shared_ptr<Object>((Object*) 1, [] (Object*) {}));
+  instance->Start(std::shared_ptr<CoreObject>((CoreObject*) 1, [] (CoreObject*) {}));
 
   EXPECT_FALSE(instance->m_multiHit) << "Thread was run more than once unexpectedly";
 }

--- a/src/autowiring/test/DecoratorTest.cpp
+++ b/src/autowiring/test/DecoratorTest.cpp
@@ -33,7 +33,7 @@ TEST_F(DecoratorTest, VerifyCorrectExtraction) {
 }
 
 TEST_F(DecoratorTest, VerifyEmptyExtraction) {
-  auto obj = std::make_shared<Object>();
+  auto obj = std::make_shared<CoreObject>();
 
   // Should be possible to obtain this value and have it remain valid even after the descriptor is gone
   const AutoFilterDescriptorInput* v = MakeAutoFilterDescriptor(obj).GetAutoFilterInput();

--- a/src/autowiring/test/ExceptionFilterTest.cpp
+++ b/src/autowiring/test/ExceptionFilterTest.cpp
@@ -71,7 +71,7 @@ public:
     }
   }
 
-  virtual void Filter(const JunctionBoxBase* pJunctionBox, Object* pRecipient) override {
+  virtual void Filter(const JunctionBoxBase* pJunctionBox, CoreObject* pRecipient) override {
     m_hit = true;
     try {
       throw;

--- a/src/autowiring/test/FactoryTest.cpp
+++ b/src/autowiring/test/FactoryTest.cpp
@@ -20,7 +20,7 @@ public:
 static_assert(!has_simple_constructor<ClassWithIntegralCtor>::value, "A class without a simple constructor was incorrectly identified as having one");
 
 class ClassWithStaticNew:
-  public Object
+  public CoreObject
 {
 public:
   ClassWithStaticNew(bool madeByFactory = false):
@@ -37,7 +37,7 @@ public:
 
 static_assert(has_simple_constructor<ClassWithStaticNew>::value, "Class with default-argument constructor was not correctly detected as such ");
 static_assert(has_static_new<ClassWithStaticNew>::value, "Class with static allocator was not correctly detected as having one");
-static_assert(!has_static_new<Object>::value, "Static New detected on a class that does not have a static New");
+static_assert(!has_static_new<CoreObject>::value, "Static New detected on a class that does not have a static New");
 
 TEST_F(FactoryTest, VerifyFactoryCall) {
   // Try to create the static new type:


### PR DESCRIPTION
The name `Object` is too generic and could clash with other libraries.