### PR TITLE
Add Barrier functionality

### DIFF
--- a/autowiring/DispatchQueue.h
+++ b/autowiring/DispatchQueue.h
@@ -187,6 +187,17 @@ public:
   void AddExisting(DispatchThunkBase* pBase);
 
   /// <summary>
+  /// Blocks until all dispatchers on the DispatchQueue at the time of the call have been dispatched
+  /// </summary>
+  /// <param name="timeout">The maximum amount of time to wait</param>
+  /// <remarks>
+  /// This method does not cause any dispatchers to run.  If the underlying dispatch queue does not have an event loop
+  /// operating on it, this method will deadlock.  It is an error for the party responsible for driving the dispatch queue
+  /// via WaitForEvent or DispatchAllEvents unless that party first delegates the responsibility elsewhere.
+  /// </remarks>
+  bool Barrier(std::chrono::nanoseconds timeout);
+
+  /// <summary>
   /// Recommends a point in time to wake up to check for events
   /// </summary>
   /// <returns>


### PR DESCRIPTION
Add Barrier functionality

Users can now infer progress on a `DispatchQueue` by making use of the `DispatchQueue::Barrier`.  This allows users to replace this:

    std::mutex lock;
    std::condition_variable cv;
    bool cond = false;
    *q += [&] {
        std::lock_guard<std::mutex> lk(lock);
        cond = true;
        cv.notify_all();
    };
    std::unique_lock lk(lock);
    cv.wait_for(lk, std::chrono::seconds(5), [&] { return cond; });

With this:

	q.Barrier(std::chrono::seconds(5));

`DispatchQueue::Barrier` also has improved performance because it does not require the user construct an explicit condition variable and mutex every time barrier support is required.