### PR TITLE
Eliminate libstdc++ support from CMakeLists

### DIFF
--- a/AutowiringConfig.h.in
+++ b/AutowiringConfig.h.in
@@ -10,11 +10,3 @@
 
 // Building for ARM?
 #cmakedefine01 autowiring_BUILD_ARM
-
-// Are we linking with C++11 STL?
-#cmakedefine01 autowiring_USE_LIBCXX
-#if autowiring_USE_LIBCXX
-#define AUTOWIRING_USE_LIBCXX 1
-#else
-#define AUTOWIRING_USE_LIBCXX 0
-#endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,33 +40,6 @@ if(EXTERNAL_LIBRARY_DIR)
   list(APPEND CMAKE_INCLUDE_PATH ${EXTERNAL_LIBRARY_DIR})
 endif()
 
-if(APPLE)
-  # Offer option for autowiring_USE_LIBCXX
-  # Check for existing definition of autowiring_USE_LIBCXX
-  if(NOT DEFINED autowiring_USE_LIBCXX)
-    option(autowiring_USE_LIBCXX "Build Autowiring using c++11" ON)
-  else()
-    if(NOT autowiring_USE_LIBCXX)
-      message("Parent project has set autowiring_USE_LIBCXX = OFF -> Build Autowiring using c++98")
-    endif()
-  endif()
-
-  # Install autoboost when using libstdc++
-  if(autowiring_USE_LIBCXX)
-    set(autowiring_INSTALL_AUTOBOOST OFF)
-  else()
-    set(autowiring_INSTALL_AUTOBOOST ON)
-  endif()
-else()
-  # Always use libc++ on other platforms
-  set(autowiring_USE_LIBCXX ON)
-
-  # Don't install autoboost unless otherwise specified
-  if(NOT DEFINED autowiring_INSTALL_AUTOBOOST)
-    set(autowiring_INSTALL_AUTOBOOST OFF)
-  endif()
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCC)
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.8")
     message(FATAL_ERROR "GCC version 4.8 minimum is required to build Autowiring")
@@ -86,16 +59,9 @@ endif()
 
 # Clang needs special additional flags to build with C++11
 if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-  # Apple needs us to tell it that we're using libc++, or it will try to use libstdc++ instead
-  if(autowiring_USE_LIBCXX)
-    message(STATUS "AppleClang C++11")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-    set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
-  else()
-    message(STATUS "AppleClang C++11 with libstdc++")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
-    set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libstdc++")
-  endif()
+  message(STATUS "AppleClang C++11")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   message(STATUS "Clang C++11")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lstdc++")
@@ -223,15 +189,6 @@ if(NOT AUTOWIRING_IS_EMBEDDED)
     COMPONENT autowiring
     FILES_MATCHING PATTERN "*.h"
   )
-
-  # Install autoboost headers
-  if(autowiring_INSTALL_AUTOBOOST)
-    install(
-      DIRECTORY ${PROJECT_SOURCE_DIR}/contrib/autoboost/autoboost
-      DESTINATION include
-      COMPONENT autowiring
-    )
-  endif()
 
   # Targets file is needed in order to describe how to link Autowiring to the rest of the system
   install(EXPORT AutowiringTargets FILE AutowiringTargets.cmake COMPONENT autowiring NAMESPACE Autowiring:: DESTINATION cmake CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES})

--- a/autowiring-configVersion.cmake.in
+++ b/autowiring-configVersion.cmake.in
@@ -12,9 +12,6 @@ if(autowiring_DEBUG)
 
   message(STATUS "Installed CMAKE_SIZEOF_VOID_P: @CMAKE_SIZEOF_VOID_P@")
   message(STATUS "Configured CMAKE_SIZEOF_VOID_P: ${CMAKE_SIZEOF_VOID_P}")
-
-  message(STATUS "Installed using autowiring_USE_LIBCXX: @autowiring_USE_LIBCXX@")
-  message(STATUS "Configured using autowiring_USE_LIBCXX: ${autowiring_USE_LIBCXX}")
 endif()
 
 # If the customer has an override architecture requirement, use that
@@ -73,25 +70,21 @@ endforeach()
 # Determine whether the user's request (either implied or explicit) for libstdc++ can
 # be met by this verison of Autowiring
 if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-  # If this value isn't defined, then we assume the user's request is "on"
-  if(NOT DEFINED autowiring_USE_LIBCXX)
-    SET(autowiring_USE_LIBCXX ON)
+  # Require that the user either omit autowiring_USE_LIBCXX or leave it off
+  if(DEFINED autowiring_USE_LIBCXX)
+    if(autowiring_USE_LIBCXX)
+      message(WARNING "Autowiring no longer supports libstdc++, autowiring_USE_LIBCXX is therefore a deprecated flag")
+    else()
+      message(STATUS "Autowiring no longer supports libstdc++")
+      set(PACKAGE_VERSION_COMPATIBLE FALSE)
+      set(PACKAGE_VERSION_UNSUITABLE TRUE)
+      return()
+    endif()
   endif()
   
   if(autowiring_DEBUG)
     message(STATUS "Installed autowiring_USE_LIBCXX: @autowiring_USE_LIBCXX@")
     message(STATUS "Configured autowiring_USE_LIBCXX: ${autowiring_USE_LIBCXX}")
-  endif()
-
-  # Our built version must be the same as the requested version.  If it's not, then we are
-  # not a match for the user's request
-  if((NOT ${autowiring_USE_LIBCXX} AND @autowiring_USE_LIBCXX@) OR (${autowiring_USE_LIBCXX} AND NOT @autowiring_USE_LIBCXX@))
-    if(autowiring_DEBUG)
-      message("User C++ runtime library request incompatible with locally built version")
-    endif()
-    set(PACKAGE_VERSION_COMPATIBLE FALSE)
-    set(PACKAGE_VERSION_UNSUITABLE TRUE)
-    return()
   endif()
 endif()
 

--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -458,18 +458,10 @@ public:
       }
 
       // Now trigger a rescan to hit any deferred, unsatisfiable entries:
-#if autowiring_USE_LIBCXX
       for (const std::type_info* ti : {&auto_id<T>::key(), &auto_id<Ts>::key()...}) {
         MarkUnsatisfiable(DecorationKey(*ti, true, 0));
         MarkUnsatisfiable(DecorationKey(*ti, false, 0));
       }
-#else
-      bool dummy[] = {
-        (MarkUnsatisfiable(DecorationKey(auto_id<T>::key(), false, 0)), false),
-        (MarkUnsatisfiable(DecorationKey(auto_id<Ts>::key(), false, 0)), false)...
-      };
-      (void)dummy;
-#endif
     }),
     PulseSatisfaction(pTypeSubs, 1 + sizeof...(Ts));
   }

--- a/autowiring/C++11/cpp11.h
+++ b/autowiring/C++11/cpp11.h
@@ -131,11 +131,7 @@
 #endif
 
 #if TYPE_TRAITS_AVAILABLE
-  #if defined(_MSC_VER) || defined(_LIBCPP_VERSION)
-    #define TYPE_TRAITS_HEADER <type_traits>
-  #else
-    #define TYPE_TRAITS_HEADER <type_traits>
-  #endif
+  #define TYPE_TRAITS_HEADER <type_traits>
 #else
   #define TYPE_TRAITS_HEADER <autowiring/C++11/boost_type_traits.h>
 #endif

--- a/src/autonet/CMakeLists.txt
+++ b/src/autonet/CMakeLists.txt
@@ -1,8 +1,3 @@
-if(NOT WIN32 AND NOT autowiring_USE_LIBCXX)
-  message("Cannot build Autonet, requires proper C++11 support")
-  return()
-endif()
-
 add_googletest(test)
 include_directories(
   ${PROJECT_SOURCE_DIR}/contrib/autoboost

--- a/src/autowiring/AutoPacketInternal.cpp
+++ b/src/autowiring/AutoPacketInternal.cpp
@@ -43,12 +43,7 @@ void AutoPacketInternal::Initialize(bool isFirstPacket) {
     call->GetCall()(call->GetAutoFilter(), *this);
 
   // First-call indicated by argumument type AutoPacket&:
-#if autowiring_USE_LIBCXX
   for (bool is_shared : {false, true}) {
-#else
-  for (int num = 0; num < 2; ++num) {
-    bool is_shared = (bool)num;
-#endif
     std::unique_lock<std::mutex> lk(m_lock);
 
     // Don't modify the decorations set if nobody expects an AutoPacket input

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -5,6 +5,9 @@ set(AutowiringTest_SRCS
   AutoConstructTest.cpp
   AutoFilterCollapseRulesTest.cpp
   AutoFilterDiagnosticsTest.cpp
+  AutoFilterFunctionTest.cpp
+  AutoFilterSequencing.cpp
+  AutoFilterTest.cpp
   AutoInjectableTest.cpp
   AutoPacketTest.cpp
   AutoPacketFactoryTest.cpp
@@ -65,14 +68,6 @@ add_windows_sources(
   AutowiringTest_SRCS
   AutoFutureTest.cpp
 )
-
-if(autowiring_USE_LIBCXX)
-  set(AutowiringTest_SRCS ${AutowiringTest_SRCS}
-    AutoFilterFunctionTest.cpp
-    AutoFilterSequencing.cpp
-    AutoFilterTest.cpp
-  )
-endif()
 
 set(AutowiringFixture_SRCS
   HasForwardOnlyType.hpp


### PR DESCRIPTION
Closes #448 

The time has finally come to eliminate support for libstdc++ once and for all.  We will start by short-circuiting all preprocessor blocks and macros that make references to libcxx.  Then comes the slow, arduous process of fixing all of the stupid backflips that we had to make to classes such as `ObjectPool` to make them compatible with libstdc++.

libstdc++ is dead.  Long live libc++