### PR TITLE
Adding constructor detection for speculative output types

### DIFF
--- a/autowiring/auto_arg.h
+++ b/autowiring/auto_arg.h
@@ -89,6 +89,32 @@ class auto_arg<auto_in<T>>:
 {};
 
 /// <summary>
+/// Construction helper for output-by-reference decoration types
+/// </summary>
+/// <remarks>
+/// If an output decoration type T has a constructor of the form T(AutoPacket&), then this constructor should
+/// be invoked preferentially when T is being constructed.
+/// </remarks>
+template<class T, bool has_default = std::is_constructible<T>::value, bool has_autofilter = std::is_constructible<T, AutoPacket&>::value>
+struct auto_arg_ctor_helper;
+
+template<class T, bool has_default>
+struct auto_arg_ctor_helper<T, has_default, true> {
+  static std::shared_ptr<T> arg(AutoPacket& packet) {
+    return std::make_shared<T>(packet);
+  }
+};
+
+template<class T, bool has_default>
+struct auto_arg_ctor_helper<T, has_default, false> {
+  static_assert(has_default, "Cannot speculatively construct an output argument of type T, it doesn't have any available constructors");
+
+  static std::shared_ptr<T> arg(AutoPacket&) {
+    return std::make_shared<T>();
+  }
+};
+
+/// <summary>
 /// Specialization for "T&" ~ auto_out<T>
 /// </summary>
 template<class T>
@@ -114,9 +140,8 @@ public:
   static const bool is_multi = false;
   static const int tshift = 0;
 
-  template<class C>
-  static std::shared_ptr<T> arg(C&) {
-    return std::make_shared<T>();
+  static std::shared_ptr<T> arg(AutoPacket& packet) {
+    return auto_arg_ctor_helper<T>::arg(packet);
   }
 };
 

--- a/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
+++ b/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
@@ -181,3 +181,29 @@ TEST_F(AutoFilterCollapseRulesTest, SharedPtrNoDefaultTest) {
   AutoRequired<AutoPacketFactory> factory;
   auto packet = factory->NewPacket();
 }
+
+class WantsAutoPacketInput {
+public:
+  WantsAutoPacketInput(void):
+    pPacket(nullptr)
+  {}
+
+  WantsAutoPacketInput(AutoPacket& packet):
+    pPacket(&packet)
+  {}
+
+  AutoPacket* pPacket;
+};
+
+class ConstructsWantsAutoPacketInput {
+public:
+  void AutoFilter(AutoPacket& packet, WantsAutoPacketInput& wapi) {
+    ASSERT_EQ(&packet, wapi.pPacket) << "Speculatively constructed output type did not have the correct constructor overload invoked";
+  }
+};
+
+TEST_F(AutoFilterCollapseRulesTest, CtorRequiredWPI) {
+  // This is enough to kick off the AutoFilter above and cause an exception, if one is going to occur
+  AutoRequired<ConstructsWantsAutoPacketInput>();
+  AutoRequired<AutoPacketFactory>()->NewPacket();
+}


### PR DESCRIPTION
If an `AutoFilter` signature contains a by-reference output type of the form `T&`, and `T(AutoPacket&)` can be constructed, then this construction signature will be invoked instead of the default constructor, even when no default constructor exists.  This provides output decorations with a way of obtaining the current packet during construction in order to provide a superior strategy for implementing new AutoFilter argument behaviors.