### PR TITLE
Make CoreObjectDescriptor's actual_type field return auto_id wrapped typ...

### DIFF
--- a/autowiring/CoreObjectDescriptor.h
+++ b/autowiring/CoreObjectDescriptor.h
@@ -26,7 +26,7 @@ struct CoreObjectDescriptor {
   template<typename TActual, typename T>
   CoreObjectDescriptor(const std::shared_ptr<TActual>& value, T*) :
     type(&typeid(T)),
-    actual_type(&typeid(*value)),
+    actual_type(&typeid(auto_id<TActual>)),
     stump(&SlotInformationStump<T>::s_stump),
     value(value),
     subscriber(MakeAutoFilterDescriptor(value)),

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -249,7 +249,7 @@ void CoreContext::AddInternal(const CoreObjectDescriptor& traits) {
     auto q = m_typeMemos.find(*traits.actual_type);
     if(q != m_typeMemos.end()) {
       auto& v = q->second;
-      if(*v.m_value == traits.pCoreObject)
+      if(traits.pCoreObject && *v.m_value == traits.pCoreObject)
         throw std::runtime_error("An attempt was made to add the same value to the same context more than once");
       if(*v.m_value)
         throw std::runtime_error("An attempt was made to add the same type to the same context more than once");


### PR DESCRIPTION
Resolves a problem where the find command in CoreContext.cpp:249 was never hit.