### PR TITLE
Adding a test to catch a factory new deduction error on Windows

### DIFF
--- a/autowiring/has_static_new.h
+++ b/autowiring/has_static_new.h
@@ -11,7 +11,11 @@
 template<class T, class Selector, class... Args>
 struct has_well_formed_static_new {
   static const bool value = std::is_convertible<
-    decltype(T::New(std::forward<Args>(*(typename std::remove_reference<Args>::type*)nullptr)...)),
+    decltype(
+      T::New(
+        std::declval<Args>()...
+      )
+    ),
     T*
   >::value;
 };

--- a/src/autowiring/test/FactoryTest.cpp
+++ b/src/autowiring/test/FactoryTest.cpp
@@ -155,3 +155,29 @@ TEST_F(FactoryTest, VerifyCanAutowireActualType) {
 
   ASSERT_TRUE(concrete.IsAutowired()) << "Failed to find the concrete derived type in a factory new construction in a case where it is known to exist";
 }
+
+class AcceptsString:
+  public Object
+{
+public:
+  AcceptsString(const char* str) :
+    str(str)
+  {}
+
+  static AcceptsString* New(const char* pstrNamespace) {
+    return new AcceptsString(pstrNamespace);
+  }
+
+  const char* const str;
+};
+
+TEST_F(FactoryTest, StringLiteralCheck) {
+  // This case can sometimes fail to compile because of the way we check for static new.
+  // String literals are interpreted to be a reference to an array, and taking the address of such a type can
+  // cause problems.
+  AutoCurrentContext()->Inject<AcceptsString>("Abcd");
+  Autowired<AcceptsString> as;
+
+  ASSERT_TRUE(as.IsAutowired()) << "Standard injection with an argument did not correctly forward the argument";
+  ASSERT_STREQ("Abcd", as->str) << "Constructed type was not constructed properly";
+}


### PR DESCRIPTION
This issue has to do with the way that a string literal is type inducted in VC++.  Attempting to do our nullptr-cast-to-ptr-dereference trick on decltype("string") causes problems because this decltype is understood to be const char (&)[], rather than const char*.