### PR TITLE
Provide more descriptive error text for junction box misses

### DIFF
--- a/autowiring/demangle.h
+++ b/autowiring/demangle.h
@@ -1,7 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <string>
-#include <typeinfo>
+#include <typeindex>
 
 struct AnySharedPointer;
 
@@ -12,6 +12,9 @@ struct AnySharedPointer;
 namespace autowiring {
   std::string demangle(const std::type_info& ti);
   std::string demangle(const std::type_info* ti);
+
+  std::string demangle(const std::type_index& ti);
+  std::string demangle(const std::type_index* ti);
 
   std::string demangle(const AnySharedPointer& ptr);
 

--- a/src/autowiring/JunctionBoxManager.cpp
+++ b/src/autowiring/JunctionBoxManager.cpp
@@ -3,9 +3,12 @@
 #include "JunctionBoxManager.h"
 #include "AutoPacketFactory.h"
 #include "AutowiringEvents.h"
+#include "demangle.h"
 #include "JunctionBox.h"
 #include "EventRegistry.h"
 #include <sstream>
+
+using namespace autowiring;
 
 template class RegEvent<AutowiringEvents>;
 template class TypeUnifierComplex<AutowiringEvents>;
@@ -28,10 +31,10 @@ std::shared_ptr<JunctionBoxBase> JunctionBoxManager::Get(const std::type_index& 
   auto box = m_junctionBoxes.find(pTypeIndex);
   if (box == m_junctionBoxes.end()) {
     std::ostringstream ss;
-    ss << "Attempted to obtain a junction box for [[ " << pTypeIndex.name() << " ]], which is not registered." << std::endl
+    ss << "Attempted to obtain a junction box for [[ " << demangle(pTypeIndex) << " ]], which is not registered." << std::endl
        << "Known junction boxes:" << std::endl;
     for (const auto& cur : m_junctionBoxes)
-      ss << cur.first.name() << std::endl;
+      ss << demangle(cur.first) << std::endl;
     throw autowiring_error(ss.str());
   }
 

--- a/src/autowiring/JunctionBoxManager.cpp
+++ b/src/autowiring/JunctionBoxManager.cpp
@@ -5,7 +5,7 @@
 #include "AutowiringEvents.h"
 #include "JunctionBox.h"
 #include "EventRegistry.h"
-#include <cassert>
+#include <sstream>
 
 template class RegEvent<AutowiringEvents>;
 template class TypeUnifierComplex<AutowiringEvents>;
@@ -26,8 +26,14 @@ JunctionBoxManager::~JunctionBoxManager(void) {}
 
 std::shared_ptr<JunctionBoxBase> JunctionBoxManager::Get(const std::type_index& pTypeIndex) {
   auto box = m_junctionBoxes.find(pTypeIndex);
-  if (box == m_junctionBoxes.end())
-    throw autowiring_error("Attempted to obtain a junction box for an unregistered type");
+  if (box == m_junctionBoxes.end()) {
+    std::ostringstream ss;
+    ss << "Attempted to obtain a junction box for [[ " << pTypeIndex.name() << " ]], which is not registered." << std::endl
+       << "Known junction boxes:" << std::endl;
+    for (const auto& cur : m_junctionBoxes)
+      ss << cur.first.name() << std::endl;
+    throw autowiring_error(ss.str());
+  }
 
   return box->second;
 }

--- a/src/autowiring/demangle.cpp
+++ b/src/autowiring/demangle.cpp
@@ -7,10 +7,10 @@
 #include <cxxabi.h>
 #include <cstdlib>
 
-std::string autowiring::demangle(const std::type_info& ti) {
+static std::string demangle_name(const char* name) {
   int status;
   std::unique_ptr<char, void(*)(void*)> res{
-    abi::__cxa_demangle(ti.name(), nullptr, nullptr, &status),
+    abi::__cxa_demangle(name, nullptr, nullptr, &status),
     std::free
   };
 
@@ -22,8 +22,8 @@ std::string autowiring::demangle(const std::type_info& ti) {
 
 #else // Windows
 
-std::string autowiring::demangle(const std::type_info& ti) {
-  std::string demangled(ti.name());
+static std::string demangle_name(const char* name) {
+  std::string demangled(name);
   
   if (demangled.find("`") != std::string::npos)
     return std::string();
@@ -33,11 +33,23 @@ std::string autowiring::demangle(const std::type_info& ti) {
 
 #endif
 
-std::string autowiring::demangle(const AnySharedPointer& ptr) {
-  return autowiring::demangle(ptr->type());
+std::string autowiring::demangle(const std::type_info& ti) {
+  return demangle_name(ti.name());
 }
 
 std::string autowiring::demangle(const std::type_info* ti) {
-  return autowiring::demangle(*ti);
+  return demangle_name(ti->name());
+}
+
+std::string autowiring::demangle(const std::type_index& ti) {
+  return demangle_name(ti.name());
+}
+
+std::string autowiring::demangle(const std::type_index* ti) {
+  return demangle_name(ti->name());
+}
+
+std::string autowiring::demangle(const AnySharedPointer& ptr) {
+  return autowiring::demangle(ptr->type());
 }
 


### PR DESCRIPTION
This error is expected to arise often enough that we should try to ensure it's informative when it does appear.  In this case, more information is better.