### PR TITLE
Add runtime variants to Snoop and Unsnoop

### DIFF
--- a/autowiring/CoreObjectDescriptor.h
+++ b/autowiring/CoreObjectDescriptor.h
@@ -15,8 +15,14 @@
 /// <summary>
 /// Mapping and extraction structure used to provide a runtime version of an Object-implementing shared pointer
 /// </summary>
+/// <remarks>
+/// This type is used to describe an object that is a member of a context.  This descriptor structure performs
+/// all of the type rule induction work that CoreContext performs, and provides users with a way to provide a
+/// runtime description of a type.  This is critical in cases where a type is not available at compile time--
+/// for instance, if that type is provided in another module that is dynamically linked.
+/// </remarks>
 struct CoreObjectDescriptor {
-  template<class TActual, class T>
+  template<typename TActual, typename T>
   CoreObjectDescriptor(const std::shared_ptr<TActual>& value, T*) :
     type(typeid(T)),
     actual_type(typeid(*value)),
@@ -47,6 +53,14 @@ struct CoreObjectDescriptor {
     (void) autowiring::fast_pointer_cast_initializer<CoreObject, T>::sc_init;
     (void) autowiring::fast_pointer_cast_initializer<T, CoreObject>::sc_init;
   }
+
+  /// <summary>
+  /// Special case where the declared type is also the true type
+  /// </summary>
+  template<typename T>
+  CoreObjectDescriptor(const std::shared_ptr<T>& value) :
+    CoreObjectDescriptor(value, static_cast<T*>(nullptr))
+  {}
 
   // The type of the passed pointer
   const std::type_info& type;


### PR DESCRIPTION
This feature allows users to describe members to be added to a context in a runtime way.  Lists of `CoreObjectDescriptor` instances may therefore be used to cross module boundaries and enable objects defined and implemented in other modules to snoop remotely defined contexts.

- [x] Tests pass on Windows
- [x] Tests pass on Linux
- [x] Tests pass on Mac