### PR TITLE
Fix Android build

### DIFF
--- a/src/autowiring/test/DispatchQueueTest.cpp
+++ b/src/autowiring/test/DispatchQueueTest.cpp
@@ -2,7 +2,8 @@
 #include "stdafx.h"
 #include <autowiring/CoreThread.h>
 #include <autowiring/DispatchQueue.h>
-#include <future>
+#include <thread>
+#include FUTURE_HEADER
 
 using namespace std;
 


### PR DESCRIPTION
Forgot to include a header required to get Autowiring building on Android