### PR TITLE
Adjust DEPRECATED macro to replicate original behavior

### DIFF
--- a/autowiring/C++11/cpp11.h
+++ b/autowiring/C++11/cpp11.h
@@ -325,15 +325,22 @@
 /*********************
  * Deprecation convenience macro
  *********************/
-#ifdef _MSC_VER
-#define DEPRECATED(signature, msg) __declspec(deprecated(msg)) signature
-#define DEPRECATED_CLASS(classname, msg) __declspec(deprecated(msg)) classname
-#define DEPRECATED_MEMBER(member, msg) member
+#ifndef _DEBUG
+  #ifdef _MSC_VER
+    #define DEPRECATED(signature, msg) __declspec(deprecated(msg)) signature
+    #define DEPRECATED_CLASS(classname, msg) __declspec(deprecated(msg)) classname
+    #define DEPRECATED_MEMBER(member, msg) member
+  #else
+    #define DEPRECATED(signature, msg) signature __attribute__((deprecated))
+    #define DEPRECATED_CLASS(classname, msg) classname
+    #define DEPRECATED_MEMBER(member, msg) DEPRECATED(member, msg)
+  #endif
 #else
-#define DEPRECATED(signature, msg) signature __attribute__((deprecated))
-#define DEPRECATED_CLASS(classname, msg)
-#define DEPRECATED_MEMBER(member, msg) DEPRECATED(member, msg)
+  #define DEPRECATED(signature, msg) signature
+  #define DEPRECATED_CLASS(classname, msg) classname
+  #define DEPRECATED_MEMBER(member, msg) member
 #endif
+
 
 /*********************
  * Enum forward declaration convenience macro - VS2010 has a bad implementation


### PR DESCRIPTION
If we don't do this, then downstream consumers which presently have "warnings as errors" turned on for their debug builds will have all of their code break when they try to run debug builds after minor version updates.