### PR TITLE
CoreContext::NotifyWhenAutowired is not actually internal

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -1185,7 +1185,6 @@ public:
     }
   };
 
-  /// \internal
   /// <summary>
   /// Adds a post-attachment listener in this context for a particular autowired member.
   /// There is no guarantee for the context in which the listener will be called.


### PR DESCRIPTION
It is expected that users will invoke this routine in order to add notification lambdas without having to expressly declare an Autowired slot.  Thus, we should allow users a way to do this directly.