### PR TITLE
Autowiring folder is no longer necessary

### DIFF
--- a/src/autonet/CMakeLists.txt
+++ b/src/autonet/CMakeLists.txt
@@ -22,8 +22,6 @@ add_library(AutoNet STATIC ${AutoNet_SRCS})
 target_link_libraries(AutoNet PRIVATE Autowiring)
 set_target_properties(AutoNet PROPERTIES INTERFACE_LINK_LIBRARIES Autowiring)
 
-set_property(TARGET AutoNet PROPERTY FOLDER "Autowiring")
-
 #
 # Install library
 #

--- a/src/autonet/test/CMakeLists.txt
+++ b/src/autonet/test/CMakeLists.txt
@@ -14,7 +14,6 @@ add_pch(AutoNetTest_SRCS "stdafx.h" "stdafx.cpp")
 
 add_executable(AutoNetTest ${AutoNetTest_SRCS})
 target_link_libraries(AutoNetTest AutoTesting AutoNet Autowiring)
-set_property(TARGET AutoNetTest PROPERTY FOLDER "Autowiring")
 
 # This is a unit test, let CMake know this
 add_test(NAME AutoNetTest COMMAND $<TARGET_FILE:AutoNetTest>)

--- a/src/autotesting/CMakeLists.txt
+++ b/src/autotesting/CMakeLists.txt
@@ -6,7 +6,6 @@ set(AutoTesting_SOURCES
 
 rewrite_header_paths(AutoTesting_SOURCES)
 add_library(AutoTesting ${AutoTesting_SOURCES})
-set_property(TARGET AutoTesting PROPERTY FOLDER "Autowiring")
 target_link_libraries(AutoTesting Autowiring)
 target_include_directories(AutoTesting PRIVATE "${CMAKE_SOURCE_DIR}/contrib/autoboost")
 

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -230,7 +230,6 @@ target_include_directories(Autowiring
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>"
   "$<INSTALL_INTERFACE:include>"
 )
-set_property(TARGET Autowiring PROPERTY FOLDER "Autowiring")
 
 # Need multithreading services if available
 find_package(Threads)

--- a/src/autowiring/benchmark/CMakeLists.txt
+++ b/src/autowiring/benchmark/CMakeLists.txt
@@ -10,7 +10,6 @@ set(AutowiringBenchmarkTest_SRCS
 add_pch(AutowiringBenchmarkTest_SRCS "stdafx.h" "stdafx.cpp")
 add_executable(AutowiringBenchmarkTest ${AutowiringBenchmarkTest_SRCS})
 target_link_libraries(AutowiringBenchmarkTest Autowiring AutowiringFixture AutoTesting)
-set_property(TARGET AutowiringBenchmarkTest PROPERTY FOLDER "Autowiring")
 
 # This is a unit test, let CMake know this
 add_test(NAME AutowiringBenchmarkTest COMMAND $<TARGET_FILE:AutowiringBenchmarkTest>)

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -89,7 +89,6 @@ set(AutowiringFixture_SRCS
 add_pch(AutowiringFixture_SRCS "stdafx.h" "stdafx.cpp")
 add_library(AutowiringFixture ${AutowiringFixture_SRCS})
 target_include_directories(AutowiringFixture PRIVATE "${CMAKE_SOURCE_DIR}/contrib/autoboost")
-set_property(TARGET AutowiringFixture PROPERTY FOLDER "Autowiring")
 
 add_pch(AutowiringTest_SRCS "stdafx.h" "stdafx.cpp")
 add_executable(AutowiringTest ${AutowiringTest_SRCS})
@@ -106,8 +105,6 @@ endif()
 if(TARGET AutoNet)
   target_link_libraries(AutowiringTest AutoNet)
 endif()
-
-set_property(TARGET AutowiringTest PROPERTY FOLDER "Autowiring")
 
 # This is a unit test, let CMake know this
 add_test(NAME AutowiringTest COMMAND $<TARGET_FILE:AutowiringTest>)


### PR DESCRIPTION
This folder was very useful when Autowiring was commonly being used as a submodule in other solutions, but now it's only ever included as a target library.  The additional subfolder is, right now, superfluous.