### PR TITLE
Correcting a flipped conditional

### DIFF
--- a/src/autowiring/CoreThread.cpp
+++ b/src/autowiring/CoreThread.cpp
@@ -84,8 +84,8 @@ bool CoreThread::WaitForEventUnsafe(std::unique_lock<std::mutex>& lk, std::chron
     if(m_aborted)
       throw dispatch_aborted_exception();
 
-    // Dispatch events if the queue is now non-empty:
-    if (!PromoteReadyDispatchersUnsafe())
+    if (PromoteReadyDispatchersUnsafe())
+      // Dispatcher is ready to run!  Exit our loop and dispatch an event
       break;
 
     if(status == std::cv_status::timeout)


### PR DESCRIPTION
This would cause a crash in cases where `m_queueUpdated` is spuriously signaled.