### PR TITLE
Enhance documentation and fix teardown listener behavior for BasicThread

### DIFF
--- a/autowiring/BasicThread.h
+++ b/autowiring/BasicThread.h
@@ -233,6 +233,26 @@ public:
   bool IsCompleted(void) const;
 
   /// <summary>
+  /// Adds a function object which will be called when this BasicThread stops running or is destroyed
+  /// </summary>
+  /// <remarks>
+  /// The listener is invoked before the destruction of this BasicThread and also immediately after the
+  /// BasicThread instance has transitioned to the Stopped state.
+  ///
+  /// Users who attach a teardown listener MUST NOT attempt to invoke any methods not defined by
+  /// BasicThread, and MUST NOT attempt to invoke any non-final virtual functions available here.  The
+  /// object itself may be partially destroyed by the time the listener is invoked, and virtual methods
+  /// may not have the expected behavior.
+  ///
+  /// It is guaranteed to be safe to call any non-virtual method defined by BasicThread from a teardown
+  /// listener.
+  /// </remarks>
+  template<class Fx>
+  void AddTeardownListener(Fx&& listener) {
+    return TeardownNotifier::AddTeardownListener(std::forward<Fx&&>(listener));
+  }
+
+  /// <summary>
   /// Begins thread execution.
   /// </summary>
   /// <remarks>

--- a/autowiring/ContextMember.h
+++ b/autowiring/ContextMember.h
@@ -38,7 +38,9 @@ public:
   /// <remarks>
   /// A context may be destroyed if and only if none of its members are running and none of
   /// them may enter a runnable state.  This happens when the last pointer to ContextMember
-  /// is lost.  Resource cleanup must be started at this point.
+  /// is lost.  Resource cleanup must be started at this point.  Context members are deemed
+  /// to be unable to enter a running state if they were not signalled to enter this state
+  /// before the last shared pointer to their outer CoreContext is released.
   ///
   /// For contexts containing strictly heirarchial objects, implementors of this method do
   /// not need to do anything.  If, however, there are circular references anywhere in the

--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -17,7 +17,9 @@ BasicThread::BasicThread(const char* pName):
   m_priority(ThreadPriority::Default)
 {}
 
-BasicThread::~BasicThread(void){}
+BasicThread::~BasicThread(void) {
+  NotifyTeardownListeners();
+}
 
 std::mutex& BasicThread::GetLock(void) {
   return m_state->m_lock;
@@ -64,12 +66,12 @@ void BasicThread::DoRunLoopCleanup(std::shared_ptr<CoreContext>&& ctxt, std::sha
   // need to hold a reference to.
   auto state = m_state;
 
-  // Perform a manual notification of teardown listeners
-  NotifyTeardownListeners();
-
   // Transition to stopped state.  Synchronization not required, transitions are all one-way
   m_stop = true;
   m_running = false;
+
+  // Perform a manual notification of teardown listeners
+  NotifyTeardownListeners();
 
   // Tell our CoreRunnable parent that we're done to ensure that our reference count will be cleared.
   Stop(false);


### PR DESCRIPTION
Add documentation to describe exactly when teardown listeners are raised for `BasicThread`.  Presently, the documentation for this method leaves things rather open-ended.  Also change NotifyTeardownListeners so it is invoked when the owning type is still a `BasicThread`, and only invoke `NotifyTeardownListeners` after the `BasicThread` has transitioned to the stopped state.