### PR TITLE
AutoFuture stabilizing merge

### DIFF
--- a/autowiring/auto_future.h
+++ b/autowiring/auto_future.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <functional>
+
+#ifdef _MSC_VER
+#include "auto_future_win.h"
+#endif

--- a/autowiring/auto_future.h
+++ b/autowiring/auto_future.h
@@ -3,4 +3,6 @@
 
 #ifdef _MSC_VER
 #include "auto_future_win.h"
+#elif defined(__APPLE__)
+#include "auto_future_mac.h"
 #endif

--- a/autowiring/auto_future.h
+++ b/autowiring/auto_future.h
@@ -1,3 +1,4 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <functional>
 

--- a/autowiring/auto_future_mac.h
+++ b/autowiring/auto_future_mac.h
@@ -1,3 +1,4 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <future>
 #include <stdexcept>

--- a/autowiring/auto_future_mac.h
+++ b/autowiring/auto_future_mac.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <future>
+#include <stdexcept>
+
+namespace autowiring {
+  /// <summary>
+  /// Platform-specific operation appending routine
+  /// </summary>
+  /// <param name="future">The future to be appended to</param>
+  /// <param name="fn">The lambda to be executed after the future is ready</param>
+  template<typename T, typename Fn>
+  void then(std::future<T>& future, Fn&& fn) {
+    
+  }
+}

--- a/autowiring/auto_future_win.h
+++ b/autowiring/auto_future_win.h
@@ -1,3 +1,4 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <future>
 #include <stdexcept>

--- a/autowiring/auto_future_win.h
+++ b/autowiring/auto_future_win.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <future>
+#include <stdexcept>
+
+namespace autowiring {
+  class _Task_async_state_unwrap:
+    public std::_Packaged_state<void()>
+  {
+  public:
+    ::Concurrency::task<void> _Task;
+  };
+
+  /// <summary>
+  /// Platform-specific operation appending routine
+  /// </summary>
+  /// <param name="future">The future to be appended to</param>
+  /// <param name="fn">The lambda to be executed after the future is ready</param>
+  template<typename T, typename Fn>
+  void then(std::future<T>& future, Fn&& fn) {
+    auto ptr = future._Ptr();
+
+    auto* taskAsync = dynamic_cast<std::_Task_async_state<T, 0>*>(ptr);
+    if (taskAsync) {
+      auto* unwrap = reinterpret_cast<_Task_async_state_unwrap*>(taskAsync);
+      unwrap->_Task.then(fn);
+      return;
+    }
+
+    throw std::runtime_error("Unrecognized future type");
+  }
+}

--- a/autowiring/auto_future_win.h
+++ b/autowiring/auto_future_win.h
@@ -3,6 +3,14 @@
 #include <stdexcept>
 
 namespace autowiring {
+  template<typename _Ret, typename... _ArgTypes>
+  class _Packaged_state_unwrap:
+    public std::_Associated_state<_Ret*>
+  {
+  public:
+    std::function<_Ret(_ArgTypes...)> _Fn;
+  };
+
   class _Task_async_state_unwrap:
     public std::_Packaged_state<void()>
   {
@@ -17,15 +25,28 @@ namespace autowiring {
   /// <param name="fn">The lambda to be executed after the future is ready</param>
   template<typename T, typename Fn>
   void then(std::future<T>& future, Fn&& fn) {
+    // Need a pointer to the underlying state block so we can decide what to do
     auto ptr = future._Ptr();
 
-    auto* taskAsync = dynamic_cast<std::_Task_async_state<T, 0>*>(ptr);
-    if (taskAsync) {
+    if (auto* taskAsync = dynamic_cast<std::_Task_async_state<T, 0>*>(ptr)) {
       auto* unwrap = reinterpret_cast<_Task_async_state_unwrap*>(taskAsync);
       unwrap->_Task.then(fn);
-      return;
-    }
+    } else if (auto* deferredAsync = dynamic_cast<std::_Deferred_async_state<T>*>(ptr)) {
+      auto* packagedState = static_cast<std::_Packaged_state<T()>*>(deferredAsync);
+      auto* unwrap = reinterpret_cast<_Packaged_state_unwrap<T>*>(packagedState);
 
-    throw std::runtime_error("Unrecognized future type");
+      // New function which consists of a call to the original then a call to the continuation
+      unwrap->_Fn = std::bind(
+        [] (const std::function<T()>& orig, const Fn& fn) {
+          auto rv = orig();
+          fn();
+          return rv;
+        },
+        std::move(unwrap->_Fn),
+        std::forward<Fn&&>(fn)
+      );
+    }
+    else
+      throw std::runtime_error("Unrecognized future type");
   }
 }

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -10,6 +10,7 @@
 #include "SatCounter.h"
 #include <algorithm>
 #include <sstream>
+#include <future>
 
 using namespace autowiring;
 

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -188,6 +188,7 @@ add_windows_sources(Autowiring_SRCS
 )
 
 add_mac_sources(Autowiring_SRCS
+  auto_future_mac.h
   CoreThreadMac.cpp
 )
 

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -15,6 +15,7 @@ set(Autowiring_SRCS
   atomic_object.h
   at_exit.h
   auto_id.h
+  auto_future.h
   AutoConfig.cpp
   AutoConfig.h
   AutoConfigManager.cpp
@@ -180,6 +181,7 @@ if(NOT APPLE)
 endif()
 
 add_windows_sources(Autowiring_SRCS
+  auto_future_win.h
   CoreThreadWin.cpp
   InterlockedExchangeWin.cpp
   thread_specific_ptr_win.h

--- a/src/autowiring/test/AutoFutureTest.cpp
+++ b/src/autowiring/test/AutoFutureTest.cpp
@@ -1,3 +1,4 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/auto_future.h>
 #include <autowiring/autowiring.h>

--- a/src/autowiring/test/AutoFutureTest.cpp
+++ b/src/autowiring/test/AutoFutureTest.cpp
@@ -1,0 +1,35 @@
+#include "stdafx.h"
+#include <autowiring/auto_future.h>
+#include <autowiring/autowiring.h>
+#include <future>
+
+class AutoFutureTest:
+  public testing::Test
+{};
+
+TEST_F(AutoFutureTest, VerifyFutureExtraction) {
+  auto f = std::async(
+    std::launch::async,
+    [] {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      return 5;
+    }
+  );
+
+  auto pr = std::make_shared<std::promise<int>>();
+  autowiring::then(
+    f,
+    [pr] { pr->set_value(201);}
+  );
+
+  // Wait for our async launch to conclude
+  f.get();
+
+  // Continuation task checks
+  auto future = pr->get_future();
+  ASSERT_EQ(
+    std::future_status::ready,
+    future.wait_for(std::chrono::seconds(5))
+  ) << "Continuation task did not launch as expected when the main task concluded";
+  ASSERT_EQ(201, future.get()) << "Future value not propagated correctly back to the origin";
+}

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -5,6 +5,7 @@ set(AutowiringTest_SRCS
   AutoConstructTest.cpp
   AutoFilterCollapseRulesTest.cpp
   AutoFilterDiagnosticsTest.cpp
+  AutoFutureTest.cpp
   AutoInjectableTest.cpp
   AutoPacketTest.cpp
   AutoPacketFactoryTest.cpp

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -5,7 +5,6 @@ set(AutowiringTest_SRCS
   AutoConstructTest.cpp
   AutoFilterCollapseRulesTest.cpp
   AutoFilterDiagnosticsTest.cpp
-  AutoFutureTest.cpp
   AutoInjectableTest.cpp
   AutoPacketTest.cpp
   AutoPacketFactoryTest.cpp
@@ -59,6 +58,11 @@ set(AutowiringTest_SRCS
   TestFixtures/ThrowsWhenRun.hpp
   TestFixtures/MultiInherit.hpp
   UuidTest.cpp
+)
+
+add_windows_sources(
+  AutowiringTest_SRCS
+  AutoFutureTest.cpp
 )
 
 if(autowiring_USE_LIBCXX)


### PR DESCRIPTION
This adds functionality for eventual support by AutoFilter for the `std::future` type as an input or output argument.  Presently, this functionality is only implemented on Windows, but if we ever figure out how to implement it on Mac/Linux, avoiding bit rot in the Windows implementation would be worthwhile.