### PR TITLE
Adding timed DoAdditionalWait variant

### DIFF
--- a/autowiring/AutoPacketFactory.h
+++ b/autowiring/AutoPacketFactory.h
@@ -75,6 +75,7 @@ public:
   bool OnStart(void) override;
   void OnStop(bool graceful) override;
   void DoAdditionalWait(void) override;
+  bool DoAdditionalWait(std::chrono::nanoseconds timeout) override;
 
   /// <summary>
   /// Causes this AutoPacketFactory to release all of its packet subscribers

--- a/autowiring/BasicThread.h
+++ b/autowiring/BasicThread.h
@@ -76,6 +76,9 @@ protected:
   // we're actually signalling this event after we free ourselves.
   const std::shared_ptr<BasicThreadStateBlock> m_state;
 
+  // Flag indicating that this thread was started at some point
+  bool m_wasStarted;
+
   // Flag indicating that we need to stop right now
   bool m_stop;
 
@@ -217,7 +220,8 @@ protected:
 
   void OnStop(bool graceful) override;
 
-  void DoAdditionalWait() override;
+  void DoAdditionalWait(void) override;
+  bool DoAdditionalWait(std::chrono::nanoseconds timeout) override;
 
 public:
   /// <summary>

--- a/autowiring/CoreJob.h
+++ b/autowiring/CoreJob.h
@@ -43,4 +43,5 @@ public:
   bool OnStart(void) override;
   void OnStop(bool graceful) override;
   void DoAdditionalWait(void) override;
+  bool DoAdditionalWait(std::chrono::nanoseconds timeout) override;
 };

--- a/autowiring/CoreRunnable.h
+++ b/autowiring/CoreRunnable.h
@@ -62,13 +62,22 @@ protected:
   virtual void OnStop(bool graceful) {};
 
   /// <summary>
-  /// Invoked when a Wait() call has been made. Override this method to perform
-  /// any actions required before this runnable enters the waiting state.
+  /// Invoked just before control is returned to the user.
   /// </summary>
+  /// <param name="timeout">The maximum amount of time to wait</param>
+  /// <returns>True if the wait succeeded, false if a timeout occurred</returns>
   /// <remarks>
-  /// This call should not block for an extended period of time.
+  /// This virtual method provides implementors with a way to add further constraints to the wait operation
+  /// beyond the condition variable held internally by this CoreRunnable.
+  ///
+  /// This method must return true if the timeout is indefinite.
   /// </remarks>
-  virtual void DoAdditionalWait() {};
+  virtual bool DoAdditionalWait(std::chrono::nanoseconds timeout) { return true; }
+
+  /// <summary>
+  /// Untimed variant of DoAdditionalWait
+  /// </summary>
+  virtual void DoAdditionalWait(void) { }
 
 public:
   // Accessor methods:

--- a/src/autowiring/AutoPacketFactory.cpp
+++ b/src/autowiring/AutoPacketFactory.cpp
@@ -128,6 +128,17 @@ void AutoPacketFactory::DoAdditionalWait(void) {
   );
 }
 
+bool AutoPacketFactory::DoAdditionalWait(std::chrono::nanoseconds timeout) {
+  std::unique_lock<std::mutex> lk(m_lock);
+  return m_stateCondition.wait_for(
+    lk,
+    timeout,
+    [this]{
+      return ShouldStop() && m_outstandingInternal.expired();
+    }
+  );
+}
+
 void AutoPacketFactory::Clear(void) {
   // Simple handoff to Stop is sufficient
   Stop(false);

--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -24,7 +24,6 @@ std::mutex& BasicThread::GetLock(void) {
 
 void BasicThread::DoRun(std::shared_ptr<CoreObject>&& refTracker) {
   assert(m_running);
-  m_wasStarted = true;
 
   // Make our own session current before we do anything else:
   CurrentContextPusher pusher(GetContext());
@@ -126,8 +125,9 @@ bool BasicThread::OnStart(void) {
   if(!context)
     return false;
 
-  // Currently running:
+  // Currently running and started:
   m_running = true;
+  m_wasStarted = true;
 
   // Place the new thread entity directly in the space where it goes to avoid
   // any kind of races arising from asynchronous access to this space

--- a/src/autowiring/CoreJob.cpp
+++ b/src/autowiring/CoreJob.cpp
@@ -118,3 +118,14 @@ void CoreJob::DoAdditionalWait(void) {
     m_curEvent = nullptr;
   }
 }
+
+bool CoreJob::DoAdditionalWait(std::chrono::nanoseconds timeout) {
+  if (!m_curEvent)
+    return true;
+
+  std::future<void>* ptr = static_cast<std::future<void>*>(m_curEvent);
+  auto status = ptr->wait_for(timeout);
+  delete ptr;
+  m_curEvent = nullptr;
+  return status == std::future_status::ready;
+}

--- a/src/autowiring/CoreRunnable.cpp
+++ b/src/autowiring/CoreRunnable.cpp
@@ -58,23 +58,28 @@ void CoreRunnable::Stop(bool graceful) {
 }
 
 void CoreRunnable::Wait(void) {
-  std::unique_lock<std::mutex> lk(m_lock);
-  m_cv.wait(lk, [this] { return ShouldStop() && !IsRunning(); });
+  {
+    std::unique_lock<std::mutex> lk(m_lock);
+    m_cv.wait(lk, [this] { return ShouldStop() && !IsRunning(); });
+  }
   DoAdditionalWait();
 }
 
 bool CoreRunnable::WaitFor(std::chrono::nanoseconds timeout) {
-  std::unique_lock<std::mutex> lk(m_lock);
-
-  if (m_cv.wait_for(lk, timeout, [this] { return ShouldStop() && !IsRunning(); }))
-    return DoAdditionalWait(timeout);
-  return false;
+  {
+    std::unique_lock<std::mutex> lk(m_lock);
+    if (!m_cv.wait_for(lk, timeout, [this] { return ShouldStop() && !IsRunning(); }))
+      return false;
+  }
+  return DoAdditionalWait(timeout);
 }
 
 template<typename TimeType>
 bool CoreRunnable::WaitUntil(TimeType timepoint) {
-  std::unique_lock<std::mutex> lk(m_lock);
-  if (m_cv.wait_until(lk, timepoint, [this] { return ShouldStop() && !IsRunning(); }))
-    return DoAdditionalWait(timepoint - TimeType::now());
-  return false;
+  {
+    std::unique_lock<std::mutex> lk(m_lock);
+    if (!m_cv.wait_until(lk, timepoint, [this] { return ShouldStop() && !IsRunning(); }))
+      return false;
+  }
+  return DoAdditionalWait(timepoint - TimeType::now());;
 }

--- a/src/autowiring/CoreRunnable.cpp
+++ b/src/autowiring/CoreRunnable.cpp
@@ -59,25 +59,22 @@ void CoreRunnable::Stop(bool graceful) {
 
 void CoreRunnable::Wait(void) {
   std::unique_lock<std::mutex> lk(m_lock);
-  m_cv.wait(lk, [this](){ return ShouldStop() && !IsRunning(); });
+  m_cv.wait(lk, [this] { return ShouldStop() && !IsRunning(); });
   DoAdditionalWait();
 }
 
 bool CoreRunnable::WaitFor(std::chrono::nanoseconds timeout) {
   std::unique_lock<std::mutex> lk(m_lock);
-  if (m_cv.wait_for(lk, timeout, [this](){ return ShouldStop() && !IsRunning(); })) {
-    DoAdditionalWait();
-    return true;
-  }
+
+  if (m_cv.wait_for(lk, timeout, [this] { return ShouldStop() && !IsRunning(); }))
+    return DoAdditionalWait(timeout);
   return false;
 }
 
 template<typename TimeType>
 bool CoreRunnable::WaitUntil(TimeType timepoint) {
   std::unique_lock<std::mutex> lk(m_lock);
-  if (m_cv.wait_until(lk, timepoint, [this](){ return ShouldStop() && !IsRunning(); })) {
-    DoAdditionalWait();
-    return true;
-  }
+  if (m_cv.wait_until(lk, timepoint, [this] { return ShouldStop() && !IsRunning(); }))
+    return DoAdditionalWait(timepoint - TimeType::now());
   return false;
 }

--- a/src/autowiring/test/ContextCleanupTest.cpp
+++ b/src/autowiring/test/ContextCleanupTest.cpp
@@ -153,7 +153,9 @@ TEST_F(ContextCleanupTest, VerifyGracefulThreadCleanup) {
   *ct += [called] { *called = true; };
 
   // Verify that a graceful shutdown ensures both lambdas are called:
+  ASSERT_FALSE(ctxt->IsShutdown()) << "Context shut down prematurely";
   ctxt->SignalShutdown(true, ShutdownMode::Graceful);
+  ASSERT_FALSE(ct->IsRunning()) << "Thread still reported as running even after a wait concluded";
   ASSERT_TRUE(*called) << "Graceful shutdown did not correctly run down all lambdas";
 }
 

--- a/src/autowiring/test/CoreThreadTest.cpp
+++ b/src/autowiring/test/CoreThreadTest.cpp
@@ -557,3 +557,49 @@ TEST_F(CoreThreadTest, SpuriousWakeupTest) {
 
   ASSERT_EQ(1UL, extraction->GetDispatchQueueLength()) << "Dispatch queue changed size under a spurious wakeup condition";
 }
+class BlocksInOnStop:
+  public CoreThread
+{
+public:
+  bool is_waiting = false;
+  bool signal = false;
+
+  void Run(void) {
+    // Let the run loop return.  This triggers cleanup operations and ultimately causes OnStop
+    // to get called in our own thread context.
+  }
+
+  bool Block(std::chrono::nanoseconds timeout) {
+    std::unique_lock<std::mutex> lk(m_lock);
+    return m_cv.wait_for(lk, timeout, [this] {return is_waiting; });
+  }
+
+  void Continue(void) {
+    std::lock_guard<std::mutex> lk(m_lock);
+    signal = true;
+    m_cv.notify_all();
+  }
+
+  void OnStop(void) override {
+    std::unique_lock<std::mutex> lk(this->m_lock);
+    is_waiting = true;
+    m_cv.notify_all();
+    m_cv.wait_for(lk, std::chrono::seconds(5), [this] { return signal; });
+  }
+};
+
+TEST_F(CoreThreadTest, ContextWaitTimesOutInOnStop) {
+  AutoCurrentContext ctxt;
+  AutoRequired<BlocksInOnStop> bios;
+  ctxt->Initiate();
+
+  // Wait for our pathological case to be waiting before we try shutting down the context
+  ASSERT_TRUE(bios->Block(std::chrono::seconds(5))) << "Blocking class failed to enter a blocked condition as expected";
+
+  ctxt->SignalShutdown();
+  ASSERT_FALSE(bios->WaitFor(std::chrono::milliseconds(1))) << "Timed wait on a misbehaving CoreThread did not time out as expected";
+  ASSERT_FALSE(ctxt->Wait(std::chrono::milliseconds(1))) << "Context wait routine did not timeout as expected";
+
+  // Let BIOS back out now:
+  bios->Continue();
+}

--- a/src/autowiring/test/DtorCorrectnessTest.cpp
+++ b/src/autowiring/test/DtorCorrectnessTest.cpp
@@ -114,8 +114,8 @@ TEST_F(DtorCorrectnessTest, VerifyDeferringDtors) {
   listener2->Wait();
 
   // Verify that we actually hit something:
-  EXPECT_TRUE(listener1->m_hitDeferred) << "Failed to hit a listener's deferred call";
-  EXPECT_TRUE(listener2->m_hitDeferred) << "Failed to hit a listener's deferred call";
+  EXPECT_TRUE(listener1->m_hitDeferred) << "Failed to hit listener #1's deferred call";
+  EXPECT_TRUE(listener2->m_hitDeferred) << "Failed to hit listener #2's deferred call";
 
   // Release all of our pointers:
   listener1.reset();

--- a/src/autowiring/test/ObjectPoolTest.cpp
+++ b/src/autowiring/test/ObjectPoolTest.cpp
@@ -367,6 +367,8 @@ TEST_F(ObjectPoolTest, MovableObjectPoolAysnc) {
     *AutoRequired<CoreThread>() += [objs] {};
   }
 
+  ASSERT_EQ(0, from.GetCached()) << "Initial pool received cached entities unexpectedly";
+
   // Kick off threads, then immediately and asynchronously move the pool:
   AutoCurrentContext()->Initiate();
   ObjectPool<int> to = std::move(from);


### PR DESCRIPTION
Though the documentation does state that `DoAdditionalWait` should not block for long periods of time, we nevertheless have implementors that _do_ block.  In order to prevent such cases from wreaking havoc and leaking out through our interfaces, a timed version of DoAdditionalWait is necessary.