### PR TITLE
Add ContextEnumeratorT::unique and a default parameter

### DIFF
--- a/autowiring/ContextEnumerator.h
+++ b/autowiring/ContextEnumerator.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include "autowiring_error.h"
 #include MEMORY_HEADER
 
 class CoreContext;
@@ -26,6 +27,11 @@ class CoreContextT;
 class ContextEnumerator
 {
 public:
+  /// <summary>
+  /// Constructs a context enumerator for the current context
+  /// </summary>
+  ContextEnumerator(void);
+
   /// <summary>
   /// Constructs an enumerator which may enumerate all of the contexts rooted at the specified root
   /// </summary>
@@ -96,7 +102,9 @@ class ContextEnumeratorT:
   public ContextEnumerator
 {
 public:
-  ContextEnumeratorT(const std::shared_ptr<CoreContext>& ctxt):
+  ContextEnumeratorT()
+  {}
+  ContextEnumeratorT(const std::shared_ptr<CoreContext>& ctxt) :
     ContextEnumerator(ctxt)
   {}
 
@@ -129,6 +137,18 @@ public:
     std::shared_ptr<CoreContextT<Sigil>> operator*(void) const { return std::static_pointer_cast<CoreContextT<Sigil>>(m_cur); }
     const CoreContext& operator->(void) const { return ***this; }
   };
+
+  // Convenience routine for returning a single unique element
+  std::shared_ptr<CoreContext> unique(void) {
+    iterator q = begin();
+    iterator r = q;
+
+    // If advancing q gets us to the end, then we only have one element and we can return success
+    if (++q == end())
+      return *r;
+
+    throw autowiring_error("Attempted to get a unique context on a context enumerator that enumerates more than one child");
+  }
 
   // Standard STL duck interface methods:
   iterator begin(void) { return iterator(m_root, m_root); };

--- a/src/autowiring/ContextEnumerator.cpp
+++ b/src/autowiring/ContextEnumerator.cpp
@@ -3,7 +3,11 @@
 #include "ContextEnumerator.h"
 #include "CoreContext.h"
 
-ContextEnumerator::ContextEnumerator(const std::shared_ptr<CoreContext>& root):
+ContextEnumerator::ContextEnumerator(void) :
+  m_root(CoreContext::CurrentContext())
+{}
+
+ContextEnumerator::ContextEnumerator(const std::shared_ptr<CoreContext>& root) :
   m_root(root)
 {}
 

--- a/src/autowiring/test/ContextEnumeratorTest.cpp
+++ b/src/autowiring/test/ContextEnumeratorTest.cpp
@@ -172,3 +172,16 @@ TEST_F(ContextEnumeratorTest, ComplexRemovalInterference) {
     ASSERT_TRUE(cur.expired()) << "Found an element that was iterated after it should have been unreachable";
 }
 
+TEST_F(ContextEnumeratorTest, Unique) {
+  AutoCreateContextT<NamedContext> named;
+  ASSERT_EQ(named, ContextEnumeratorT<NamedContext>().unique()) <<
+    "Expected the unique context to be equal to the specifically named child context";
+}
+
+TEST_F(ContextEnumeratorTest, BadUnique) {
+  AutoCreateContextT<NamedContext> named1;
+  AutoCreateContextT<NamedContext> named2;
+
+  ASSERT_THROW(ContextEnumeratorT<NamedContext>().unique(), autowiring_error) <<
+    "An attempt to obtain a unique context from an enumerator providing more than one should throw an exception";
+}


### PR DESCRIPTION
Often, ContextEnumerator is used to obtain a single item.  Provide a helper routine which checks the single item assumption and also simplify the constructor syntax to make ContextEnumeratorT easier to use.