### PR TITLE
Fix chrono windows

### DIFF
--- a/autowiring/C++11/chrono_with_profiling_clock.h
+++ b/autowiring/C++11/chrono_with_profiling_clock.h
@@ -1,0 +1,60 @@
+#pragma once
+#if STL11_ALLOWED
+#define CHRONO_HEADER <chrono>
+#else
+#define CHRONO_HEADER <autowiring/C++11/boost_chrono.h>
+#endif
+
+//This solution taken from http://stackoverflow.com/questions/8386128/how-to-get-the-precision-of-high-resolution-clock
+//Hopefully it will be able to be depricated when VS2015 hits.
+
+#if defined(_MSC_VER) && _MSC_VER < 1900 //high_resolution_clock is broken on all MSVC versions below 2015.
+union _LARGE_INTEGER;
+typedef _LARGE_INTEGER LARGE_INTEGER;
+
+extern "C" {
+  __declspec(dllimport)
+    int
+    __stdcall
+    QueryPerformanceCounter(LARGE_INTEGER * lpPerformanceCount);
+
+  __declspec(dllimport)
+    int
+    __stdcall
+    QueryPerformanceFrequency(LARGE_INTEGER * lpFrequency);
+}
+
+namespace {
+  const long long g_Frequency = []()
+  {
+    int64_t frequency;
+    QueryPerformanceFrequency(&reinterpret_cast<LARGE_INTEGER&>(frequency));
+    return frequency;
+  }();
+}
+
+namespace std {
+  namespace chrono{
+    struct profiling_clock
+    {
+      typedef long long                           rep;
+      typedef nano                                period;
+      typedef duration<rep, period>               duration;
+      typedef time_point<profiling_clock>         time_point;
+      static const bool is_steady = true;
+
+      static time_point now() {
+        int64_t count;
+        QueryPerformanceCounter(&reinterpret_cast<LARGE_INTEGER&>(count));
+        return time_point(duration(count * static_cast<rep>(period::den) / g_Frequency));
+      }
+    };
+  }
+}
+#else
+namespace std {
+  namespace chrono {
+    typedef high_resolution_clock profiling_clock;
+  }
+}
+#endif

--- a/autowiring/C++11/chrono_with_profiling_clock.h
+++ b/autowiring/C++11/chrono_with_profiling_clock.h
@@ -1,8 +1,8 @@
 #pragma once
 #if STL11_ALLOWED
-#define CHRONO_HEADER <chrono>
+#include <chrono>
 #else
-#define CHRONO_HEADER <autowiring/C++11/boost_chrono.h>
+#include <autowiring/C++11/boost_chrono.h>
 #endif
 
 //This solution taken from http://stackoverflow.com/questions/8386128/how-to-get-the-precision-of-high-resolution-clock

--- a/autowiring/C++11/chrono_with_profiling_clock.h
+++ b/autowiring/C++11/chrono_with_profiling_clock.h
@@ -1,4 +1,6 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+
 #if STL11_ALLOWED
 #include <chrono>
 #else

--- a/autowiring/C++11/cpp11.h
+++ b/autowiring/C++11/cpp11.h
@@ -304,11 +304,7 @@
  /**
  * Chrono
  */
-#if STL11_ALLOWED
-  #define CHRONO_HEADER <chrono>
-#else
-  #define CHRONO_HEADER <autowiring/C++11/boost_chrono.h>
-#endif
+#define CHRONO_HEADER <autowiring/C++11/chrono_with_profiling_clock.h>
 
  /**
  * Utility


### PR DESCRIPTION
Modifies CHRONO_HEADER to point at a custom .h file which will include the appropriate *real* chrono header as before and also define an extension class, profiling_clock, which is a custom and correctly working clock in MSVC2013 and a typedef of high_resolution_clock on all other platforms.  Actually tested as a viable solution this time!