### PR TITLE
Add an interface support query ability to CoreContext

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -773,7 +773,7 @@ public:
   /// Note that the junction box will also contain members of child contexts that implement the specified interface, and
   /// instances that are snooping this context.
   ///
-  /// This method's result will be an empty vector if the context is not currently initiated.
+  /// This method's result will be an empty iterable if the context is not currently initiated.
   /// </remarks>
   template<class T>
   JunctionBox<T>& All(void) {

--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -750,6 +750,39 @@ public:
     FindByType(ptr);
     return ptr != nullptr;
   }
+
+  /// <summary>
+  /// Runtime variant of All
+  /// </summary>
+  /// <remarks>
+  /// This instance does not cause a correct instantiation of the underlying junction box.  Users are cautioned against
+  /// using this method directly unless they are able to ensure a proper entry is made into the type registry.
+  ///
+  /// It is an error to call this method on an unregistered type.
+  /// </remarks>
+  JunctionBoxBase& All(const std::type_info& ti) const;
+
+  /// <summary>
+  /// Returns all members of and snoopers on this context which implement the specified interface
+  /// </summary>
+  /// <remarks>
+  /// This method makes use of the JunctionBox subsystem, and thus is extremely efficient.  The underlying system is
+  /// memoized, and new entries automatically update any existing memos, which gives this routine O(n) efficiency, where
+  /// n is the number of types in this context that implement the specified interface.
+  ///
+  /// Note that the junction box will also contain members of child contexts that implement the specified interface, and
+  /// instances that are snooping this context.
+  ///
+  /// This method's result will be an empty vector if the context is not currently initiated.
+  /// </remarks>
+  template<class T>
+  JunctionBox<T>& All(void) {
+    // Type registration, needed to ensure our junction box actually exists
+    (void) RegEvent<T>::r;
+
+    // Simple coercive transfer:
+    return static_cast<JunctionBox<T>&>(All(typeid(T)));
+  }
   
   template<typename T, typename... Args>
   std::shared_ptr<T> DEPRECATED(Construct(Args&&... args), "'Construct' is deprecated, use 'Inject' instead");

--- a/autowiring/JunctionBoxBase.h
+++ b/autowiring/JunctionBoxBase.h
@@ -52,6 +52,12 @@ public:
   bool IsInitiated(void) const {return m_isInitiated;}
   void Initiate(void) {m_isInitiated=true;}
   
+  /// <summary>
+  /// Convenience method allowing consumers to quickly determine whether any listeners exist
+  /// </summary>
+  /// <returns>
+  /// True if at least one listener has been registered
+  /// </returns>
   virtual bool HasListeners(void) const = 0;
 
   // Event attachment and detachment pure virtuals

--- a/autowiring/JunctionBoxEntry.h
+++ b/autowiring/JunctionBoxEntry.h
@@ -6,11 +6,15 @@
 class CoreContext;
 
 struct JunctionBoxEntryBase {
+  JunctionBoxEntryBase(void) :
+    m_owner(nullptr)
+  {}
+
   JunctionBoxEntryBase(CoreContext* owner) :
     m_owner(owner)
   {}
 
-  CoreContext* const m_owner;
+  CoreContext* m_owner;
 };
 
 /// <summary>
@@ -20,17 +24,14 @@ template<class T>
 struct JunctionBoxEntry:
   JunctionBoxEntryBase
 {
+  JunctionBoxEntry(void) {}
+
   JunctionBoxEntry(CoreContext* owner, std::shared_ptr<T> ptr) :
     JunctionBoxEntryBase(owner),
     m_ptr(ptr)
   {}
 
   std::shared_ptr<T> m_ptr;
-
-  JunctionBoxEntry& operator=(const JunctionBoxEntry& rhs) {
-    // This shouldn't be used. non-c++11 containers require this...
-    throw std::runtime_error("Can't copy a JunctionBoxEntry");
-  }
 
   bool operator==(const JunctionBoxEntry& rhs) const {
     return m_ptr == rhs.m_ptr;

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -630,6 +630,13 @@ void CoreContext::AddBolt(const std::shared_ptr<BoltBase>& pBase) {
     m_nameListeners[typeid(void)].push_back(pBase.get());
 }
 
+JunctionBoxBase& CoreContext::All(const std::type_info& ti) const {
+  auto jb = m_junctionBoxManager->Get(ti);
+  if (!jb)
+    throw autowiring_error("Attempted to obtain a junction box which has not been declared");
+  return *jb;
+}
+
 void CoreContext::BuildCurrentState(void) {
   AutoGlobalContext glbl;
   glbl->Invoke(&AutowiringEvents::NewContext)(*this);

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -454,11 +454,12 @@ TEST_F(CoreContextTest, All) {
   auto& allMembers = ctxt->All<MyClassForAllBase>();
   ASSERT_LE(2UL, allMembers.size()) << "All members not correctly identified by call to all";
 
-  bool found1;
-  bool found2;
+  // Check all instances found
+  bool found1 = false;
+  bool found2 = false;
   for (auto& cur : allMembers) {
-    found1 = &cur == c1.get();
-    found2 = &cur == c2.get();
+    found1 |= &cur == c1.get();
+    found2 |= &cur == c2.get();
   }
 
   ASSERT_TRUE(found1) << "Failed to find MyClassForAll<1> via its ContextMember interface";

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -434,3 +434,33 @@ TEST_F(CoreContextTest, AppropriateShutdownInterleave) {
   ASSERT_TRUE(ctxtOuter->Wait(std::chrono::seconds(5))) << "Outer context did not tear down in a timely fashion";
   ASSERT_TRUE(ctxtInner->Wait(std::chrono::seconds(5))) << "Inner context did not tear down in a timely fashion";
 }
+
+class MyClassForAllBase {};
+
+template<int N>
+class MyClassForAll:
+  public MyClassForAllBase
+{
+};
+
+TEST_F(CoreContextTest, All) {
+  AutoCurrentContext ctxt;
+  ctxt->Initiate();
+
+  AutoRequired<MyClassForAll<1>> c1;
+  AutoRequired<MyClassForAll<2>> c2;
+
+  // Sanity check first:
+  auto& allMembers = ctxt->All<MyClassForAllBase>();
+  ASSERT_LE(2UL, allMembers.size()) << "All members not correctly identified by call to all";
+
+  bool found1;
+  bool found2;
+  for (auto& cur : allMembers) {
+    found1 = &cur == c1.get();
+    found2 = &cur == c2.get();
+  }
+
+  ASSERT_TRUE(found1) << "Failed to find MyClassForAll<1> via its ContextMember interface";
+  ASSERT_TRUE(found2) << "Failed to find MyClassForAll<2> via its ContextMember interface";
+}


### PR DESCRIPTION
This allows users to get all implementors of a particular interface in a context.

This method returns an empty vector if it is called before the context is initiated.