### PR TITLE
Allow altitude to be easily specified when using lambda autofilters

### DIFF
--- a/autowiring/AutoFilterDescriptor.h
+++ b/autowiring/AutoFilterDescriptor.h
@@ -186,11 +186,11 @@ struct AutoFilterDescriptor:
   /// Recipients added in this way cannot receive piped data, since they are anonymous.
   /// </remarks>
   template<class Fn>
-  AutoFilterDescriptor(Fn fn):
+  AutoFilterDescriptor(Fn fn, autowiring::altitude altitude = autowiring::altitude::Standard):
     AutoFilterDescriptor(
       AnySharedPointer(std::make_shared<Fn>(std::forward<Fn>(fn))),
       &typeid(Fn),
-      autowiring::altitude::Standard,
+      altitude,
       CallExtractor<decltype(&Fn::operator())>::template Enumerate<AutoFilterDescriptorInput, AutoFilterDescriptorInputT>::types,
       false,
       &CallExtractor<decltype(&Fn::operator())>::template Call<&Fn::operator()>

--- a/autowiring/AutoPacketFactory.h
+++ b/autowiring/AutoPacketFactory.h
@@ -119,6 +119,25 @@ public:
   /// </remarks>
   void RemoveSubscriber(const AutoFilterDescriptor& autoFilter);
 
+  struct AutoPacketFactoryExpression {
+    AutoPacketFactoryExpression(AutoPacketFactory& factory, autowiring::altitude altitude):
+      factory(factory),
+      altitude(altitude)
+    {}
+
+    AutoPacketFactory& factory;
+    autowiring::altitude altitude;
+
+    template<class Fx>
+    AutoFilterDescriptor operator,(Fx&& fx) {
+      return factory.AddSubscriber(AutoFilterDescriptor(std::forward<Fx&&>(fx), altitude));
+    }
+  };
+
+  AutoPacketFactoryExpression operator+=(autowiring::altitude altitude) {
+    return AutoPacketFactoryExpression(*this, altitude);
+  }
+
   /// <summary>
   /// Convienance overload of operator+= to add a subscriber from a lambda
   /// </summary>

--- a/src/autowiring/test/AutoFilterAltitudeTest.cpp
+++ b/src/autowiring/test/AutoFilterAltitudeTest.cpp
@@ -51,3 +51,30 @@ TEST_F(AutoFilterAltitudeTest, StandardAltitudeArrangement) {
   ASSERT_EQ(5, alt4->order);
   ASSERT_EQ(6, alt5->order);
 }
+
+TEST_F(AutoFilterAltitudeTest, LambdaAltitudesOnFactory) {
+  AutoCurrentContext()->Initiate();
+  AutoRequired<AutoPacketFactory> factory;
+
+  int seq = 0;
+  int ctr[9];
+
+  for (size_t i = 0; i < 9; i++) {
+    ctr[i] = -1;
+    *factory += (autowiring::altitude)i, [&, i] {
+      ctr[i] = ++seq;
+    };
+  }
+
+  // Generate a packet and trip the assignments:
+  auto packet = factory->NewPacket();
+  ASSERT_EQ(9, ctr[0]);
+  ASSERT_EQ(8, ctr[1]);
+  ASSERT_EQ(7, ctr[2]);
+  ASSERT_EQ(6, ctr[3]);
+  ASSERT_EQ(5, ctr[4]);
+  ASSERT_EQ(4, ctr[5]);
+  ASSERT_EQ(3, ctr[6]);
+  ASSERT_EQ(2, ctr[7]);
+  ASSERT_EQ(1, ctr[8]);
+}


### PR DESCRIPTION
Altitudes can be specified using the comma notation, similar to how delays are specified for dispatchers:

```C++
AutoRequired<AutoPacketFactory> factory;
*factory += autowiring::altitude::Highest, [] (const MyDecoration&) {};
```