### PR TITLE
Correcting invalid macro specification on Windows

### DIFF
--- a/autowiring/BasicThread.h
+++ b/autowiring/BasicThread.h
@@ -86,7 +86,7 @@ protected:
   bool m_running;
 
   // Legacy field, some clients still refer to this
-  bool& DEPRECATED(m_completed, "Use IsCompleted instead");
+  bool& DEPRECATED_MEMBER(m_completed, "Use IsCompleted instead");
 
   // The current thread priority
   ThreadPriority m_priority;

--- a/autowiring/C++11/cpp11.h
+++ b/autowiring/C++11/cpp11.h
@@ -325,20 +325,14 @@
 /*********************
  * Deprecation convenience macro
  *********************/
-#ifndef _DEBUG
-
 #ifdef _MSC_VER
 #define DEPRECATED(signature, msg) __declspec(deprecated(msg)) signature
 #define DEPRECATED_CLASS(classname, msg) __declspec(deprecated(msg)) classname
+#define DEPRECATED_MEMBER(member, msg) member
 #else
 #define DEPRECATED(signature, msg) signature __attribute__((deprecated))
 #define DEPRECATED_CLASS(classname, msg)
-#endif
-
-#else
-// In release mode we don't bother to deprecate
-#define DEPRECATED(signature, msg) signature
-#define DEPRECATED_CLASS(classname, msg)
+#define DEPRECATED_MEMBER(member, msg) DEPRECATED(member, msg)
 #endif
 
 /*********************


### PR DESCRIPTION
- [x] Builds on x86/x64 Debug/Release Windows