### PR TITLE
AddSubscriber must return the added AutoFilterDescriptor

### DIFF
--- a/autowiring/AutoPacketFactory.h
+++ b/autowiring/AutoPacketFactory.h
@@ -89,32 +89,51 @@ public:
   /// <summary>
   /// Registers the passed subscriber, if it defines a method called AutoFilter
   /// </summary>
+  /// <param name="rhs">The descriptor for the AutoFilter to be added</param>
+  /// <returns>rhs</returns>
   /// <remarks>
   /// This method is idempotent
   /// </remarks>
-  void AddSubscriber(const AutoFilterDescriptor& rhs);
+  const AutoFilterDescriptor& AddSubscriber(const AutoFilterDescriptor& rhs);
 
   /// <summary>
   /// Convenience override of AddSubscriber
   /// </summary>
+  /// <param name="rhs">A shared pointer to a type which has an AutoFilter routine on it</param>
+  /// <remarks>
+  /// For this call to be valid, T::AutoFilter must be defined and must be a compliant AutoFilter
+  /// </remarks>
   template<class T>
-  void AddSubscriber(const std::shared_ptr<T>& rhs) {
-    AddSubscriber(AutoFilterDescriptor(rhs));
-  }
-
-  /// <summary>
-  /// Convienance overload of operator+= to add a subscriber from a lambda
-  /// </summary>
-  template<class Fx>
-  void operator+=(Fx&& fx) {
-    AddSubscriber(AutoFilterDescriptor(std::forward<Fx&&>(fx)));
+  AutoFilterDescriptor AddSubscriber(const std::shared_ptr<T>& rhs) {
+    return AddSubscriber(AutoFilterDescriptor(rhs));
   }
 
   /// <summary>
   /// Removes the designated AutoFilter from this factory
   /// </summary>
   /// <param name="autoFilter">The AutoFilter to be removed</param>
+  /// <remarks>
+  /// This method will not retroactively modify packets that have already been issued with the specified
+  /// AutoFilter on it.  Only packets that are issued after this method returns will lack the presence of
+  /// the autoFilter described by the parameter.
+  /// </remarks>
   void RemoveSubscriber(const AutoFilterDescriptor& autoFilter);
+
+  /// <summary>
+  /// Convienance overload of operator+= to add a subscriber from a lambda
+  /// </summary>
+  /// <remarks>
+  /// This method provides a way to attach a lambda function directly to the factory
+  /// </remarks>
+  template<class Fx>
+  AutoFilterDescriptor operator+= (Fx&& fx) {
+    return AddSubscriber(AutoFilterDescriptor(std::forward<Fx&&>(fx)));
+  }
+
+  /// <summary>
+  /// Overloaded counterpart to RemoveSubscriber
+  /// </summary>
+  void operator-=(const AutoFilterDescriptor& desc);
 
 protected:
   /// <summary>

--- a/src/autowiring/AutoPacketFactory.cpp
+++ b/src/autowiring/AutoPacketFactory.cpp
@@ -144,15 +144,20 @@ void AutoPacketFactory::Clear(void) {
   Stop(false);
 }
 
-void AutoPacketFactory::AddSubscriber(const AutoFilterDescriptor& rhs) {
+const AutoFilterDescriptor& AutoPacketFactory::AddSubscriber(const AutoFilterDescriptor& rhs) {
   std::lock_guard<std::mutex> lk(m_lock);
   m_autoFilters.insert(rhs);
+  return rhs;
 }
 
 void AutoPacketFactory::RemoveSubscriber(const AutoFilterDescriptor& autoFilter) {
   // Trivial removal from the autofilter set:
   std::lock_guard<std::mutex> lk(m_lock);
   m_autoFilters.erase(autoFilter);
+}
+
+void AutoPacketFactory::operator-=(const AutoFilterDescriptor& desc) {
+  RemoveSubscriber(desc);
 }
 
 AutoFilterDescriptor AutoPacketFactory::GetTypeDescriptorUnsafe(const std::type_info* nodeType) {

--- a/src/autowiring/test/AutoPacketFactoryTest.cpp
+++ b/src/autowiring/test/AutoPacketFactoryTest.cpp
@@ -238,9 +238,8 @@ TEST_F(AutoPacketFactoryTest, MultiDecorateTest) {
 }
 
 TEST_F(AutoPacketFactoryTest, MultiPostHocIntroductionTest) {
-  AutoCurrentContext ctxt;
-  ctxt->Initiate();
-  AutoRequired<AutoPacketFactory> factory(ctxt);
+  AutoCurrentContext()->Initiate();
+  AutoRequired<AutoPacketFactory> factory;
 
   int called = 0;
 
@@ -255,4 +254,17 @@ TEST_F(AutoPacketFactoryTest, MultiPostHocIntroductionTest) {
   };
 
   ASSERT_EQ(3, called) << "Not all lambda functions were called as expected";
+}
+
+TEST_F(AutoPacketFactoryTest, CanRemoveAddedLambda) {
+  AutoCurrentContext()->Initiate();
+  AutoRequired<AutoPacketFactory> factory;
+
+  auto desc = *factory += [](int&){};
+  auto packet1 = factory->NewPacket();
+  *factory -= desc;
+  auto packet2 = factory->NewPacket();
+
+  ASSERT_TRUE(packet1->Has<int>()) << "First packet did not posess expected decoration";
+  ASSERT_FALSE(packet2->Has<int>()) << "Decoration present even after all filters were removed from a factory";
 }


### PR DESCRIPTION
This is intended to make it simpler to unregister filters added to an AutoPacketFactory, especially when the registration occurs via a lambda function.  Also add more tests to confirm that this behavior functions as expected.