### PR TITLE
Standardize syntax in chrono_with_profiling_clock

### DIFF
--- a/autowiring/C++11/chrono_with_profiling_clock.h
+++ b/autowiring/C++11/chrono_with_profiling_clock.h
@@ -2,33 +2,29 @@
 #pragma once
 
 #if STL11_ALLOWED
-#include <chrono>
+  #include <chrono>
 #else
-#include <autowiring/C++11/boost_chrono.h>
+  #include <autowiring/C++11/boost_chrono.h>
 #endif
 
-//This solution taken from http://stackoverflow.com/questions/8386128/how-to-get-the-precision-of-high-resolution-clock
-//Hopefully it will be able to be depricated when VS2015 hits.
+// This solution taken from http://stackoverflow.com/questions/8386128/how-to-get-the-precision-of-high-resolution-clock
+// Hopefully it will be able to be depricated when VS2015 hits.
 
-#if defined(_MSC_VER) && _MSC_VER < 1900 //high_resolution_clock is broken on all MSVC versions below 2015.
+// high_resolution_clock is broken on all MSVC versions below 2015.
+#if defined(_MSC_VER) && _MSC_VER < 1900
 union _LARGE_INTEGER;
 typedef _LARGE_INTEGER LARGE_INTEGER;
 
 extern "C" {
   __declspec(dllimport)
-    int
-    __stdcall
-    QueryPerformanceCounter(LARGE_INTEGER * lpPerformanceCount);
+  int __stdcall QueryPerformanceCounter(LARGE_INTEGER * lpPerformanceCount);
 
   __declspec(dllimport)
-    int
-    __stdcall
-    QueryPerformanceFrequency(LARGE_INTEGER * lpFrequency);
+  int __stdcall QueryPerformanceFrequency(LARGE_INTEGER * lpFrequency);
 }
 
 namespace {
-  const double g_nanosecs_per_tic = []()
-  {
+  const double g_nanosecs_per_tic = [] {
     int64_t frequency;
     QueryPerformanceFrequency(&reinterpret_cast<LARGE_INTEGER&>(frequency));
     return 1e9 / static_cast<double>(frequency);
@@ -36,19 +32,26 @@ namespace {
 }
 
 namespace std {
-  namespace chrono{
+  namespace chrono {
     struct profiling_clock
     {
-      typedef long long                           rep;
-      typedef nano                                period;
-      typedef duration<rep, period>               duration;
-      typedef time_point<profiling_clock>         time_point;
+      typedef long long rep;
+      typedef nano period;
+      typedef duration<rep, period> duration;
+      typedef time_point<profiling_clock> time_point;
       static const bool is_steady = true;
 
-      static time_point now() {
+      static time_point now(void) {
         int64_t count;
         QueryPerformanceCounter(&reinterpret_cast<LARGE_INTEGER&>(count));
-        return time_point(duration(static_cast<int64_t>(static_cast<double>(count) * g_nanosecs_per_tic)));
+
+        // A cast to double is necessary, here, due to the fact that a potentially very large number
+        // is being multiplied by a very small number.
+        return time_point{
+          duration{
+            static_cast<int64_t>(static_cast<double>(count) * g_nanosecs_per_tic)
+          }
+        };
       }
     };
   }


### PR DESCRIPTION
No functional changes, only syntax standardization