### PR TITLE
Bugfix context enumerator t unique

### DIFF
--- a/autowiring/ContextEnumerator.h
+++ b/autowiring/ContextEnumerator.h
@@ -150,6 +150,12 @@ public:
   // Convenience routine for returning a single unique element
   std::shared_ptr<CoreContext> unique(void) {
     iterator q = begin();
+
+    // If there are no elements in this enumerator (indicated by begin() == end()), then throw an error,
+    // as this operation is undefined.
+    if (q == end())
+      throw autowiring_error("Attempted to get a unique context on a context enumerator that enumerates no children");
+
     iterator r = q;
 
     // If advancing q gets us to the end, then we only have one element and we can return success

--- a/src/autowiring/test/ContextEnumeratorTest.cpp
+++ b/src/autowiring/test/ContextEnumeratorTest.cpp
@@ -179,7 +179,13 @@ TEST_F(ContextEnumeratorTest, Unique) {
     "Expected the unique context to be equal to the specifically named child context";
 }
 
-TEST_F(ContextEnumeratorTest, BadUnique) {
+TEST_F(ContextEnumeratorTest, BadUnique0) {
+  // Intentionally create 0 contexts with the NamedContext sigil.
+  ASSERT_THROW(ContextEnumeratorT<NamedContext>().unique(), autowiring_error) <<
+    "An attempt to obtain a unique context from an enumerator providing none should throw an exception";
+}
+
+TEST_F(ContextEnumeratorTest, BadUnique2) {
   AutoCreateContextT<NamedContext> named1;
   AutoCreateContextT<NamedContext> named2;
 


### PR DESCRIPTION
Wrote a unit test exposing a bug in ContextEnumeratorT::unique.  Fixed said bug.