### PR TITLE
Adding a double-check for operator-> and operator*

### DIFF
--- a/autowiring/AutowirableSlot.h
+++ b/autowiring/AutowirableSlot.h
@@ -184,15 +184,23 @@ public:
     // where we can guarantee that the type will be completely defined, because the user is about
     // to make use of this type.
     (void) autowiring::fast_pointer_cast_initializer<T, CoreObject>::sc_init;
-    return get();
+
+    auto retVal = get();
+    if (!retVal)
+      throw autowiring_error("Attempted to dereference a null autowired field");
+    return retVal;
   }
 
   T& operator*(void) const {
+    auto retVal = get();
+    if (!retVal)
+      throw autowiring_error("Attempted to dereference a null autowired field");
+
     // We have to initialize here, in the operator context, because we don't actually know if the
     // user will be making use of this type.
     (void) autowiring::fast_pointer_cast_initializer<T, CoreObject>::sc_init;
 
-    return *get();
+    return *retVal;
   }
 
   using AnySharedPointer::operator=;

--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -331,6 +331,20 @@ public:
     return std::shared_ptr<T>::get();
   }
 
+  T* operator->(void) const {
+    auto retVal = std::shared_ptr<T>::operator->();
+    if (!retVal)
+      throw autowiring_error("Attempted to dereference a null autowired field");
+    return retVal;
+  }
+
+  T& operator*(void) const {
+    auto retVal = std::shared_ptr<T>::operator*();
+    if (!retVal)
+      throw autowiring_error("Attempted to dereference a null autowired field");
+    return retVal;
+  }
+
   bool IsAutowired(void) const { return std::shared_ptr<T>::get() != nullptr; }
 };
 

--- a/src/autowiring/test/AutowiringTest.cpp
+++ b/src/autowiring/test/AutowiringTest.cpp
@@ -178,3 +178,9 @@ TEST_F(AutowiringTest, StaticNewWithArgs) {
     ctxt->SignalShutdown(true);
   }
 }
+
+TEST_F(AutowiringTest, NullDereferenceAttempt) {
+  Autowired<SimpleObject> co;
+  ASSERT_ANY_THROW(*co) << "A dereference attempt on a CoreObject did not throw an exception as expected";
+  ASSERT_ANY_THROW(co->one) << "A dereference attempt on a CoreObject did not throw an exception as expected";
+}


### PR DESCRIPTION
An attempt to dereference an Autowired or AutowiredFast field should result in an exception, rather than just crashing due to a null pointer dereference.