### PR TITLE
Add a version number linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ before_install:
   # Enforce Leap Motion copyright notice
   - ./scripts/copyright_check.sh
 
+  # Verify that our version numbers all line up
+  - ./scripts/version_number_updated.sh
+
   # g++4.8.1
   - if [ "$CXX" == "g++" ]; then
       sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/publicDoxyfile.conf
+++ b/publicDoxyfile.conf
@@ -38,7 +38,7 @@ PROJECT_NAME           = Autowiring
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.4.2
+PROJECT_NUMBER         = 0.4.5
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/scripts/version_number_updated.sh
+++ b/scripts/version_number_updated.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+#
+# Ensure that the version.cmake version number is the same everywhere
+#
+
+# Get the version number from version.cmake first
+if ! version=$(grep -oE "[0-9]+.[0-9]+.[0-9]+" version.cmake); then
+  echo "Version number not found in version.cmake"
+  exit 1
+fi
+
+# Verify that this identical version number appears in our doxygen files
+if ! grep $version Doxyfile; then
+  echo "Expected to find version $version in Doxyfile"
+  exit 1
+fi
+if ! grep $version publicDoxyfile.conf; then
+  echo "Expected to find version $version in publicDoxyfile.conf"
+  exit 1
+fi


### PR DESCRIPTION
We have to copy the version number in (currently) three different places, and it's easy to miss one.  This ensures that these three spots all report the same number.