### PR TITLE
Refactoring AutoNetTransport concept

### DIFF
--- a/autowiring/AutoNetServer.h
+++ b/autowiring/AutoNetServer.h
@@ -8,18 +8,42 @@
 #include STL_UNORDERED_MAP
 #include FUNCTIONAL_HEADER
 
-class AutoNetTransport {
+class AutoNetTransportHandler {
 public:
   typedef std::weak_ptr<void> connection_hdl;
-  
+
+  virtual void OnOpen(connection_hdl handle) = 0;
+  virtual void OnClose(connection_hdl handle) = 0;
+  virtual void OnMessage(connection_hdl handle, const std::string& message) = 0;
+};
+
+/// <summary>
+/// Represents a transport implementation that carries AutoNet data to a visualizer client
+/// </summary>
+class AutoNetTransport {
+public:
+  /// <summary>
+  /// Causes the transport to begin servicing user requests
+  /// </summary>
   virtual void Start(void) = 0;
+
+  /// <summary>
+  /// Causes the transport to stop servicing user requests, also shuts down any active connections
+  /// </summary>
   virtual void Stop(void) = 0;
+
+  /// <summary>
+  /// Transmits the specified string message to the remote host
+  /// </summary>
+  virtual void Send(AutoNetTransportHandler::connection_hdl hdl, const std::string& msg) = 0;
   
-  virtual void Send(connection_hdl hdl, const std::string& msg) = 0;
-  
-  virtual void OnOpen(std::function<void(connection_hdl)> fn) = 0;
-  virtual void OnClose(std::function<void(connection_hdl)> fn) = 0;
-  virtual void OnMessage(std::function<void(connection_hdl, std::string)> fn) = 0;
+  /// <summary>
+  /// Assigns the handler for operations occuring on this transport
+  /// </summary>
+  /// <remarks>
+  /// This routine accepts a nullptr argument, the effect will be to clear the current handler
+  /// </remarks>
+  virtual void SetTransportHandler(std::shared_ptr<AutoNetTransportHandler> handler) = 0;
 };
 
 class AutoNetServer;

--- a/src/autonet/AutoNetTransportHttp.cpp
+++ b/src/autonet/AutoNetTransportHttp.cpp
@@ -1,0 +1,68 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "AutoNetTransportHttp.hpp"
+
+AutoNetTransportHttp::AutoNetTransportHttp(void) :
+  m_port(8000)
+{
+  m_server.init_asio();
+  m_server.set_access_channels(websocketpp::log::alevel::none);
+  m_server.set_error_channels(websocketpp::log::elevel::none);
+
+
+  m_server.set_open_handler([this](connection_hdl hdl) {
+    auto handler =
+      (
+        (std::lock_guard<std::mutex>)m_lock,
+        m_connections.insert(hdl),
+        m_handler
+      );
+    if (m_handler)
+      m_handler->OnOpen(hdl);
+  });
+
+  m_server.set_close_handler([this](connection_hdl hdl) {
+    auto handler =
+      (
+        (std::lock_guard<std::mutex>)m_lock,
+        m_connections.erase(hdl),
+        m_handler
+      );
+
+    m_handler->OnClose(hdl);
+  });
+
+  m_server.set_message_handler([this](websocketpp::connection_hdl hdl, message_ptr message){
+    auto handler = ((std::lock_guard<std::mutex>)m_lock, m_handler);
+
+    std::string msg = message->get_payload();
+    handler->OnMessage(hdl, msg);
+  });
+}
+
+AutoNetTransportHttp::~AutoNetTransportHttp(void)
+{
+}
+
+void AutoNetTransportHttp::Start(void) {
+  m_server.listen(m_port);
+  m_server.start_accept();
+  m_server.run();
+}
+
+void AutoNetTransportHttp::Stop(void) {
+  if (m_server.is_listening())
+    m_server.stop_listening();
+
+  for (auto& conn : m_connections)
+    m_server.close(conn, websocketpp::close::status::normal, "closed");
+}
+
+void AutoNetTransportHttp::Send(connection_hdl hdl, const std::string& msg){
+  m_server.send(hdl, msg, websocketpp::frame::opcode::text);
+}
+
+void AutoNetTransportHttp::SetTransportHandler(std::shared_ptr<AutoNetTransportHandler> handler) {
+  std::lock_guard<std::mutex> lk(m_lock);
+  m_handler = handler;
+}

--- a/src/autonet/AutoNetTransportHttp.hpp
+++ b/src/autonet/AutoNetTransportHttp.hpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "AutoNetServer.h"
+#include MEMORY_HEADER
+#include MUTEX_HEADER
+#include <array>
+#include <set>
+
+// Need to redefine this namespace so we don't create linker problems.  Such problems may be
+// created if our static library is imported by another project that uses an incompatible
+// version of websocketpp.
+#define websocketpp websocketpp_autonet
+#include <websocketpp/server.hpp>
+#include <websocketpp/config/asio_no_tls.hpp>
+
+/// <summary>
+/// Default transport layer for AutoNet
+/// </summary>
+/// <remarks>
+/// This transport implementation provides a very simple unsecure HTTP server implementation
+/// </remarks>
+class AutoNetTransportHttp:
+  public AutoNetTransport
+{
+public:
+  typedef std::weak_ptr<void> connection_hdl;
+
+  AutoNetTransportHttp();
+  virtual ~AutoNetTransportHttp();
+
+  void Start(void) override;
+  void Stop(void) override;
+
+  void Send(connection_hdl hdl, const std::string& msg);
+  void SetTransportHandler(std::shared_ptr<AutoNetTransportHandler> handler) override;
+
+private:
+  typedef websocketpp::server<websocketpp::config::asio> t_server;
+  typedef t_server::message_ptr message_ptr;
+
+  // Transport handler reference
+  std::shared_ptr<AutoNetTransportHandler> m_handler;
+
+  std::mutex m_lock;
+  std::set<connection_hdl, std::owner_less<connection_hdl>> m_connections;
+  int m_port;
+  t_server m_server;
+}; 

--- a/src/autonet/CMakeLists.txt
+++ b/src/autonet/CMakeLists.txt
@@ -13,6 +13,8 @@ set(AutoNet_SRCS
   AutoNetServer.h
   AutoNetServerImpl.cpp
   AutoNetServerImpl.hpp
+  AutoNetTransportHttp.hpp
+  AutoNetTransportHttp.cpp
   ${PROJECT_SOURCE_DIR}/contrib/json11/json11.cpp
   ${PROJECT_SOURCE_DIR}/contrib/json11/json11.hpp
 )


### PR DESCRIPTION
Better to have the transport in a separate file if it's a separate class.  Also flipped a link that was making use of std::function in preference of an explicit interface, which seems to be more appropriate in this case.