### PR TITLE
Simplification of the TypeIdentifier concept

### DIFF
--- a/autowiring/CoreObjectDescriptor.h
+++ b/autowiring/CoreObjectDescriptor.h
@@ -37,11 +37,9 @@ struct CoreObjectDescriptor {
     pBoltBase(autowiring::fast_pointer_cast<BoltBase>(value)),
     receivesEvents(
       [this]{
-        for (auto evt = g_pFirstEventEntry; evt; evt = evt->pFlink) {
-          auto identifier = evt->NewTypeIdentifier();
-          if (identifier->IsSameAs(pCoreObject.get()))
+        for (auto evt = g_pFirstEventEntry; evt; evt = evt->pFlink)
+          if (evt->IsSameAs(pCoreObject.get()))
             return true;
-        }
         // "T" not found in event registry
         return false;
       }()

--- a/autowiring/EventRegistry.h
+++ b/autowiring/EventRegistry.h
@@ -6,7 +6,9 @@
 
 class JunctionBoxBase;
 
-struct EventRegistryEntry {
+struct EventRegistryEntry:
+  public TypeIdentifierBase
+{
   EventRegistryEntry(const std::type_info& ti);
   
   // Next entry in the list:
@@ -16,19 +18,9 @@ struct EventRegistryEntry {
   const std::type_info& ti;
   
   /// <summary>
-  /// The runtime type information corresponding to this entry
-  /// </summary>
-  virtual const std::type_info& GetTypeInfo(void) const = 0;
-  
-  /// <summary>
   /// Constructor method, used to generate a new junction box
   /// </summary>
   virtual std::shared_ptr<JunctionBoxBase> NewJunctionBox(void) const = 0;
-  
-  /// <summary>
-  /// Used to create a type identifier value, for use with AutoNet
-  /// </summary>
-  virtual std::shared_ptr<TypeIdentifierBase> NewTypeIdentifier(void) const = 0;
 };
 
 template<class T>
@@ -38,20 +30,16 @@ struct EventRegistryEntryT:
   EventRegistryEntryT(void):
     EventRegistryEntry(typeid(T))
   {}
-  
+
   virtual const std::type_info& GetTypeInfo(void) const override { return typeid(T); }
-
-
+  
   virtual std::shared_ptr<JunctionBoxBase> NewJunctionBox(void) const override {
-    return std::static_pointer_cast<JunctionBoxBase>(
-      std::make_shared<JunctionBox<T>>()
-    );
+    return std::make_shared<JunctionBox<T>>();
   }
 
-  std::shared_ptr<TypeIdentifierBase> NewTypeIdentifier(void) const override {
-    return std::static_pointer_cast<TypeIdentifierBase>(
-      std::make_shared<TypeIdentifier<T>>()
-    );
+  // true if "obj" is an event receiver for T
+  bool IsSameAs(const CoreObject* obj) const override {
+    return !!dynamic_cast<const T*>(obj);
   }
 };
 

--- a/autowiring/TypeIdentifier.h
+++ b/autowiring/TypeIdentifier.h
@@ -5,20 +5,13 @@
 
 // Checks if an Object* listens to a event T;
 struct TypeIdentifierBase {
-  virtual bool IsSameAs(const CoreObject* obj) = 0;
-  virtual const std::type_info& Type() = 0;
-};
+  /// <summary>
+  /// The runtime type information corresponding to this identifier
+  /// </summary>
+  virtual const std::type_info& GetTypeInfo(void) const = 0;
 
-template<typename T>
-  struct TypeIdentifier:
-public TypeIdentifierBase
-{
-  // true if "obj" is an event receiver for T
-  bool IsSameAs(const CoreObject* obj) override {
-    return !!dynamic_cast<const T*>(obj);
-  }
-  
-  const std::type_info& Type() override {
-    return typeid(T);
-  }
+  /// <returns>
+  /// True if this type identifier can cast the specified CoreObject
+  /// </returns>
+  virtual bool IsSameAs(const CoreObject* obj) const = 0;
 };

--- a/autowiring/TypeRegistry.h
+++ b/autowiring/TypeRegistry.h
@@ -10,7 +10,9 @@ namespace autowiring {
   void InjectCurrent(void);
 }
 
-struct TypeRegistryEntry {
+struct TypeRegistryEntry:
+  public TypeIdentifierBase
+{
   TypeRegistryEntry(const std::type_info& ti);
 
   // Next entry in the list:
@@ -18,16 +20,6 @@ struct TypeRegistryEntry {
 
   // Type of this entry:
   const std::type_info& ti;
-
-  /// <summary>
-  /// The runtime type information corresponding to this entry
-  /// </summary>
-  virtual const std::type_info& GetTypeInfo(void) const = 0;
-
-  /// <summary>
-  /// Used to create a type identifier value, for use with AutoNet
-  /// </summary>
-  virtual std::shared_ptr<TypeIdentifierBase> NewTypeIdentifier(void) const = 0;
 
   /// <summary>
   /// Returns true if an injection is possible on the described type
@@ -57,10 +49,9 @@ struct TypeRegistryEntryT:
 
   virtual const std::type_info& GetTypeInfo(void) const override { return typeid(T); }
 
-  std::shared_ptr<TypeIdentifierBase> NewTypeIdentifier(void) const override {
-    return std::static_pointer_cast<TypeIdentifierBase>(
-      std::make_shared<TypeIdentifier<T>>()
-    );
+  // true if "obj" is an event receiver for T
+  bool IsSameAs(const CoreObject* obj) const override {
+    return !!dynamic_cast<const T*>(obj);
   }
 
   bool CanInject(void) const override {

--- a/src/autonet/AutoNetServerImpl.cpp
+++ b/src/autonet/AutoNetServerImpl.cpp
@@ -57,7 +57,7 @@ AutoNetServerImpl::AutoNetServerImpl(std::unique_ptr<AutoNetTransport>&& transpo
 
   // Generate list of all events from event registry
   for(auto event = g_pFirstEventEntry; event; event = event->pFlink)
-    m_EventTypes.insert(event->NewTypeIdentifier());
+    m_EventTypes.insert(event);
 }
 
 AutoNetServerImpl::~AutoNetServerImpl(){}
@@ -233,8 +233,8 @@ void AutoNetServerImpl::NewObject(CoreContext& ctxt, const CoreObjectDescriptor&
     {
       Json::array listenerTypes;
       for(const auto& event : m_EventTypes) {
-        if(event->IsSameAs(object.pCoreObject.get()))
-          listenerTypes.push_back(autowiring::demangle(event->Type()));
+        if (object.receivesEvents)
+          listenerTypes.push_back(autowiring::demangle(event->GetTypeInfo()));
       }
 
       if(!listenerTypes.empty())

--- a/src/autonet/AutoNetServerImpl.hpp
+++ b/src/autonet/AutoNetServerImpl.hpp
@@ -145,7 +145,7 @@ protected:
   std::map<int, CoreContext*> m_ContextPtrs;
 
   // All event types
-  std::set<std::shared_ptr<TypeIdentifierBase>> m_EventTypes;
+  std::set<const TypeIdentifierBase*> m_EventTypes;
 
   // All ContextMembers
   std::map<std::string, std::function<void(void)>> m_AllTypes;


### PR DESCRIPTION
There's no need to construct `TypeIdentifier` instances as shared pointers because there is no mutable data stored here.  Instead, make use of the underlying interface directly in all places where GetTypeIdentifier would have been used.