### PR TITLE
Fix DispatchQueue Exceptions

### DIFF
--- a/autowiring/DispatchQueue.h
+++ b/autowiring/DispatchQueue.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include "autowiring_error.h"
 #include "DispatchThunk.h"
 #include <list>
 #include <queue>
@@ -14,10 +15,10 @@ class DispatchQueue;
 /// Thrown when a dispatch operation was aborted
 /// </summary>
 class dispatch_aborted_exception:
-  public std::exception
+  public autowiring_error
 {
 public:
-  dispatch_aborted_exception(void);
+  dispatch_aborted_exception(const std::string& what);
   virtual ~dispatch_aborted_exception(void);
 };
 

--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -2,6 +2,7 @@
 #include "stdafx.h"
 #include "BasicThread.h"
 #include "Autowired.h"
+#include "autowiring_error.h"
 #include "BasicThreadStateBlock.h"
 #include "ContextEnumerator.h"
 #include "fast_pointer_cast.h"
@@ -109,7 +110,7 @@ void BasicThread::WaitForStateUpdate(const std::function<bool()>& fn) {
     }
   );
   if(ShouldStop())
-    throw dispatch_aborted_exception();
+    throw dispatch_aborted_exception("Thread was stopped before the function returned true");
 }
 
 void BasicThread::PerformStatusUpdate(const std::function<void()>& fn) {

--- a/src/autowiring/DispatchQueue.cpp
+++ b/src/autowiring/DispatchQueue.cpp
@@ -82,7 +82,7 @@ void DispatchQueue::Abort(void) {
 void DispatchQueue::WaitForEvent(void) {
   std::unique_lock<std::mutex> lk(m_dispatchLock);
   if (m_aborted)
-    throw dispatch_aborted_exception("Dispatch queue was aborted while waiting for an event");
+    throw dispatch_aborted_exception("Dispatch queue was aborted prior to waiting for an event");
 
   // Unconditional delay:
   m_queueUpdated.wait(lk, [this]() -> bool {
@@ -124,7 +124,7 @@ bool DispatchQueue::WaitForEvent(std::chrono::steady_clock::time_point wakeTime)
 
 bool DispatchQueue::WaitForEventUnsafe(std::unique_lock<std::mutex>& lk, std::chrono::steady_clock::time_point wakeTime) {
   if (m_aborted)
-    throw dispatch_aborted_exception("Dispatch queue was aborted while waiting for an event");
+    throw dispatch_aborted_exception("Dispatch queue was aborted prior to waiting for an event");
 
   while (m_dispatchQueue.empty()) {
     // Derive a wakeup time using the high precision timer:

--- a/src/autowiring/DispatchQueue.cpp
+++ b/src/autowiring/DispatchQueue.cpp
@@ -2,7 +2,6 @@
 #include "stdafx.h"
 #include "DispatchQueue.h"
 #include "at_exit.h"
-#include "autowiring_error.h"
 #include <assert.h>
 
 dispatch_aborted_exception::dispatch_aborted_exception(const std::string& what):
@@ -192,7 +191,7 @@ bool DispatchQueue::Barrier(std::chrono::nanoseconds timeout) {
   std::unique_lock<std::mutex> lk(m_dispatchLock);
   bool rv = m_queueUpdated.wait_for(lk, timeout, [&] { return m_aborted || *complete; });
   if (m_aborted)
-    throw autowiring_error("Dispatch queue was aborted while a barrier was invoked");
+    throw dispatch_aborted_exception("Dispatch queue was aborted while a barrier was invoked");
   return rv;
 }
 
@@ -208,7 +207,7 @@ void DispatchQueue::Barrier(void) {
     // At this point, the dispatch queue MUST be completely run down.  We have no outstanding references
     // to our stack-allocated "complete" variable.  Furthermore, after m_aborted is true, no further
     // dispatchers are permitted to be run.
-    throw autowiring_error("Dispatch queue was aborted while a barrier was invoked");
+    throw dispatch_aborted_exception("Dispatch queue was aborted while a barrier was invoked");
 }
 
 std::chrono::steady_clock::time_point

--- a/src/autowiring/DispatchQueue.cpp
+++ b/src/autowiring/DispatchQueue.cpp
@@ -5,7 +5,10 @@
 #include "autowiring_error.h"
 #include <assert.h>
 
-dispatch_aborted_exception::dispatch_aborted_exception(void){}
+dispatch_aborted_exception::dispatch_aborted_exception(const std::string& what):
+  autowiring_error(what)
+{}
+
 dispatch_aborted_exception::~dispatch_aborted_exception(void){}
 
 DispatchQueue::DispatchQueue(void):
@@ -80,12 +83,12 @@ void DispatchQueue::Abort(void) {
 void DispatchQueue::WaitForEvent(void) {
   std::unique_lock<std::mutex> lk(m_dispatchLock);
   if (m_aborted)
-    throw dispatch_aborted_exception();
+    throw dispatch_aborted_exception("Dispatch queue was aborted while waiting for an event");
 
   // Unconditional delay:
   m_queueUpdated.wait(lk, [this]() -> bool {
     if (m_aborted)
-      throw dispatch_aborted_exception();
+      throw dispatch_aborted_exception("Dispatch queue was aborted while waiting for an event");
 
     return
       // We will need to transition out if the delay queue receives any items:
@@ -122,7 +125,7 @@ bool DispatchQueue::WaitForEvent(std::chrono::steady_clock::time_point wakeTime)
 
 bool DispatchQueue::WaitForEventUnsafe(std::unique_lock<std::mutex>& lk, std::chrono::steady_clock::time_point wakeTime) {
   if (m_aborted)
-    throw dispatch_aborted_exception();
+    throw dispatch_aborted_exception("Dispatch queue was aborted while waiting for an event");
 
   while (m_dispatchQueue.empty()) {
     // Derive a wakeup time using the high precision timer:
@@ -134,7 +137,7 @@ bool DispatchQueue::WaitForEventUnsafe(std::unique_lock<std::mutex>& lk, std::ch
 
     // Short-circuit if the queue was aborted
     if (m_aborted)
-      throw dispatch_aborted_exception();
+      throw dispatch_aborted_exception("Dispatch queue was aborted while waiting for an event");
 
     if (PromoteReadyDispatchersUnsafe())
       // Dispatcher is ready to run!  Exit our loop and dispatch an event


### PR DESCRIPTION
Fixes:
* ```dispatch_aborted_exception``` should inherit from ```autowiring_error```
* ```DispatchQueue::Barrier(*)``` functions should throw ```dispatch_aborted_exception```