### PR TITLE
Preparatory refactor of Snoop to AddSnooper

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -981,13 +981,20 @@ public:
   /// <param name="pRecipient">The recipient of the event</param>
   void FilterFiringException(const JunctionBoxBase* pProxy, CoreObject* pRecipient);
 
+  /// <seealso cref="Snoop">Identical to RemoveSnooper</seealso>
+  void DEPRECATED(Snoop(const CoreObjectDescriptor& traits), "Use AddSnooper instead") { return AddSnooper(traits); }
+  template<class T>
+  void DEPRECATED(Snoop(const std::shared_ptr<T>& pSnooper), "Use AddSnooper instead");
+  template<class T>
+  void DEPRECATED(Snoop(const Autowired<T>& snooper), "Use AddSnooper instead");
+  
   /// <summary>
-  /// Runtime version of Snoop
+  /// Runtime version of AddSnooper
   /// </summary>
-  void Snoop(const CoreObjectDescriptor& traits);
+  void AddSnooper(const CoreObjectDescriptor& traits);
 
   /// <summary>
-  /// Registers the specified event receiver to receive messages broadcast within this context.
+  /// Registers the specified event receiver to receive messages from this context
   /// </summary>
   /// <remarks>
   /// This enables the passed event receiver to snoop events that are broadcast from a
@@ -998,16 +1005,16 @@ public:
   /// broadcast in THIS context will be forwarded to the snooper.
   /// </remarks>
   template<class T>
-  void Snoop(const std::shared_ptr<T>& pSnooper) {
-    Snoop(CoreObjectDescriptor(pSnooper, (T*)nullptr));
+  void AddSnooper(const std::shared_ptr<T>& pSnooper) {
+    AddSnooper(CoreObjectDescriptor(pSnooper, (T*)nullptr));
   }
 
   /// <summary>
   /// Resolution overload
   /// </summary>
   template<class T>
-  void Snoop(const Autowired<T>& snooper) {
-    Snoop(
+  void AddSnooper(const Autowired<T>& snooper) {
+    AddSnooper(
       CoreObjectDescriptor(
         static_cast<const std::shared_ptr<T>&>(snooper),
         (T*)nullptr
@@ -1015,28 +1022,35 @@ public:
     );
   }
 
-  /// <summary>
-  /// Runtime version of Unsnoop
-  /// </summary>
-  void Unsnoop(const CoreObjectDescriptor& traits);
+  /// <seealso cref="RemoveSnooper">Identical to RemoveSnooper</seealso>
+  void DEPRECATED(Unsnoop(const CoreObjectDescriptor& traits), "Use RemoveSnooper instead") { return RemoveSnooper(traits); }
+  template<class T>
+  void DEPRECATED(Unsnoop(const std::shared_ptr<T>& pSnooper), "Use RemoveSnooper instead");
+  template<class T>
+  void DEPRECATED(Unsnoop(const Autowired<T>& snooper), "Use RemoveSnooper instead");
 
   /// <summary>
-  /// Unregisters an event receiver previously registered to receive snooped events
+  /// Runtime version of RemoveSnooper
+  /// </summary>
+  void RemoveSnooper(const CoreObjectDescriptor& traits);
+
+  /// <summary>
+  /// Unregisters a snooper previously registered to receive snooped events
   /// </summary>
   /// <remarks>
-  /// It is an error to call this method without a prior call to Snoop
+  /// It is an error to call this method without a prior call to AddSnooper
   /// </remarks>
   template<class T>
-  void Unsnoop(const std::shared_ptr<T>& pSnooper) {
-    Unsnoop(CoreObjectDescriptor(pSnooper, (T*)nullptr));
+  void RemoveSnooper(const std::shared_ptr<T>& pSnooper) {
+    RemoveSnooper(CoreObjectDescriptor(pSnooper, (T*)nullptr));
   }
   
   /// <summary>
-  /// Resolution overload
+  /// Resolution overload of RemoveSnooper
   /// </summary>
   template<class T>
-  void Unsnoop(const Autowired<T>& snooper) {
-    Unsnoop(
+  void RemoveSnooper(const Autowired<T>& snooper) {
+    RemoveSnooper(
       CoreObjectDescriptor(
         static_cast<const std::shared_ptr<T>&>(snooper),
         (T*)nullptr
@@ -1270,6 +1284,30 @@ std::ostream& operator<<(std::ostream& os, const CoreContext& context);
 template<typename T, typename... Sigil>
 void CoreContext::AutoRequireMicroBolt(void) {
   Inject<MicroBolt<T, Sigil...>>();
+}
+
+template<class T>
+void CoreContext::Snoop(const std::shared_ptr<T>& pSnooper)
+{
+  return AddSnooper(pSnooper);
+}
+
+template<class T>
+void CoreContext::Snoop(const Autowired<T>& snooper)
+{
+  return AddSnooper(snooper);
+}
+
+template<class T>
+void CoreContext::Unsnoop(const std::shared_ptr<T>& pSnooper)
+{
+  return RemoveSnooper(pSnooper);
+}
+
+template<class T>
+void CoreContext::Unsnoop(const Autowired<T>& snooper)
+{
+  return RemoveSnooper(snooper);
 }
 
 template<class T>

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -1019,7 +1019,7 @@ void CoreContext::FilterFiringException(const JunctionBoxBase* pProxy, CoreObjec
     }
 }
 
-void CoreContext::Snoop(const CoreObjectDescriptor& traits) {
+void CoreContext::AddSnooper(const CoreObjectDescriptor& traits) {
   // Add to collections of snoopers
   InsertSnooper(traits.value);
 
@@ -1032,7 +1032,7 @@ void CoreContext::Snoop(const CoreObjectDescriptor& traits) {
     AddPacketSubscriber(traits.subscriber);
 }
 
-void CoreContext::Unsnoop(const CoreObjectDescriptor& traits) {
+void CoreContext::RemoveSnooper(const CoreObjectDescriptor& traits) {
   RemoveSnooper(traits.value);
 
   // Cleanup if its an EventReceiver


### PR DESCRIPTION
Fixes #469.  The Snoop method is misleading.  We cannot rename this method because it is too extensively used, but we can start a deprecation policy and get it fixed eventually.