### PR TITLE
Add a "m_completed" reference bool for compatibility reasons

### DIFF
--- a/autowiring/BasicThread.h
+++ b/autowiring/BasicThread.h
@@ -85,6 +85,9 @@ protected:
   // Run condition:
   bool m_running;
 
+  // Legacy field, some clients still refer to this
+  bool& DEPRECATED(m_completed, "Use IsCompleted instead");
+
   // The current thread priority
   ThreadPriority m_priority;
 
@@ -224,6 +227,11 @@ protected:
   bool DoAdditionalWait(std::chrono::nanoseconds timeout) override;
 
 public:
+  /// <returns>
+  /// True if this thread has transitioned to a completed state
+  /// </returns>
+  bool IsCompleted(void) const;
+
   /// <summary>
   /// Begins thread execution.
   /// </summary>

--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -13,6 +13,7 @@ BasicThread::BasicThread(const char* pName):
   m_wasStarted(false),
   m_stop(false),
   m_running(false),
+  m_completed(m_state->m_completed),
   m_priority(ThreadPriority::Default)
 {}
 
@@ -167,6 +168,10 @@ bool BasicThread::DoAdditionalWait(std::chrono::nanoseconds timeout) {
     timeout,
     [this] { return m_state->m_completed; }
   );
+}
+
+bool BasicThread::IsCompleted(void) const {
+  return m_state->m_completed;
 }
 
 void BasicThread::ForceCoreThreadReidentify(void) {


### PR DESCRIPTION
This field is protected and some downstream consumers still make use of it.  It needs to be left present until the next major version bump.