### PR TITLE
Eliminating deprecated RemoveSatCounter routine

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -91,11 +91,6 @@ protected:
   void AddSatCounter(SatCounter& satCounter);
 
   /// <summary>
-  /// Removes all AutoFilter argument information for a recipient
-  /// </summary>
-  void RemoveSatCounter(const SatCounter& satCounter);
-
-  /// <summary>
   /// Marks the specified entry as being unsatisfiable
   /// </summary>
   void MarkUnsatisfiable(const DecorationKey& key);

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -121,26 +121,6 @@ void AutoPacket::AddSatCounter(SatCounter& satCounter) {
   }
 }
 
-void AutoPacket::RemoveSatCounter(const SatCounter& satCounter) {
-  for(auto pCur = satCounter.GetAutoFilterInput(); *pCur; pCur++) {
-    DecorationKey key(*pCur->ti, pCur->tshift);
-
-    DecorationDisposition* entry = &m_decorations[key];
-
-    // Decide what to do with this entry:
-    if (pCur->is_input) {
-      assert(!entry->m_subscribers.empty());
-      assert(&satCounter == entry->m_subscribers.back());
-      entry->m_subscribers.pop_back();
-    }
-    if (pCur->is_output) {
-      assert(!entry->m_publishers.empty());
-      assert(&satCounter == entry->m_publishers.back());
-      entry->m_publishers.pop_back();
-    }
-  }
-}
-
 void AutoPacket::MarkUnsatisfiable(const DecorationKey& key) {
   // Perform unsatisfaction logic
   if (key.tshift) {


### PR DESCRIPTION
Routine was last used back when `ObjectPool` was being used to pool `AutoPacket` instances; `AutoPacket::Initialize` was being used to restore the packet to its default state.