### PR TITLE
Fix zero-length query call for DispatchQueue::Barrier

### DIFF
--- a/autowiring/DispatchQueue.h
+++ b/autowiring/DispatchQueue.h
@@ -186,6 +186,9 @@ public:
   ///
   /// If DispatchQueue::Abort() is called before the dispatcher has been completed, this method will throw an exception.
   /// If a dispatcher on the underlying DispatchQueue throws an exception, this method will also throw an exception.
+  ///
+  /// If zero is passed as the timeout value, this method will return true if and only if the queue was empty at the time
+  /// of the call, ignoring any delayed dispatchers.
   /// </remarks>
   bool Barrier(std::chrono::nanoseconds timeout);
 


### PR DESCRIPTION
When Barrier is called with a value of zero, the return value must be set according to the number of elements in the queue as of the time of the call.  Not only is this a good optimization, but it's also a way to allow consumers to easily poll the status of the queue.

Fixes #504