### PR TITLE
AutoNetServerImpl must stop itself when an exception is thrown by CoreThread::Run

### DIFF
--- a/src/autonet/AutoNetServerImpl.cpp
+++ b/src/autonet/AutoNetServerImpl.cpp
@@ -83,7 +83,14 @@ void AutoNetServerImpl::Run(void){
   });
 
   PollThreadUtilization(std::chrono::milliseconds(1000));
-  CoreThread::Run();
+
+  try {
+    CoreThread::Run();
+  }
+  catch (...) {
+    Stop();
+    throw;
+  }
 }
 
 void AutoNetServerImpl::OnStop(void) {


### PR DESCRIPTION
We have an `std::future` in scope at this point.  This future will block and wait for the transport to terminate, which won't happen until the context is stopped.  This will prevent the `CoreThread::Run` unhandled exception handler from ever receiving control.  To prevent deadlock, this condition must be specifically addressed and prevented.