### PR TITLE
Fix CoreContext initiation

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -455,7 +455,7 @@ protected:
   /// <summary>
   /// Invoked by a parent context when the parent has transitioned to the Running state
   /// </summary>
-  void TryTransitionChildrenToRunState(void);
+  void TryTransitionChildrenState(void);
 
   /// <summary>
   /// Registers a factory _function_, a lambda which is capable of constructing decltype(fn())

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -237,6 +237,45 @@ TEST_F(CoreContextTest, InitiateCausesDelayedHold) {
 TEST_F(CoreContextTest, InitiateOrder) {
   AutoCurrentContext testCtxt;
   testCtxt->Initiate();
+  // Initiate inner to outer
+  {
+    auto outerCtxt = testCtxt->Create<void>();
+    auto middleCtxt = outerCtxt->Create<void>();
+    auto innerCtxt = middleCtxt->Create<void>();
+    
+    innerCtxt->Initiate();
+    middleCtxt->Initiate();
+    outerCtxt->Initiate();
+    
+    EXPECT_TRUE(outerCtxt->IsRunning()) << "Context not running after begin initiated";
+    EXPECT_TRUE(middleCtxt->IsRunning()) << "Context not running after begin initiated";
+    EXPECT_TRUE(innerCtxt->IsRunning()) << "Context not running after begin initiated";
+    
+    innerCtxt->SignalShutdown(true);
+    middleCtxt->SignalShutdown(true);
+    outerCtxt->SignalShutdown(true);
+  }
+  
+  // Initiate outer to inner
+  {
+    auto outerCtxt = testCtxt->Create<void>();
+    auto middleCtxt = outerCtxt->Create<void>();
+    auto innerCtxt = middleCtxt->Create<void>();
+    
+    outerCtxt->Initiate();
+    middleCtxt->Initiate();
+    innerCtxt->Initiate();
+    
+    EXPECT_TRUE(outerCtxt->IsRunning()) << "Context not running after begin initiated";
+    EXPECT_TRUE(middleCtxt->IsRunning()) << "Context not running after begin initiated";
+    EXPECT_TRUE(innerCtxt->IsRunning()) << "Context not running after begin initiated";
+    
+    innerCtxt->SignalShutdown(true);
+    middleCtxt->SignalShutdown(true);
+    outerCtxt->SignalShutdown(true);
+  }
+  
+  // Initiate middle, inner, then outer
   {
     auto outerCtxt = testCtxt->Create<void>();
     auto middleCtxt = outerCtxt->Create<void>();
@@ -246,30 +285,79 @@ TEST_F(CoreContextTest, InitiateOrder) {
     innerCtxt->Initiate();
     outerCtxt->Initiate();
     
-    EXPECT_TRUE(outerCtxt->IsRunning());
-    EXPECT_TRUE(middleCtxt->IsRunning());
-    EXPECT_TRUE(innerCtxt->IsRunning());
+    EXPECT_TRUE(outerCtxt->IsRunning()) << "Context not running after begin initiated";
+    EXPECT_TRUE(middleCtxt->IsRunning()) << "Context not running after begin initiated";
+    EXPECT_TRUE(innerCtxt->IsRunning()) << "Context not running after begin initiated";
     
     outerCtxt->SignalShutdown(true);
     middleCtxt->SignalShutdown(true);
     innerCtxt->SignalShutdown(true);
   }
-  
+}
+
+TEST_F(CoreContextTest, InitiateMultipleChildren) {
+  AutoCurrentContext outerCtxt;
+  // Initiate all children
   {
-    auto outerCtxt = testCtxt->Create<void>();
-    auto middleCtxt = outerCtxt->Create<void>();
-    auto innerCtxt = middleCtxt->Create<void>();
-    
-    innerCtxt->Initiate();
-    middleCtxt->Initiate();
-    outerCtxt->Initiate();
-    
-    EXPECT_TRUE(outerCtxt->IsRunning());
-    EXPECT_TRUE(middleCtxt->IsRunning());
-    EXPECT_TRUE(innerCtxt->IsRunning());
-    
-    innerCtxt->SignalShutdown(true);
-    middleCtxt->SignalShutdown(true);
-    outerCtxt->SignalShutdown(true);
+    auto testCtxt = outerCtxt->Create<void>();
+    auto child1 = testCtxt->Create<void>();
+    auto child2 = testCtxt->Create<void>();
+    auto child3 = testCtxt->Create<void>();
+
+    child1->Initiate();
+    child2->Initiate();
+    child3->Initiate();
+
+    testCtxt->Initiate();
+
+    EXPECT_TRUE(child1->IsRunning());
+    EXPECT_TRUE(child2->IsRunning());
+    EXPECT_TRUE(child3->IsRunning());
+
+    child1->SignalShutdown(true);
+    child2->SignalShutdown(true);
+    child3->SignalShutdown(true);
+  }
+
+  // Don't initiate middle child
+  {
+    auto testCtxt = outerCtxt->Create<void>();
+    auto child1 = testCtxt->Create<void>();
+    auto child2 = testCtxt->Create<void>();
+    auto child3 = testCtxt->Create<void>();
+
+    child1->Initiate();
+    child3->Initiate();
+
+    testCtxt->Initiate();
+
+    EXPECT_TRUE(child1->IsRunning());
+    EXPECT_FALSE(child2->IsInitiated());
+    EXPECT_TRUE(child3->IsRunning());
+
+    child1->SignalShutdown(true);
+    child2->SignalShutdown(true);
+    child3->SignalShutdown(true);
+  }
+
+  // Don't initiate middle child and initiate parent first
+  {
+    auto testCtxt = outerCtxt->Create<void>();
+    auto child1 = testCtxt->Create<void>();
+    auto child2 = testCtxt->Create<void>();
+    auto child3 = testCtxt->Create<void>();
+
+    testCtxt->Initiate();
+
+    child1->Initiate();
+    child3->Initiate();
+
+    EXPECT_TRUE(child1->IsRunning());
+    EXPECT_FALSE(child2->IsInitiated());
+    EXPECT_TRUE(child3->IsRunning());
+
+    child1->SignalShutdown(true);
+    child2->SignalShutdown(true);
+    child3->SignalShutdown(true);
   }
 }

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -251,8 +251,6 @@ TEST_F(CoreContextTest, InitiateOrder) {
     EXPECT_TRUE(middleCtxt->IsRunning()) << "Context not running after begin initiated";
     EXPECT_TRUE(innerCtxt->IsRunning()) << "Context not running after begin initiated";
     
-    innerCtxt->SignalShutdown(true);
-    middleCtxt->SignalShutdown(true);
     outerCtxt->SignalShutdown(true);
   }
   
@@ -270,8 +268,6 @@ TEST_F(CoreContextTest, InitiateOrder) {
     EXPECT_TRUE(middleCtxt->IsRunning()) << "Context not running after begin initiated";
     EXPECT_TRUE(innerCtxt->IsRunning()) << "Context not running after begin initiated";
     
-    innerCtxt->SignalShutdown(true);
-    middleCtxt->SignalShutdown(true);
     outerCtxt->SignalShutdown(true);
   }
   
@@ -290,64 +286,59 @@ TEST_F(CoreContextTest, InitiateOrder) {
     EXPECT_TRUE(innerCtxt->IsRunning()) << "Context not running after begin initiated";
     
     outerCtxt->SignalShutdown(true);
-    middleCtxt->SignalShutdown(true);
-    innerCtxt->SignalShutdown(true);
   }
 }
 
 TEST_F(CoreContextTest, InitiateMultipleChildren) {
-  AutoCurrentContext outerCtxt;
+  AutoCurrentContext testCtxt;
+  testCtxt->Initiate();
   // Initiate all children
   {
-    auto testCtxt = outerCtxt->Create<void>();
-    auto child1 = testCtxt->Create<void>();
-    auto child2 = testCtxt->Create<void>();
-    auto child3 = testCtxt->Create<void>();
+    auto outerCtxt = testCtxt->Create<void>();
+    auto child1 = outerCtxt->Create<void>();
+    auto child2 = outerCtxt->Create<void>();
+    auto child3 = outerCtxt->Create<void>();
 
     child1->Initiate();
     child2->Initiate();
     child3->Initiate();
 
-    testCtxt->Initiate();
+    outerCtxt->Initiate();
 
     EXPECT_TRUE(child1->IsRunning());
     EXPECT_TRUE(child2->IsRunning());
     EXPECT_TRUE(child3->IsRunning());
 
-    child1->SignalShutdown(true);
-    child2->SignalShutdown(true);
-    child3->SignalShutdown(true);
+    outerCtxt->SignalShutdown(true);
   }
 
   // Don't initiate middle child
   {
-    auto testCtxt = outerCtxt->Create<void>();
-    auto child1 = testCtxt->Create<void>();
-    auto child2 = testCtxt->Create<void>();
-    auto child3 = testCtxt->Create<void>();
+    auto outerCtxt = testCtxt->Create<void>();
+    auto child1 = outerCtxt->Create<void>();
+    auto child2 = outerCtxt->Create<void>();
+    auto child3 = outerCtxt->Create<void>();
 
     child1->Initiate();
     child3->Initiate();
 
-    testCtxt->Initiate();
+    outerCtxt->Initiate();
 
     EXPECT_TRUE(child1->IsRunning());
     EXPECT_FALSE(child2->IsInitiated());
     EXPECT_TRUE(child3->IsRunning());
 
-    child1->SignalShutdown(true);
-    child2->SignalShutdown(true);
-    child3->SignalShutdown(true);
+    outerCtxt->SignalShutdown(true);
   }
 
   // Don't initiate middle child and initiate parent first
   {
-    auto testCtxt = outerCtxt->Create<void>();
-    auto child1 = testCtxt->Create<void>();
-    auto child2 = testCtxt->Create<void>();
-    auto child3 = testCtxt->Create<void>();
+    auto outerCtxt = testCtxt->Create<void>();
+    auto child1 = outerCtxt->Create<void>();
+    auto child2 = outerCtxt->Create<void>();
+    auto child3 = outerCtxt->Create<void>();
 
-    testCtxt->Initiate();
+    outerCtxt->Initiate();
 
     child1->Initiate();
     child3->Initiate();
@@ -356,8 +347,6 @@ TEST_F(CoreContextTest, InitiateMultipleChildren) {
     EXPECT_FALSE(child2->IsInitiated());
     EXPECT_TRUE(child3->IsRunning());
 
-    child1->SignalShutdown(true);
-    child2->SignalShutdown(true);
-    child3->SignalShutdown(true);
+    outerCtxt->SignalShutdown(true);
   }
 }


### PR DESCRIPTION
`CoreContext` wasn't correctly transitioning children to the `CanRun` state. Also, there were problems when only a subset of children were initiated