### PR TITLE
Move dispatch_aborted_exception to its own file, add default ctor

### DIFF
--- a/autowiring/DispatchQueue.h
+++ b/autowiring/DispatchQueue.h
@@ -1,6 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "autowiring_error.h"
+#include "dispatch_aborted_exception.h"
 #include "DispatchThunk.h"
 #include <list>
 #include <queue>
@@ -9,18 +9,6 @@
 #include MEMORY_HEADER
 
 class DispatchQueue;
-
-/// \internal
-/// <summary>
-/// Thrown when a dispatch operation was aborted
-/// </summary>
-class dispatch_aborted_exception:
-  public autowiring_error
-{
-public:
-  dispatch_aborted_exception(const std::string& what);
-  virtual ~dispatch_aborted_exception(void);
-};
 
 /// <summary>
 /// This is an asynchronous queue of zero-argument functions

--- a/autowiring/dispatch_aborted_exception.h
+++ b/autowiring/dispatch_aborted_exception.h
@@ -1,0 +1,16 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "autowiring_error.h"
+
+/// \internal
+/// <summary>
+/// Thrown when a dispatch operation was aborted
+/// </summary>
+class dispatch_aborted_exception:
+  public autowiring_error
+{
+public:
+  dispatch_aborted_exception(void);
+  dispatch_aborted_exception(const std::string& what);
+  virtual ~dispatch_aborted_exception(void);
+};

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -100,6 +100,8 @@ set(Autowiring_SRCS
   demangle.cpp
   demangle.h
   Deserialize.h
+  dispatch_aborted_exception.h
+  dispatch_aborted_exception.cpp
   DispatchQueue.cpp
   DispatchQueue.h
   DispatchThunk.h

--- a/src/autowiring/DispatchQueue.cpp
+++ b/src/autowiring/DispatchQueue.cpp
@@ -4,12 +4,6 @@
 #include "at_exit.h"
 #include <assert.h>
 
-dispatch_aborted_exception::dispatch_aborted_exception(const std::string& what):
-  autowiring_error(what)
-{}
-
-dispatch_aborted_exception::~dispatch_aborted_exception(void){}
-
 DispatchQueue::DispatchQueue(void):
   m_dispatchCap(1024),
   m_aborted(false)

--- a/src/autowiring/dispatch_aborted_exception.cpp
+++ b/src/autowiring/dispatch_aborted_exception.cpp
@@ -1,0 +1,13 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "dispatch_aborted_exception.h"
+
+dispatch_aborted_exception::dispatch_aborted_exception(void) :
+  autowiring_error("Dispatch queue aborted")
+{}
+
+dispatch_aborted_exception::dispatch_aborted_exception(const std::string& what) :
+  autowiring_error(what)
+{}
+
+dispatch_aborted_exception::~dispatch_aborted_exception(void){}


### PR DESCRIPTION
Adding an exception explanation behavior to `dispatch_aborted_exception` is nice, but it still must be possible to default-construct this type.  Also provide it its own header.