### PR TITLE
Completion status moved into its own status block

### DIFF
--- a/autowiring/BasicThread.h
+++ b/autowiring/BasicThread.h
@@ -82,9 +82,6 @@ protected:
   // Run condition:
   bool m_running;
 
-  // Completion condition, true when this thread is no longer running and has run at least once
-  bool m_completed;
-
   // The current thread priority
   ThreadPriority m_priority;
 

--- a/autowiring/BasicThreadStateBlock.h
+++ b/autowiring/BasicThreadStateBlock.h
@@ -7,7 +7,8 @@
 struct BasicThreadStateBlock:
   std::enable_shared_from_this<BasicThreadStateBlock>
 {
-  ~BasicThreadStateBlock();
+  BasicThreadStateBlock(void);
+  ~BasicThreadStateBlock(void);
 
   // General purpose thread lock and update condition for the lock
   std::mutex m_lock;
@@ -15,4 +16,7 @@ struct BasicThreadStateBlock:
 
   // The current thread, if running
   std::thread m_thisThread;
+
+  // Completion condition, true when this thread is no longer running and has run at least once
+  bool m_completed;
 };

--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -12,7 +12,6 @@ BasicThread::BasicThread(const char* pName):
   m_state(std::make_shared<BasicThreadStateBlock>()),
   m_stop(false),
   m_running(false),
-  m_completed(false),
   m_priority(ThreadPriority::Default)
 {}
 
@@ -70,10 +69,6 @@ void BasicThread::DoRunLoopCleanup(std::shared_ptr<CoreContext>&& ctxt, std::sha
   m_stop = true;
   m_running = false;
 
-  // Need to ensure that "stop" and "running" are actually updated in memory before we mark "complete"
-  std::atomic_thread_fence(std::memory_order_release);
-  m_completed = true;
-
   // Tell our CoreRunnable parent that we're done to ensure that our reference count will be cleared.
   Stop(false);
 
@@ -97,6 +92,7 @@ void BasicThread::DoRunLoopCleanup(std::shared_ptr<CoreContext>&& ctxt, std::sha
   // Notify other threads that we are done.  At this point, any held references that might still exist
   // notification must happen from a synchronized level in order to ensure proper ordering.
   std::lock_guard<std::mutex> lk(state->m_lock);
+  state->m_completed = true;
   state->m_stateCondition.notify_all();
 }
 
@@ -146,7 +142,7 @@ bool BasicThread::OnStart(void) {
 void BasicThread::OnStop(bool graceful) {
   // If we were never started, we need to set our completed flag to true
   if (!m_running) {
-    m_completed = true;
+    m_state->m_completed = true;
   }
 
   // Always invoke stop handler:
@@ -158,7 +154,7 @@ void BasicThread::DoAdditionalWait(void) {
   std::unique_lock<std::mutex> lk(m_state->m_lock);
   m_state->m_stateCondition.wait(
     lk,
-    [this] {return this->m_completed; }
+    [this] {return m_state->m_completed; }
   );
 }
 

--- a/src/autowiring/BasicThreadStateBlock.cpp
+++ b/src/autowiring/BasicThreadStateBlock.cpp
@@ -2,4 +2,9 @@
 #include "stdafx.h"
 #include "BasicThreadStateBlock.h"
 
-BasicThreadStateBlock::~BasicThreadStateBlock(){}
+BasicThreadStateBlock::BasicThreadStateBlock(void):
+  m_completed(false)
+{}
+
+BasicThreadStateBlock::~BasicThreadStateBlock(void)
+{}


### PR DESCRIPTION
In the single context owner case, when the sole external holder of a `CoreContext` invokes `CoreContext::Wait`, that owner must hold the sole exclusive shared pointer to the context on return.  This means that threads running in that context must not transition themselves to the "completed" state until after releasing all shared pointers to their enclosing context.

In order to do this, the "completed" status flag has been moved to the context block, in order to allow us to update it even in the "lights out" countercase where the last holder of the context is a runnable in that same context.