### PR TITLE
Correcting accidental copy

### DIFF
--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -332,17 +332,17 @@ public:
   }
 
   T* operator->(void) const {
-    auto retVal = std::shared_ptr<T>::operator->();
+    auto* retVal = std::shared_ptr<T>::operator->();
     if (!retVal)
       throw autowiring_error("Attempted to dereference a null autowired field");
     return retVal;
   }
 
   T& operator*(void) const {
-    auto retVal = std::shared_ptr<T>::operator*();
+    T* retVal = std::shared_ptr<T>::get();
     if (!retVal)
       throw autowiring_error("Attempted to dereference a null autowired field");
-    return retVal;
+    return *retVal;
   }
 
   bool IsAutowired(void) const { return std::shared_ptr<T>::get() != nullptr; }

--- a/src/autowiring/test/AutowiringTest.cpp
+++ b/src/autowiring/test/AutowiringTest.cpp
@@ -184,3 +184,9 @@ TEST_F(AutowiringTest, NullDereferenceAttempt) {
   ASSERT_ANY_THROW(*co) << "A dereference attempt on a CoreObject did not throw an exception as expected";
   ASSERT_ANY_THROW(co->one) << "A dereference attempt on a CoreObject did not throw an exception as expected";
 }
+
+TEST_F(AutowiringTest, FastNullDereferenceAttempt) {
+  AutowiredFast<SimpleObject> co;
+  ASSERT_ANY_THROW(*co) << "A dereference attempt on a CoreObject did not throw an exception as expected";
+  ASSERT_ANY_THROW(co->one) << "A dereference attempt on a CoreObject did not throw an exception as expected";
+}


### PR DESCRIPTION
MSVC thinks that this statement is meant to create a copy of the return value of operator*, add a ref-qualifier to disambiguate.

- [x] Unit test added to guard against regressions here