### PR TITLE
Fix factory New with move-only parameters

### DIFF
--- a/autowiring/has_static_new.h
+++ b/autowiring/has_static_new.h
@@ -11,7 +11,7 @@
 template<class T, class Selector, class... Args>
 struct has_well_formed_static_new {
   static const bool value = std::is_convertible<
-    decltype(T::New(*(typename std::remove_reference<Args>::type*)nullptr...)),
+    decltype(T::New(std::forward<Args>(*(typename std::remove_reference<Args>::type*)nullptr)...)),
     T*
   >::value;
 };
@@ -24,11 +24,8 @@ struct has_well_formed_static_new<T, std::false_type, Args...> {
 template<typename T, typename... Args>
 struct has_static_new
 {
-  template<class Fn, Fn>
-  struct unnamed_constant;
-
   template<class U>
-  static std::true_type select(decltype(U::New(*(typename std::remove_reference<Args>::type*)nullptr...))*);
+  static std::true_type select(decltype(U::New(std::forward<Args>(*(typename std::remove_reference<Args>::type*)nullptr)...))*);
 
   template<class U>
   static std::false_type select(...);

--- a/src/autowiring/test/AutowiringTest.cpp
+++ b/src/autowiring/test/AutowiringTest.cpp
@@ -162,7 +162,7 @@ StaticNewInt* CreateStaticNewIntImpl(std::unique_ptr<int> val){
 TEST_F(AutowiringTest, StaticNewWithArgs) {
   const bool static_new = has_static_new<StaticNewInt, typename std::unique_ptr<int>>::value;
   ASSERT_TRUE(static_new) << "has_static_new didn't correctly identify static New()";
-  
+
   {
     AutoCreateContext ctxt;
     ASSERT_NO_THROW(ctxt->Inject<StaticNewInt>()) << "Exception throws while injecting member";

--- a/src/autowiring/test/AutowiringTest.cpp
+++ b/src/autowiring/test/AutowiringTest.cpp
@@ -111,3 +111,70 @@ TEST_F(AutowiringTest, CanAutowireCompletelyUndefinedType) {
   Autowired<CompletelyUndefinedType> cut;
   ASSERT_EQ(nullptr, cut.get_unsafe()) << "Autowiring of a completely undefined type succeeded unexpectedly";
 }
+
+class StaticNewInt;
+
+StaticNewInt* CreateStaticNewIntImpl();
+StaticNewInt* CreateStaticNewIntImpl(std::unique_ptr<int>);
+
+class StaticNewInt:
+  public CoreObject
+{
+protected:
+  StaticNewInt(void){}
+public:
+  static StaticNewInt* New(std::unique_ptr<int> value) {
+    return CreateStaticNewIntImpl(std::move(value));
+  }
+
+  static StaticNewInt* New(void) {
+    return CreateStaticNewIntImpl();
+  }
+
+  virtual int getValue(void) = 0;
+};
+
+class StaticNewIntImpl:
+  public StaticNewInt
+{
+public:
+  StaticNewIntImpl(void):
+    m_value(new int(42))
+  {}
+  StaticNewIntImpl(std::unique_ptr<int> val):
+    m_value(std::move(val))
+  {}
+
+  int getValue(void) override {
+    return *m_value;
+  }
+
+  std::unique_ptr<int> m_value;
+};
+
+StaticNewInt* CreateStaticNewIntImpl(){
+  return new StaticNewIntImpl();
+}
+StaticNewInt* CreateStaticNewIntImpl(std::unique_ptr<int> val){
+  return new StaticNewIntImpl(std::move(val));
+}
+
+TEST_F(AutowiringTest, StaticNewWithArgs) {
+  const bool static_new = has_static_new<StaticNewInt, typename std::unique_ptr<int>>::value;
+  ASSERT_TRUE(static_new) << "has_static_new didn't correctly identify static New()";
+  
+  {
+    AutoCreateContext ctxt;
+    ASSERT_NO_THROW(ctxt->Inject<StaticNewInt>()) << "Exception throws while injecting member";
+    AutowiredFast<StaticNewInt> obj(ctxt);
+    EXPECT_EQ(42, obj->getValue()) << "Wrong constructor called";
+    ctxt->SignalShutdown(true);
+  }
+  {
+    AutoCreateContext ctxt;
+    ASSERT_NO_THROW(auto obj = ctxt->Inject<StaticNewInt>(std::unique_ptr<int>(new int(1337)))) << "Exception throws while injecting member";
+    AutowiredFast<StaticNewInt> obj(ctxt);
+    EXPECT_EQ(1337, obj->getValue()) << "Wrong constructor called";
+    ctxt->SignalShutdown(true);
+  }
+}


### PR DESCRIPTION
`has_static_new` didn't work correctly when any of the args were move-only. This prevented providing your own transport layer to `AutoNetServer`.