### PR TITLE
Correcting 64-bit Windows unit test failure

### DIFF
--- a/autowiring/auto_future_win.h
+++ b/autowiring/auto_future_win.h
@@ -4,12 +4,30 @@
 #include <stdexcept>
 
 namespace autowiring {
+  #pragma pack(push, _CRT_PACKING)
+
   template<typename _Ret, typename... _ArgTypes>
   class _Packaged_state_unwrap:
-    public std::_Associated_state<_Ret*>
+    public std::_Associated_state<_Ret>
   {
   public:
     std::function<_Ret(_ArgTypes...)> _Fn;
+  };
+
+  template<typename _Ret, typename... _ArgTypes>
+  class _Packaged_state_unwrap<_Ret&, _ArgTypes...>:
+    public std::_Associated_state<_Ret*>
+  {
+  public:
+    std::function<_Ret&(_ArgTypes...)> _Fn;
+  };
+
+  template<typename... _ArgTypes>
+  class _Packaged_state_unwrap<void, _ArgTypes...>:
+    public std::_Associated_state<int>
+  {
+  public:
+    std::function<void(_ArgTypes...)> _Fn;
   };
 
   class _Task_async_state_unwrap:
@@ -18,6 +36,7 @@ namespace autowiring {
   public:
     ::Concurrency::task<void> _Task;
   };
+  #pragma pack(pop)
 
   /// <summary>
   /// Platform-specific operation appending routine
@@ -35,6 +54,11 @@ namespace autowiring {
     } else if (auto* deferredAsync = dynamic_cast<std::_Deferred_async_state<T>*>(ptr)) {
       auto* packagedState = static_cast<std::_Packaged_state<T()>*>(deferredAsync);
       auto* unwrap = reinterpret_cast<_Packaged_state_unwrap<T>*>(packagedState);
+
+      static_assert(
+        sizeof(*packagedState) == sizeof(*unwrap),
+        "Size of unwrapped version differs from underlying version, internal API has changed"
+      );
 
       // New function which consists of a call to the original then a call to the continuation
       unwrap->_Fn = std::bind(


### PR DESCRIPTION
Issue has to do with layout changes in the `_Packaged_task` structure.  Added an additional static assertion to catch these layout changes if they occur on other build configurations in the future.