### PR TITLE
Refactor DispatchQueue to use an intrusive list instead of an std::list

### DIFF
--- a/autowiring/DispatchQueue.h
+++ b/autowiring/DispatchQueue.h
@@ -31,10 +31,14 @@ public:
 
 protected:
   // The maximum allowed number of pended dispatches before pended calls start getting dropped
-  size_t m_dispatchCap;
+  size_t m_dispatchCap = 1000;
 
-  // The dispatch queue proper:
-  std::list<DispatchThunkBase*> m_dispatchQueue;
+  // Current linked list length
+  size_t m_count = 0;
+
+  // The dispatch queue proper.  A vector is used, here, not a queue, because this collection is frequently emptied.
+  DispatchThunkBase* m_pHead = nullptr;
+  DispatchThunkBase* m_pTail = nullptr;
 
   // Priority queue of non-ready events:
   std::priority_queue<DispatchThunkDelayed> m_delayedQueue;
@@ -47,7 +51,7 @@ protected:
 
   // True if DispatchQueue::Abort has been called.  This will cause the dispatch queue's remaining entries
   // to be dumped and prevent the introduction of new entries to the queue.
-  bool m_aborted;
+  bool m_aborted = false;
 
   /// <summary>
   /// Moves all ready events from the delayed queue into the dispatch queue
@@ -78,28 +82,29 @@ protected:
   /// </remarks>
   virtual void OnPended(std::unique_lock<std::mutex>&& lk) {}
 
+  template<class _Fx>
+  void Pend(_Fx&& fx) {
+    PendExisting(
+      std::unique_lock<std::mutex>(m_dispatchLock),
+      new DispatchThunk<_Fx>(std::forward<_Fx&&>(fx))
+    );
+  }
+
   /// <summary>
   /// Attaches an element to the end of the dispatch queue without any checks.
   /// </summary>
-  template<class _Fx>
-  void Pend(_Fx&& fx) {
-    std::unique_lock<std::mutex> lk(m_dispatchLock);
-    m_dispatchQueue.push_back(new DispatchThunk<_Fx>(fx));
-    m_queueUpdated.notify_all();
-
-    OnPended(std::move(lk));
-  }
+  void PendExisting(std::unique_lock<std::mutex>&& lk, DispatchThunkBase* thunk);
 
 public:
   /// <returns>
   /// True if there are curerntly any dispatchers ready for execution--IE, DispatchEvent would return true
   /// </returns>
-  bool AreAnyDispatchersReady(void) const { return !m_dispatchQueue.empty(); }
+  bool AreAnyDispatchersReady(void) const { return !!m_count; }
 
   /// <returns>
   /// The total number of all ready and delayed events
   /// </returns>
-  size_t GetDispatchQueueLength(void) const {return m_dispatchQueue.size() + m_delayedQueue.size();}
+  size_t GetDispatchQueueLength(void) const {return m_count + m_delayedQueue.size();}
 
   /// <summary>
   /// Causes the current dispatch queue to be dumped if it's non-empty
@@ -173,7 +178,11 @@ public:
   /// <summary>
   /// Explicit overload for already-constructed dispatch thunk types
   /// </summary>
-  void AddExisting(DispatchThunkBase* pBase);
+  void AddExisting(std::unique_ptr<DispatchThunkBase>&& pBase) {
+    std::unique_lock<std::mutex> lk(m_dispatchLock);
+    if (m_count < m_dispatchCap)
+      PendExisting(std::move(lk), pBase.release());
+  }
 
   /// <summary>
   /// Blocks until all dispatchers on the DispatchQueue at the time of the call have been dispatched
@@ -273,11 +282,23 @@ public:
     static_assert(!std::is_pointer<_Fx>::value, "Cannot pend a pointer to a function, we must have direct ownership");
 
     std::unique_lock<std::mutex> lk(m_dispatchLock);
-    if(m_dispatchQueue.size() >= m_dispatchCap)
+    if (m_count >= m_dispatchCap)
       return;
 
-    m_dispatchQueue.push_back(new DispatchThunk<_Fx>(std::forward<_Fx>(fx)));
-    m_queueUpdated.notify_all();
+    // Count must be separately maintained:
+    m_count++;
+
+    // Linked list setup:
+    auto thunk = new DispatchThunk<_Fx>(std::forward<_Fx>(fx));
+    if (m_pHead)
+      m_pTail->m_pFlink = thunk; 
+    else {
+      m_pHead = thunk;
+      m_queueUpdated.notify_all();
+    }
+    m_pTail = thunk;
+
+    // Notification as needed:
     OnPended(std::move(lk));
   }
 };

--- a/autowiring/DispatchQueue.h
+++ b/autowiring/DispatchQueue.h
@@ -2,6 +2,7 @@
 #pragma once
 #include "dispatch_aborted_exception.h"
 #include "DispatchThunk.h"
+#include <atomic>
 #include <list>
 #include <queue>
 #include MUTEX_HEADER
@@ -19,6 +20,8 @@ class DispatchQueue;
 class DispatchQueue {
 public:
   DispatchQueue(void);
+  DispatchQueue(DispatchQueue&&) = delete;
+  DispatchQueue(const DispatchQueue&) = delete;
 
   /// <summary>
   /// Runs down the dispatch queue without calling anything
@@ -34,7 +37,7 @@ protected:
   size_t m_dispatchCap = 1000;
 
   // Current linked list length
-  size_t m_count = 0;
+  std::atomic<size_t> m_count{0};
 
   // The dispatch queue proper.  A vector is used, here, not a queue, because this collection is frequently emptied.
   DispatchThunkBase* m_pHead = nullptr;

--- a/src/autowiring/CoreJob.cpp
+++ b/src/autowiring/CoreJob.cpp
@@ -44,9 +44,10 @@ void CoreJob::OnPended(std::unique_lock<std::mutex>&& lk){
   if(!outstanding) {
     // We're currently signalled to stop, we must empty the queue and then
     // return here--we can't accept dispatch delivery on a stopped queue.
-    while(!m_dispatchQueue.empty()) {
-      delete m_dispatchQueue.front();
-      m_dispatchQueue.pop_front();
+    for (auto cur = m_pHead; cur;) {
+      auto next = cur->m_pFlink;
+      delete cur;
+      cur = next;
     }
   } else {
     // Need to ask the thread pool to handle our events again:
@@ -97,11 +98,9 @@ bool CoreJob::OnStart(void) {
   m_running = true;
 
   std::unique_lock<std::mutex> lk;
-  if(!m_dispatchQueue.empty()) {
+  if(m_pHead)
     // Simulate a pending event, because we need to set up our async:
     OnPended(std::move(lk));
-  }
-
   return true;
 }
 

--- a/src/autowiring/DispatchQueue.cpp
+++ b/src/autowiring/DispatchQueue.cpp
@@ -189,8 +189,6 @@ void DispatchQueue::PendExisting(std::unique_lock<std::mutex>&& lk, DispatchThun
 }
 
 bool DispatchQueue::Barrier(std::chrono::nanoseconds timeout) {
-  static const char text [] = "Dispatch queue was aborted while a barrier was invoked";
-
   // Optimistic check first:
   std::unique_lock<std::mutex> lk(m_dispatchLock);
 

--- a/src/autowiring/test/DispatchQueueTest.cpp
+++ b/src/autowiring/test/DispatchQueueTest.cpp
@@ -100,7 +100,8 @@ struct BarrierMonitor {
   // Standard continuation behavior:
   std::mutex lock;
   std::condition_variable cv;
-  bool done;
+  size_t nReady = 0;
+  bool done = false;
 };
 
 TEST_F(DispatchQueueTest, BarrierWithAbort) {
@@ -113,28 +114,34 @@ TEST_F(DispatchQueueTest, BarrierWithAbort) {
 
   // This dispatch entry will delay until we're ready for it to continue:
   *ct += [b] {
-    std::lock_guard<std::mutex> lk(b->lock);
+    std::unique_lock<std::mutex> lk(b->lock);
+    b->nReady++;
+    b->cv.notify_all();
+    b->cv.wait(lk, [&] { return b->done; });
   };
-
-  // Delay for long enough for the barrier to be reached:
-  std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
   // Launch something that will barrier:
   auto f = std::async(
     std::launch::async,
     [=] {
-      try {
-        ct->Barrier(std::chrono::seconds(5));
+      {
+        std::unique_lock<std::mutex> lk(b->lock);
+        b->nReady++;
+        b->cv.notify_all();
       }
-      catch (autowiring_error&) {
-        return false;
-      }
-      return true;
+      return ct->Barrier(std::chrono::seconds(5));
     }
   );
 
-  // Now abandon the queue, this should cause the async thread to quit:
+  // Wait for all threads to hit the barrier, then signal anyone interested that they can back out
+  b->cv.wait(lk, [&] { return b->nReady == 2; });
+  b->done = true;
+  b->cv.notify_all();
+
+  // Abandon the queue before relinquishing the lock:
   ct->Abort();
+
   ASSERT_EQ(std::future_status::ready, f.wait_for(std::chrono::seconds(5))) << "Barrier did not abort fast enough";
-  ASSERT_FALSE(f.get()) << "Exception should have been thrown inside the Barrier call";
+  bool rs;
+  ASSERT_ANY_THROW(rs = f.get()) << "Barrier call returned " << std::boolalpha << rs << " instead of throwing an exception";
 }


### PR DESCRIPTION
An intrusive linked list, in this case, is a much better choice.  Heap allocations for each entry in the collection are unavoidably necessary because entries have a variable size, which means a linked list is an improvement over `std::list`.

If necessary, a next step could be to use a journal-based arena allocator in order to keep links in the list sequential with respect to each other.

- [x] Merge #507 