### PR TITLE
Make ContextEnumerator a ForwardIterator

### DIFF
--- a/autowiring/ContextEnumerator.h
+++ b/autowiring/ContextEnumerator.h
@@ -47,7 +47,7 @@ public:
   /// The iterator class which is actually used in enumerating contexts
   class iterator {
   public:
-    typedef std::input_iterator_tag iterator_category;
+    typedef std::forward_iterator_tag iterator_category;
     typedef const std::shared_ptr<CoreContext>& value_type;
     typedef size_t difference_type;
     typedef const std::shared_ptr<CoreContext>* pointer;
@@ -73,8 +73,10 @@ public:
     
     // Operator overloads:
     const iterator& operator++(void);
+    iterator operator++(int);
+
     const std::shared_ptr<CoreContext>& operator*(void) const { return m_cur; }
-    const CoreContext& operator->(void) const { return ***this; }
+    const std::shared_ptr<CoreContext>& operator->(void) const { return m_cur; }
     bool operator==(const iterator& rhs) const { return m_root == rhs.m_root && m_cur == rhs.m_cur; }
     bool operator!=(const iterator& rhs) const { return !(*this == rhs); }
     explicit operator bool(void) const { return !!m_cur.get(); }
@@ -132,6 +134,13 @@ public:
       ContextEnumerator::iterator::operator++();
       _advance();
       return *this;
+    }
+
+    iterator operator++(int) {
+      auto retVal = *this;
+      ContextEnumerator::iterator::operator++(0);
+      _advance();
+      return retVal;
     }
 
     std::shared_ptr<CoreContextT<Sigil>> operator*(void) const { return std::static_pointer_cast<CoreContextT<Sigil>>(m_cur); }

--- a/src/autowiring/ContextEnumerator.cpp
+++ b/src/autowiring/ContextEnumerator.cpp
@@ -50,6 +50,12 @@ const ContextEnumerator::iterator& ContextEnumerator::iterator::operator++(void)
   return *this;
 }
 
+ContextEnumerator::iterator ContextEnumerator::iterator::operator++(int) {
+  auto retVal = *this;
+  _next(m_cur->FirstChild());
+  return retVal;
+}
+
 CurrentContextEnumerator::CurrentContextEnumerator(void) :
   ContextEnumerator(CoreContext::CurrentContext())
 {

--- a/src/autowiring/test/ContextEnumeratorTest.cpp
+++ b/src/autowiring/test/ContextEnumeratorTest.cpp
@@ -11,7 +11,7 @@ class ContextEnumeratorTest:
 TEST_F(ContextEnumeratorTest, DegenerateEnumeration) {
   size_t ct = 0;
   for(const auto& cur : ContextEnumerator(std::shared_ptr<CoreContext>(nullptr))) {
-    ASSERT_TRUE(!!cur.get()) << "Context enumerator incorrectly enumerated a null context pointer";
+    ASSERT_TRUE(!!cur) << "Context enumerator incorrectly enumerated a null context pointer";
     ct++;
   }
   ASSERT_EQ(0UL, ct) << "An empty enumerator unexpectedly enumerated one or more entries";
@@ -184,4 +184,35 @@ TEST_F(ContextEnumeratorTest, BadUnique) {
 
   ASSERT_THROW(ContextEnumeratorT<NamedContext>().unique(), autowiring_error) <<
     "An attempt to obtain a unique context from an enumerator providing more than one should throw an exception";
+}
+
+TEST_F(ContextEnumeratorTest, ForwardIteratorCheck) {
+  static_assert(std::is_default_constructible<ContextEnumerator::iterator>::value, "ForwardIterator constraint requires iterators to be default-constructable");
+  static_assert(
+    std::is_same<
+      std::iterator_traits<ContextEnumerator::iterator>::iterator_category,
+      std::forward_iterator_tag
+    >::value,
+    "ContextEnumerator iterator not recognized as a forward iterator"
+  );
+
+  AutoCreateContext ctxt1;
+  AutoCreateContext ctxt2;
+  AutoCreateContext ctxt2_0(ctxt2);
+  AutoCreateContext ctxt2_1(ctxt2);
+  AutoCreateContext ctxt2_1_0(ctxt2_1);
+  AutoCreateContext ctxt3;
+
+  ContextEnumerator e;
+  auto a = e.begin();
+  auto b = e.begin();
+
+  ASSERT_EQ(a++, b++) << "Incrementation equivalence was not satisfied";
+  ASSERT_EQ(a, b) << "Iterators not equivalent after incrementation";
+
+  auto prior = *b;
+  a++;
+  ASSERT_EQ(prior, *b) << "Incrementation of an unrelated iterator invalidated a copy of that iterator";
+  ++b;
+  ASSERT_EQ(a, b) << "Postfix and prefix incrementation are not equivalently implemented";
 }

--- a/src/autowiring/test/ContextEnumeratorTest.cpp
+++ b/src/autowiring/test/ContextEnumeratorTest.cpp
@@ -215,4 +215,12 @@ TEST_F(ContextEnumeratorTest, ForwardIteratorCheck) {
   ASSERT_EQ(prior, *b) << "Incrementation of an unrelated iterator invalidated a copy of that iterator";
   ++b;
   ASSERT_EQ(a, b) << "Postfix and prefix incrementation are not equivalently implemented";
+
+  a++;
+  ASSERT_EQ(a, std::next(b)) << "std::next did not correctly return the next iterator after the specified iterator";
+  b++;
+
+  std::advance(a, 1);
+  b++;
+  ASSERT_EQ(a, b) << "std::advance did not actually advance an iterator";
 }


### PR DESCRIPTION
This should make `ContextEnumerator::iterator` a bit more flexible for algorithms which cannot operate on an `InputIterator` alone.