### PR TITLE
Enhance behavior of Unsatisfiable to have some predictable side-effects

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -591,7 +591,7 @@ template<class T>
 bool AutoPacket::Get(const std::shared_ptr<T>*& out) const {
   static_assert(!std::is_const<T>::value, "Overload resolution selected an incorrect version of Get");
 
-  const DecorationDisposition* pDisposition = GetDisposition(DecorationKey(auto_id<T>::key()));
+  const DecorationDisposition* pDisposition = GetDisposition(DecorationKey(auto_id<T>::key(), true, 0));
   if (!pDisposition || pDisposition->m_decorations.size() != 1) {
     out = nullptr;
     return false;

--- a/autowiring/SharedPointerSlot.h
+++ b/autowiring/SharedPointerSlot.h
@@ -135,16 +135,20 @@ public:
   /// </remarks>
   virtual void reset(void) {}
 
+  template<class T>
+  static const std::shared_ptr<T>& null(void) {
+    static const std::shared_ptr<T> s_empty;
+    return s_empty;
+  }
+
   /// <summary>
   /// Attempts to coerce this type to the specified type
   /// </summary>
   template<class T>
   const std::shared_ptr<T>& as(void) const {
-    static const std::shared_ptr<T> s_empty;
-
     if (type() == typeid(void))
       // This is allowed, we always permit null to be cast to the requested type.
-      return s_empty;
+      return null<T>();
 
     if (type() != typeid(auto_id<T>))
       throw std::runtime_error("Attempted to obtain a shared pointer for an unrelated type");

--- a/autowiring/auto_arg.h
+++ b/autowiring/auto_arg.h
@@ -76,7 +76,10 @@ public:
 
   template<class C>
   static const std::shared_ptr<const T>& arg(C& packet) {
-    return packet.template GetShared<T>();
+    auto retVal = packet.template GetShared<T>();
+    if (!retVal)
+      return SharedPointerSlot::null<const T>();
+    return *retVal;
   }
 };
 
@@ -203,7 +206,7 @@ public:
 
   static const bool is_input = true;
   static const bool is_output = false;
-  static const bool is_shared = false;
+  static const bool is_shared = true;
   static const bool is_multi = false;
   static const int tshift = N;
 

--- a/src/autowiring/AutoPacketGraph.cpp
+++ b/src/autowiring/AutoPacketGraph.cpp
@@ -81,7 +81,7 @@ void AutoPacketGraph::AutoFilter(AutoPacket& packet) {
   packet.AddTeardownListener([this, &packet] () {
     for (auto& cur : packet.GetDecorations()) {
       auto& decoration = cur.second;
-      auto type = &decoration.GetKey().ti;
+      auto type = cur.first.ti;
 
       for (auto& publisher : decoration.m_publishers) {
         if (!publisher->remaining) {

--- a/src/autowiring/AutoPacketInternal.cpp
+++ b/src/autowiring/AutoPacketInternal.cpp
@@ -21,16 +21,14 @@ void AutoPacketInternal::Initialize(bool isFirstPacket) {
   // Find all subscribers with no required or optional arguments:
   std::vector<SatCounter*> callCounters;
   for (auto* satCounter = m_firstCounter; satCounter; satCounter = satCounter->flink) {
-    
     // Prime the satisfaction graph for element:
     AddSatCounter(*satCounter);
-    
     if (!satCounter->remaining)
       callCounters.push_back(satCounter);
   }
   
   // Mark timeshifted decorations as unsatisfiable on the first packet
-  if (isFirstPacket) {
+  if (isFirstPacket)
     for (auto& dec : m_decorations) {
       auto& key = dec.first;
       if (key.tshift) {
@@ -38,7 +36,6 @@ void AutoPacketInternal::Initialize(bool isFirstPacket) {
         MarkSuccessorsUnsatisfiable(key);
       }
     }
-  }
 
   // Call all subscribers with no required or optional arguments:
   // NOTE: This may result in decorations that cause other subscribers to be called.
@@ -46,7 +43,17 @@ void AutoPacketInternal::Initialize(bool isFirstPacket) {
     call->GetCall()(call->GetAutoFilter(), *this);
 
   // First-call indicated by argumument type AutoPacket&:
-  UpdateSatisfaction(DecorationKey(typeid(auto_arg<AutoPacket&>::id_type)));
+  for (bool is_shared : {false, true}) {
+    std::unique_lock<std::mutex> lk(m_lock);
+
+    // Don't modify the decorations set if nobody expects an AutoPacket input
+    auto q = m_decorations.find(DecorationKey(typeid(auto_arg<AutoPacket&>::id_type), is_shared, 0));
+    if (q == m_decorations.end())
+      continue;
+
+    q->second.m_state = DispositionState::Satisfied;
+    UpdateSatisfactionUnsafe(std::move(lk), q->second);
+  }
 }
 
 std::shared_ptr<AutoPacketInternal> AutoPacketInternal::SuccessorInternal(void) {

--- a/src/autowiring/test/ArgumentTypeTest.cpp
+++ b/src/autowiring/test/ArgumentTypeTest.cpp
@@ -87,7 +87,7 @@ TEST_F(ArgumentTypeTest, TestAutoIn) {
 
   // Deduced Type
   const auto& arg = t_argShared::arg(*packet);
-  ASSERT_TRUE(arg.unique()) << "AutoPacket should store the sole shared pointer reference";
+  ASSERT_EQ(2UL, arg.use_count()) << "AutoPacket should store exactly two shared pointer references";
 }
 
 TEST_F(ArgumentTypeTest, TestAutoOut) {
@@ -113,6 +113,6 @@ TEST_F(ArgumentTypeTest, TestAutoOut) {
 
   const Argument<0>* arg = nullptr;
   ASSERT_TRUE(packet->Get(arg)) << "Missing output";
-  ASSERT_EQ(a0, packet->GetShared<Argument<0>>()) << "Shared pointer copied incorrectly";
+  ASSERT_EQ(a0, *packet->GetShared<Argument<0>>()) << "Shared pointer copied incorrectly";
   ASSERT_EQ(1, arg->i) << "Output was not copied";
 }

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -45,6 +45,7 @@ set(AutowiringTest_SRCS
   SelfSelectingFixtureTest.cpp
   TeardownNotifierTest.cpp
   TypeRegistryTest.cpp
+  SatisfiabilityTest.cpp
   ScopeTest.cpp
   SnoopTest.cpp
   TupleTest.cpp

--- a/src/autowiring/test/DecoratorTest.cpp
+++ b/src/autowiring/test/DecoratorTest.cpp
@@ -68,6 +68,8 @@ TEST_F(DecoratorTest, VerifySimplePacketDecoration) {
 }
 
 TEST_F(DecoratorTest, VerifyDecoratorAwareness) {
+  auto filter = [](const Decoration<0>& zero, const Decoration<1>& one) {};
+
   // Create a packet while the factory has no subscribers:
   AutoRequired<AutoPacketFactory> factory;
   auto packet1 = factory->NewPacket();
@@ -76,17 +78,17 @@ TEST_F(DecoratorTest, VerifyDecoratorAwareness) {
   ASSERT_FALSE(packet1->HasSubscribers<Decoration<0>>()) << "Subscription exists where one should not have existed";
 
   // Create another packet where a subscriber exists:
-  AutoRequired<FilterA> filterA;
+  *factory += filter;
   auto packet2 = factory->NewPacket();
 
   // Verify the first packet still does not have subscriptions:
-  ASSERT_THROW(packet1->GetSatisfaction<FilterA>(), autowiring_error) << "Subscription was incorrectly, retroactively added to a packet";
+  ASSERT_THROW(packet1->GetSatisfaction<decltype(filter)>(), autowiring_error) << "Subscription was incorrectly, retroactively added to a packet";
   ASSERT_FALSE(packet1->HasSubscribers<Decoration<0>>()) << "Subscription was incorrectly, retroactively added to a packet";
   ASSERT_EQ(0UL, packet1->GetDecorationTypeCount()) << "Subscription was incorrectly, retroactively added to a packet";
   ASSERT_FALSE(packet1->HasSubscribers<Decoration<0>>()) << "Subscription was incorrectly, retroactively added to a packet";
 
   // Verify the second one does:
-  ASSERT_THROW(packet2->GetSatisfaction<FilterA>(), autowiring_error) << "Packet lacked an expected subscription";
+  ASSERT_THROW(packet2->GetSatisfaction<decltype(filter)>(), autowiring_error) << "Packet lacked an expected subscription";
   ASSERT_EQ(2UL, packet2->GetDecorationTypeCount()) << "Incorrect count of expected decorations";
   ASSERT_TRUE(packet2->HasSubscribers<Decoration<0>>()) << "Packet lacked an expected subscription";
 }

--- a/src/autowiring/test/SatisfiabilityTest.cpp
+++ b/src/autowiring/test/SatisfiabilityTest.cpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include <autowiring/autowiring.h>
+#include "TestFixtures/Decoration.hpp"
+
+class SatisfiabilityTest:
+  public testing::Test
+{
+public:
+  SatisfiabilityTest(void) {
+    AutoCurrentContext()->Initiate();
+  }
+
+  AutoRequired<AutoPacketFactory> factory;
+};
+
+TEST_F(SatisfiabilityTest, MarkUnsatisfiableCalls) {
+  auto packet = factory->NewPacket();
+
+  // This filter shouldn't be called, because it expects a reference as an input
+  bool bRefCalled = false;
+  *packet += [&bRefCalled](const Decoration<0>& dec) { bRefCalled = true; };
+
+  // This one should be called because the input is a shared pointer
+  bool bSharedPtrCalled = false;
+  *packet += [&bSharedPtrCalled](std::shared_ptr<const Decoration<0>> dec) { bSharedPtrCalled = true; };
+
+  packet->Unsatisfiable<Decoration<0>>();
+
+  ASSERT_FALSE(bRefCalled) << "Reference version should not have been called";
+  ASSERT_TRUE(bSharedPtrCalled) << "Shared pointer version should have been called as a result of Unsatisfiable";
+}


### PR DESCRIPTION
If an `AutoFilter` accepts an `std::shared_ptr<const T>`, it should be invoked if `MarkUnsatisfiable` is called.  If it simply accepts `const T&`, then it should not be called.