### PR TITLE
AutoPacket::Get must throw exceptions for multiply present decorations

### DIFF
--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -324,6 +324,12 @@ void AutoPacket::ThrowNotDecoratedException(const DecorationKey& key) {
   throw std::runtime_error(ss.str());
 }
 
+void AutoPacket::ThrowMultiplyDecoratedException(const DecorationKey& key) {
+  std::stringstream ss;
+  ss << "Attempted to obtain a type " << autowiring::demangle(key.ti) << " which was decorated more than once on this packet";
+  throw std::runtime_error(ss.str());
+}
+
 size_t AutoPacket::GetDecorationTypeCount(void) const
 {
   std::lock_guard<std::mutex> lk(m_lock);

--- a/src/autowiring/test/AutoPacketTest.cpp
+++ b/src/autowiring/test/AutoPacketTest.cpp
@@ -43,3 +43,22 @@ TEST_F(AutoPacketTest, FactoryCallTest) {
 
   ASSERT_TRUE(bCalled);
 }
+
+TEST_F(AutoPacketTest, MultipleDecorateGetFailures) {
+  // Decorate with two integer types:
+  *factory += [](int& arg) { arg = 0; };
+  *factory += [](int& arg) { arg = 1; };
+
+  // Now issue the packet:
+  auto packet = factory->NewPacket();
+
+  // Any type of "Get" call made on int should fail now
+  {
+    const int* out;
+    ASSERT_ANY_THROW(packet->Get(out));
+  }
+  {
+    const std::shared_ptr<const int>* out;
+    ASSERT_ANY_THROW(packet->Get(out));
+  }
+}


### PR DESCRIPTION
This is because this variant assumes that there are zero or one decorations present on the packet; when this assumption is violated, we shouldn't simply return control to the caller as though there are no decorations present; rather, this exceptional case should be handled expressly as it indicates a violation of convention has taken place.