### PR TITLE
Throw an exception instead of asserting

### DIFF
--- a/src/autowiring/JunctionBoxManager.cpp
+++ b/src/autowiring/JunctionBoxManager.cpp
@@ -26,7 +26,9 @@ JunctionBoxManager::~JunctionBoxManager(void) {}
 
 std::shared_ptr<JunctionBoxBase> JunctionBoxManager::Get(const std::type_index& pTypeIndex) {
   auto box = m_junctionBoxes.find(pTypeIndex);
-  assert(box != m_junctionBoxes.end() && "If JunctionBox isn't found, EventRegistry isn't working");
+  if (box == m_junctionBoxes.end())
+    throw autowiring_error("Attempted to obtain a junction box for an unregistered type");
+
   return box->second;
 }
 


### PR DESCRIPTION
When the JunctionBoxManager can't find a specified type, an exception is likely to be more informative and at least provide users with a way of gracefully recovering from this condition.