### PR TITLE
Reintroducing CoreContext::Add

### DIFF
--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -350,3 +350,14 @@ TEST_F(CoreContextTest, InitiateMultipleChildren) {
     outerCtxt->SignalShutdown(true);
   }
 }
+
+class CoreContextAddTestClass {};
+
+TEST_F(CoreContextTest, CoreContextAdd) {
+  auto myClass = std::make_shared<CoreContextAddTestClass>();
+  AutoCurrentContext ctxt;
+  ctxt->Add(myClass);
+
+  Autowired<CoreContextAddTestClass> mc;
+  ASSERT_TRUE(mc.IsAutowired()) << "Manually registered interface was not detected as expected";
+}


### PR DESCRIPTION
This method allows users to explicitly register a type in a context for discovery without making that type fully present in the context as a concrete type.  The specified interface will not be the subject of event receipt nor will it participate in `AutoFilter` networks.  `CoreContext::Add` is the logical counterpart to `CoreContext::Snoop`.