### PR TITLE
ObjectTraits is now CoreObjectDescriptor

### DIFF
--- a/autowiring/AutoPacketGraph.h
+++ b/autowiring/AutoPacketGraph.h
@@ -98,7 +98,7 @@ protected:
   /// AutowiringEvents overrides
   virtual void NewContext(CoreContext&) override {}
   virtual void ExpiredContext(CoreContext&) override {}
-  virtual void NewObject(CoreContext&, const ObjectTraits&) override;
+  virtual void NewObject(CoreContext&, const CoreObjectDescriptor&) override;
   
   /// CoreRunnable overrides
   virtual bool OnStart(void) override;

--- a/autowiring/AutowiringEvents.h
+++ b/autowiring/AutowiringEvents.h
@@ -3,7 +3,7 @@
 #include "EventRegistry.h"
 #include TYPE_INDEX_HEADER
 
-struct ObjectTraits;
+struct CoreObjectDescriptor;
 class CoreContext;
 
 /// <summary>
@@ -17,7 +17,7 @@ public:
   
   virtual void NewContext(CoreContext&)=0;
   virtual void ExpiredContext(CoreContext&)=0;
-  virtual void NewObject(CoreContext&, const ObjectTraits&)=0;
+  virtual void NewObject(CoreContext&, const CoreObjectDescriptor&)=0;
 };
 
 // Extern explicit template instantiation declarations added to prevent

--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -16,7 +16,7 @@
 #include "InvokeRelay.h"
 #include "JunctionBoxManager.h"
 #include "member_new_type.h"
-#include "ObjectTraits.h"
+#include "CoreObjectDescriptor.h"
 #include "result_or_default.h"
 #include "TeardownNotifier.h"
 #include "TypeRegistry.h"
@@ -162,7 +162,7 @@ public:
     DeferrableAutowiring* pFirst;
 
     // A back reference to the concrete type from which this memo was generated:
-    const ObjectTraits* pObjTraits;
+    const CoreObjectDescriptor* pObjTraits;
 
     // Once this memo entry is satisfied, this will contain the AnySharedPointer instance that performs
     // the satisfaction
@@ -230,7 +230,7 @@ protected:
   class AutoFactoryFn;
 
   // This is a list of concrete types, indexed by the true type of each element.
-  std::list<ObjectTraits> m_concreteTypes;
+  std::list<CoreObjectDescriptor> m_concreteTypes;
 
   // This is a memoization map used to memoize any already-detected interfaces.
   mutable std::unordered_map<std::type_index, MemoEntry> m_typeMemos;
@@ -327,7 +327,7 @@ protected:
   /// <summary>
   /// Invokes all deferred autowiring fields, generally called after a new member has been added
   /// </summary>
-  void UpdateDeferredElements(std::unique_lock<std::mutex>&& lk, const ObjectTraits& entry);
+  void UpdateDeferredElements(std::unique_lock<std::mutex>&& lk, const CoreObjectDescriptor& entry);
 
   /// \internal
   /// <summary>
@@ -398,7 +398,7 @@ protected:
   /// <summary>
   /// Internal type introduction routine
   /// </summary>
-  void AddInternal(const ObjectTraits& traits);
+  void AddInternal(const CoreObjectDescriptor& traits);
 
   /// \internal
   /// <summary>
@@ -454,7 +454,7 @@ protected:
   /// <summary>
   /// Forwarding routine, only removes from this context
   /// </summary>
-  void UnsnoopAutoPacket(const ObjectTraits& traits);
+  void UnsnoopAutoPacket(const CoreObjectDescriptor& traits);
 
   /// \internal
   /// <summary>
@@ -671,7 +671,7 @@ public:
 
     try {
       // Pass control to the insertion routine, which will handle injection from this point:
-      AddInternal(ObjectTraits(retVal, (T*)nullptr));
+      AddInternal(CoreObjectDescriptor(retVal, (T*)nullptr));
     }
     catch(autowiring_error&) {
       // We know why this exception occurred.  It's because, while we were constructing our
@@ -950,7 +950,7 @@ public:
   /// </remarks>
   template<class T>
   void Snoop(const std::shared_ptr<T>& pSnooper) {
-    const ObjectTraits traits(pSnooper, (T*)nullptr);
+    const CoreObjectDescriptor traits(pSnooper, (T*)nullptr);
     
     // Add to collections of snoopers
     InsertSnooper(pSnooper);
@@ -980,7 +980,7 @@ public:
   /// </remarks>
   template<class T>
   void Unsnoop(const std::shared_ptr<T>& pSnooper) {
-    const ObjectTraits traits(pSnooper, (T*)nullptr);
+    const CoreObjectDescriptor traits(pSnooper, (T*)nullptr);
     
     RemoveSnooper(pSnooper);
     

--- a/autowiring/CoreObjectDescriptor.h
+++ b/autowiring/CoreObjectDescriptor.h
@@ -15,9 +15,9 @@
 /// <summary>
 /// Mapping and extraction structure used to provide a runtime version of an Object-implementing shared pointer
 /// </summary>
-struct ObjectTraits {
+struct CoreObjectDescriptor {
   template<class TActual, class T>
-  ObjectTraits(const std::shared_ptr<TActual>& value, T*) :
+  CoreObjectDescriptor(const std::shared_ptr<TActual>& value, T*) :
     type(typeid(T)),
     actual_type(typeid(*value)),
     stump(SlotInformationStump<T>::s_stump),
@@ -51,7 +51,7 @@ struct ObjectTraits {
   // The type of the passed pointer
   const std::type_info& type;
 
-  // The "actual type" used by Autowiring.  This type may differ from ObjectTraits::type in cases
+  // The "actual type" used by Autowiring.  This type may differ from CoreObjectDescriptor::type in cases
   // where a type unifier is used, or if the concrete type is defined in an external module--for
   // instance, by a class factory.
   const std::type_info& actual_type;

--- a/nuget/tools/autowiring.natvis
+++ b/nuget/tools/autowiring.natvis
@@ -40,7 +40,7 @@
     </Expand>
   </Type>
 
-  <Type Name="std::vector&lt;ObjectTraits, std::allocator&lt;ObjectTraits&gt;&gt;">
+  <Type Name="std::vector&lt;CoreObjectDescriptor, std::allocator&lt;CoreObjectDescriptor&gt;&gt;">
     <DisplayString>[size = {_Mylast - _Myfirst}]</DisplayString>
     <Expand>
       <Item Name="Size">_Mylast - _Myfirst</Item>
@@ -51,7 +51,7 @@
     </Expand>
   </Type>
 
-  <Type Name="ObjectTraits">
+  <Type Name="CoreObjectDescriptor">
     <DisplayString Condition="type._M_data != nullptr">[{((char*)type._M_data + 6 + (*(char*)type._M_data == 's')),sb}, uses = {((std::shared_ptr&lt;Object&gt;*)((SharedPointerSlot*)value.m_space)-&gt;m_space)-&gt;_Rep-&gt;_Uses}]</DisplayString>
     <DisplayString>?</DisplayString>
     <Expand>

--- a/src/autonet/AutoNetServerImpl.cpp
+++ b/src/autonet/AutoNetServerImpl.cpp
@@ -5,7 +5,7 @@
 #include "autowiring.h"
 #include "AutoNetTransportHttp.hpp"
 #include "demangle.h"
-#include "ObjectTraits.h"
+#include "CoreObjectDescriptor.h"
 #include "EventRegistry.h"
 #include "TypeRegistry.h"
 #include <iostream>
@@ -170,7 +170,7 @@ void AutoNetServerImpl::ExpiredContext(CoreContext& oldCtxt){
   };
 }
 
-void AutoNetServerImpl::NewObject(CoreContext& ctxt, const ObjectTraits& object){
+void AutoNetServerImpl::NewObject(CoreContext& ctxt, const CoreObjectDescriptor& object){
   int contextID = ResolveContextID(&ctxt);
 
   *this += [this, object, contextID]{

--- a/src/autonet/AutoNetServerImpl.hpp
+++ b/src/autonet/AutoNetServerImpl.hpp
@@ -14,7 +14,7 @@
   #define BOOST_NO_CXX11_HDR_INITIALIZER_LIST
 #endif
 
-struct ObjectTraits;
+struct CoreObjectDescriptor;
 struct TypeIdentifierBase;
 
 // Protocol layer for AutoNet
@@ -70,7 +70,7 @@ public:
   /// </summary>
   /// <param name="ctxt">Context containing the object</param>
   /// <param name="obj">The object</param>
-  virtual void NewObject(CoreContext& ctxt, const ObjectTraits& obj) override;
+  virtual void NewObject(CoreContext& ctxt, const CoreObjectDescriptor& obj) override;
 
 protected:
   /// <summary>

--- a/src/autowiring/AutoPacketGraph.cpp
+++ b/src/autowiring/AutoPacketGraph.cpp
@@ -67,7 +67,7 @@ void AutoPacketGraph::RecordDelivery(const std::type_info* ti, const AutoFilterD
   itr->second++;
 }
 
-void AutoPacketGraph::NewObject(CoreContext&, const ObjectTraits&) {
+void AutoPacketGraph::NewObject(CoreContext&, const CoreObjectDescriptor&) {
   LoadEdges();
 }
 

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -133,7 +133,7 @@ set(Autowiring_SRCS
   ObjectPool.h
   ObjectPoolMonitor.cpp
   ObjectPoolMonitor.h
-  ObjectTraits.h
+  CoreObjectDescriptor.h
   SatCounter.h
   SatCounter.cpp
   SharedPointerSlot.h

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -194,7 +194,7 @@ const std::type_info& CoreContext::GetAutoTypeId(const AnySharedPointer& ptr) co
   if (q == m_typeMemos.end() || !q->second.pObjTraits)
     throw autowiring_error("Attempted to obtain the true type of a shared pointer that was not a member of this context");
 
-  const ObjectTraits* pObjTraits = q->second.pObjTraits;
+  const CoreObjectDescriptor* pObjTraits = q->second.pObjTraits;
   return pObjTraits->type;
 }
 
@@ -237,7 +237,7 @@ std::shared_ptr<CoreObject> CoreContext::IncrementOutstandingThreadCount(void) {
   return retVal;
 }
 
-void CoreContext::AddInternal(const ObjectTraits& traits) {
+void CoreContext::AddInternal(const CoreObjectDescriptor& traits) {
   {
     std::unique_lock<std::mutex> lk(m_stateBlock->m_lock);
 
@@ -324,7 +324,7 @@ CoreContext::MemoEntry& CoreContext::FindByTypeUnsafe(AnySharedPointer& referenc
   }
 
   // Resolve based on iterated dynamic casts for each concrete type:
-  const ObjectTraits* pObjTraits = nullptr;
+  const CoreObjectDescriptor* pObjTraits = nullptr;
   for(const auto& type : m_concreteTypes) {
     if(!reference->try_assign(*type.value))
       // No match, try the next entry
@@ -736,7 +736,7 @@ void CoreContext::BroadcastContextCreationNotice(const std::type_info& sigil) co
     m_pParent->BroadcastContextCreationNotice(sigil);
 }
 
-void CoreContext::UpdateDeferredElements(std::unique_lock<std::mutex>&& lk, const ObjectTraits& entry) {
+void CoreContext::UpdateDeferredElements(std::unique_lock<std::mutex>&& lk, const CoreObjectDescriptor& entry) {
   // Collection of satisfiable lists:
   std::vector<DeferrableUnsynchronizedStrategy*> satisfiable;
 
@@ -1045,7 +1045,7 @@ void CoreContext::TryTransitionChildrenState(void) {
   lk.unlock();
 }
 
-void CoreContext::UnsnoopAutoPacket(const ObjectTraits& traits) {
+void CoreContext::UnsnoopAutoPacket(const CoreObjectDescriptor& traits) {
   {
     std::lock_guard<std::mutex> lk(m_stateBlock->m_lock);
     

--- a/src/autowiring/test/ContextCleanupTest.cpp
+++ b/src/autowiring/test/ContextCleanupTest.cpp
@@ -74,7 +74,7 @@ TEST_F(ContextCleanupTest, VerifyContextDtor) {
       AutoRequired<SimpleObject> simple;
       objVerifier = simple;
 
-      // Each ObjectTraits instance holds 2 strong references to SimpleObject, as CoreObject type and as ContextMember type.
+      // Each CoreObjectDescriptor instance holds 2 strong references to SimpleObject, as CoreObject type and as ContextMember type.
       // One instance is held in CoreContext::m_concreteTypes and the other in the CoreContext::m_typeMemos.
       // Finally, once more reference is held by the shared_ptr<SimpleObject> inheritance of simple.
       EXPECT_EQ(5, objVerifier.use_count()) << "Unexpected number of references to a newly constructed object";


### PR DESCRIPTION
We are preparing to make `CoreObjectDescriptor` a public interface, thus changing the name of this type is necessary.