### PR TITLE
Feature signal upgrades

### DIFF
--- a/autowiring/Decompose.h
+++ b/autowiring/Decompose.h
@@ -1,11 +1,14 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "is_any.h"
+#include <tuple>
 #include <typeinfo>
 
 template<class... Ts>
 struct TemplatePack {
   static const int N = sizeof...(Ts);
+
+  typedef std::tuple<Ts...> t_args;
 
   /// <returns>
   /// An array of type T, parameterized by the bound function's arguments

--- a/autowiring/auto_signal.h
+++ b/autowiring/auto_signal.h
@@ -33,6 +33,9 @@ namespace autowiring {
       signal_node_base* pFlink;
       signal_node_base* pBlink;
       
+      /// <summary>
+      /// Removes this node from the list it's in, or throws if it's the head.
+      /// </summary>
       void remove(){
         // Clear linkage
         if (this->pBlink)
@@ -63,8 +66,20 @@ namespace autowiring {
       const std::function<void(Args...)> fn;
 
       using signal_node_base::remove;
-    };
 
+      /// <summary>
+      /// Appends the specified handler to this list of nodes.
+      /// </summary>
+      internal::signal_node<Args...>* operator+=(std::function<void(Args...)>&& fn) {
+        auto retVal = new internal::signal_node<Args...>(std::move(fn));
+        retVal->pBlink = this;
+        retVal->pFlink = pFlink;
+        if (pFlink)
+          pFlink->pBlink = retVal;
+        pFlink = retVal;
+        return retVal;
+      }
+    };
 
     struct signal_registration_base {
       signal_registration_base(void);
@@ -180,13 +195,7 @@ namespace autowiring {
     /// Attaches the specified handler to this signal
     /// </summary>
     internal::signal_node<Args...>* operator+=(std::function<void(Args...)>&& fn) {
-      auto retVal = new internal::signal_node<Args...>(std::move(fn));
-      retVal->pBlink = this;
-      retVal->pFlink = pFlink;
-      if (pFlink)
-        pFlink->pBlink = retVal;
-      pFlink = retVal;
-      return retVal;
+      return *reinterpret_cast<internal::signal_node<Args...>*>(this) += std::move(fn);
     }
   };
 

--- a/autowiring/auto_signal.h
+++ b/autowiring/auto_signal.h
@@ -62,11 +62,11 @@ namespace autowiring {
         fn(std::move(fn))
       {}
       
-      //Functions where the first argument is a signal_node_base are also ok.
-      signal_node(std::function<void(signal_node_base*, Args...)>&& newFn) :
-        fn([this, newFn](Args... args){ newFn(this, args...); })
+      //Functions where the first argument is a signal_node<...> or base type are also ok.
+      signal_node(std::function<void(signal_node<Args...>*, Args...)>&& newFn) :
+      fn([this, newFn](Args... args){ newFn(this, args...); })
       {}
-
+      
       const std::function<void(Args...)> fn;
 
       /// <summary>

--- a/autowiring/is_any.h
+++ b/autowiring/is_any.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include "C++11/cpp11.h"
 #include TYPE_TRAITS_HEADER
 
 /// <summary>

--- a/src/autowiring/test/AutoSignalTest.cpp
+++ b/src/autowiring/test/AutoSignalTest.cpp
@@ -135,7 +135,7 @@ TEST_F(AutoSignalTest, NodeRemoval) {
   
   ASSERT_ANY_THROW(signal1 -= registration2) << "Removing a registration from a different signal than it was registered to failed to throw an exception";
 
-  registration1->remove();
+  delete registration1;
   signal1();
   signal2();
   
@@ -213,7 +213,7 @@ TEST_F(AutoSignalTest, SelfRemovingCall) {
     ASSERT_EQ(magic, magic_number);
     ASSERT_EQ(registration1, reg);
     ++handler_called1;
-    reg->remove();
+    delete reg;
   };
   
   signal1(magic_number);

--- a/src/autowiring/test/AutoSignalTest.cpp
+++ b/src/autowiring/test/AutoSignalTest.cpp
@@ -122,3 +122,23 @@ TEST_F(AutoSignalTest, RaiseASignalWithinASlotTest) {
   ASSERT_TRUE(handler_called1) << "Handler 1 was not called on a stack-allocated signal";
   ASSERT_TRUE(handler_called2) << "Handler 2 was not called on a stack-allocated signal";
 }
+
+TEST_F(AutoSignalTest, NodeRemoval) {
+  autowiring::signal<void(void)> signal1;
+  autowiring::signal<void(void)> signal2;
+
+  bool handler_called1 = false;
+  bool handler_called2 = false;
+
+  auto* registration1 = signal1 += [&] { handler_called1 = true; };
+  auto* registration2 = signal2 += [&] { handler_called2 = true; };
+  
+  ASSERT_ANY_THROW(signal1 -= registration2) << "Removing a registration from a different signal than it was registered to failed to throw an exception";
+
+  registration1->remove();
+  signal1();
+  signal2();
+  
+  ASSERT_FALSE(handler_called1) << "Handler1 was called after being unregistered";
+  ASSERT_TRUE(handler_called2) << "Handler2 was removed after an invalid -= operation";
+}

--- a/src/autowiring/test/AutoSignalTest.cpp
+++ b/src/autowiring/test/AutoSignalTest.cpp
@@ -190,11 +190,11 @@ TEST_F(AutoSignalTest, SelfReferencingCall) {
 
   //The main test is just if this thing will compile
   signal_t::registration_t* registration1 =
-  signal1 += [&](autowiring::internal::signal_node_base* reg, int magic) {
-    ASSERT_EQ(magic, magic_number);
-    ASSERT_EQ(registration1, reg);
-    handler_called1 = true;
-  };
+    signal1 += [&](autowiring::internal::signal_node_base* reg, int magic) {
+      ASSERT_EQ(magic, magic_number);
+      ASSERT_EQ(registration1, reg);
+      handler_called1 = true;
+    };
 
   signal1(magic_number);
 
@@ -216,7 +216,7 @@ TEST_F(AutoSignalTest, SelfModifyingCall) {
     ASSERT_EQ(magic, magic_number);
     ASSERT_EQ(registration1, reg);
     ++handler_called1;
-    
+    reg->remove();
     delete reg;
   };
   
@@ -230,6 +230,7 @@ TEST_F(AutoSignalTest, SelfModifyingCall) {
       ++handler_called3;
     };
     
+    reg->remove();
     delete reg;
   };
   


### PR DESCRIPTION
-Makes signal_node_base more full featured
-Adds support for self-referencing lambdas which take a pointer to a node as their first argument
-Adds the ability for registration objects (aka nodes) to delete themselves without also holding a reference to the list they belong to
-Makes removing a node from a list it did not belong to throw an exception
