### PR TITLE
Reduce the template instantiation depth for AutoFilter

### DIFF
--- a/autowiring/AutoFilterDescriptor.h
+++ b/autowiring/AutoFilterDescriptor.h
@@ -293,27 +293,6 @@ public:
   bool operator>=(const AutoFilterDescriptor& rhs) const { return !(*this < rhs);}
 };
 
-template<class T, bool has_autofilter = has_autofilter<T>::value>
-class AutoFilterDescriptorSelect:
-  public std::true_type
-{
-public:
-  AutoFilterDescriptorSelect(const std::shared_ptr<T>& subscriber) :
-    desc(subscriber)
-  {}
-
-  const AutoFilterDescriptor desc;
-};
-
-template<class T>
-class AutoFilterDescriptorSelect<T, false>:
-  public std::false_type
-{
-public:
-  AutoFilterDescriptorSelect(const std::shared_ptr<T>&) {}
-  const AutoFilterDescriptor desc;
-};
-
 /// <summary>
 /// Utility routine to support the creation of an AutoFilterDescriptor from T::AutoFilter
 /// </summary>
@@ -322,7 +301,26 @@ public:
 /// </remarks>
 template<class T>
 AutoFilterDescriptor MakeAutoFilterDescriptor(const std::shared_ptr<T>& ptr) {
-  return std::move(AutoFilterDescriptorSelect<T>(ptr).desc);
+  return MakeAutoFilterDescriptor(ptr, std::integral_constant<bool, has_autofilter<T>::value>());
+}
+
+/// <summary>
+/// Alias for AutoFilterDescriptor(ptr)
+/// </summary>
+template<class T>
+AutoFilterDescriptor MakeAutoFilterDescriptor(const std::shared_ptr<T>& ptr, std::true_type) {
+  return AutoFilterDescriptor(ptr);
+}
+
+/// <summary>
+/// Utility routine to support the creation of an AutoFilterDescriptor from T::AutoFilter
+/// </summary>
+/// <remarks>
+/// This method will return an empty descriptor in the case that T::AutoFilter is not defined
+/// </remarks>
+template<class T>
+AutoFilterDescriptor MakeAutoFilterDescriptor(const std::shared_ptr<T>&, std::false_type) {
+  return AutoFilterDescriptor();
 }
 
 namespace std {

--- a/autowiring/AutoPacketFactory.h
+++ b/autowiring/AutoPacketFactory.h
@@ -98,7 +98,7 @@ public:
   /// </summary>
   template<class T>
   void AddSubscriber(const std::shared_ptr<T>& rhs) {
-    AddSubscriber(MakeAutoFilterDescriptor<T>(rhs));
+    AddSubscriber(AutoFilterDescriptor(rhs));
   }
 
   /// <summary>

--- a/autowiring/auto_tuple.h
+++ b/autowiring/auto_tuple.h
@@ -65,10 +65,9 @@ namespace autowiring {
 
     tuple(void) = default;
 
-    template<class T, class... Ts>
-    tuple(T&& arg, Ts&&... args) :
-      tuple<Args...>(std::forward<Ts&&>(args)...),
-      tuple_value<sizeof...(Ts), Arg>(std::forward<T&&>(arg))
+    tuple(Arg&& arg, Args&&... args) :
+      tuple<Args...>(std::forward<Args>(args)...),
+      tuple_value<sizeof...(Args), Arg>(std::forward<Arg&&>(arg))
     {}
 
     template<class OtherT, class... OtherTs>

--- a/src/autowiring/test/DecoratorTest.cpp
+++ b/src/autowiring/test/DecoratorTest.cpp
@@ -22,7 +22,7 @@ TEST_F(DecoratorTest, VerifyCorrectExtraction) {
 
   // Run our prop extractor based on a known decorator:
   AutoRequired<FilterA> filterA;
-  AutoFilterDescriptor desc = MakeAutoFilterDescriptor(filterA);
+  AutoFilterDescriptor desc(static_cast<std::shared_ptr<FilterA>&>(filterA));
   for(const AutoFilterDescriptorInput* cur = desc.GetAutoFilterInput(); *cur; cur++)
     v.push_back(cur->ti);
   ASSERT_EQ(2UL, v.size()) << "Extracted an insufficient number of types from a known filter function";


### PR DESCRIPTION
Should make it easier to understand template instantiation errors arising due to bad AutoFilter arguments.