### PR TITLE
Fix bug in AnySharedPointer::operator<

### DIFF
--- a/autowiring/AnySharedPointer.h
+++ b/autowiring/AnySharedPointer.h
@@ -50,19 +50,9 @@ public:
     return *slot() == rhs;
   }
 
-  /// <summary>
-  /// Default for std library sorting of unique elements
-  /// </summary>
+  // Additional operator overloads:
   bool operator<(const AnySharedPointer& rhs) const { return *slot() < *rhs.slot();}
-
-  /// <summary>
-  /// Default for std library sorting of repeatable elements
-  /// </summary>
-  bool operator<=(const AnySharedPointer& rhs) const { return *slot() <= *rhs.slot();}
-
-  bool operator>(const AnySharedPointer& rhs) const { return *slot() > *rhs.slot();}
-
-  bool operator>=(const AnySharedPointer& rhs) const { return *slot() >= *rhs.slot();}
+  bool operator!=(const AnySharedPointer& rhs) const { return !(*this == rhs); }
 
   /// <summary>
   /// Copy assignment operator

--- a/autowiring/AutoFilterDescriptor.h
+++ b/autowiring/AutoFilterDescriptor.h
@@ -274,21 +274,16 @@ public:
   /// Default for std library sorting of unique elements
   /// </summary>
   bool operator<(const AutoFilterDescriptor& rhs) const {
-    // This filter is "logically prior" to the right-hand side if this filter has a HIGHER altitude
-    // than the one on the right-hand side
     return
       std::tie(m_altitude, m_pCall, m_autoFilter) <
       std::tie(rhs.m_altitude, rhs.m_pCall, rhs.m_autoFilter);
   }
 
-  /// <summary>
-  /// Default for std library sorting of repeatable elements
-  /// </summary>
+  // Operator overloads:
   bool operator<=(const AutoFilterDescriptor& rhs) const { return *this < rhs || *this == rhs;}
-
   bool operator>(const AutoFilterDescriptor& rhs) const { return !(*this <= rhs);}
-
   bool operator>=(const AutoFilterDescriptor& rhs) const { return !(*this < rhs);}
+  bool operator!=(const AutoFilterDescriptor& rhs) const { return !(*this == rhs); }
 };
 
 /// <summary>

--- a/autowiring/SharedPointerSlot.h
+++ b/autowiring/SharedPointerSlot.h
@@ -7,6 +7,7 @@
 #include "SlotInformation.h"
 #include MEMORY_HEADER
 #include <stdexcept>
+#include <tuple>
 
 template<class T, bool use_object = true>
 struct SharedPointerSlotT;
@@ -55,7 +56,7 @@ protected:
   virtual void assign(const SharedPointerSlot& rhs) {}
 
 public:
-  operator bool(void) const { return !empty(); }
+  explicit operator bool(void) const { return !empty(); }
   virtual operator std::shared_ptr<CoreObject>(void) const { return std::shared_ptr<CoreObject>(); }
   virtual void* ptr(void) { return nullptr; }
   virtual const void* ptr(void) const { return nullptr; }
@@ -172,6 +173,15 @@ public:
     // Instantiate the static cast with "false" because this function should not be attempting to
     // instantiate any casts.
     return static_cast<const SharedPointerSlotT<T, false>*>(this)->get();
+  }
+
+  bool operator<(const SharedPointerSlot& rhs) const {
+    return
+      &type() < &rhs.type() ?
+      true :
+      &type() == &rhs.type() ?
+      ptr() < rhs.ptr() :
+      false;
   }
 
   /// <summary>


### PR DESCRIPTION
This bug is being caused by an implicit cast from `SharedPointerSlot` to `bool`.  The resulting boolean is being used in the various comparison operations silently.  Mark `SharedPointerSlot::operator bool` as `explicit` and then correct the compiler errors that result.

This bug is causing AutoFilters to sometimes be considered equal even when they are not.  It manifests most obviously when multiple AutoFilter lambdas are being attached to the same packet, but have different pointer values.  Currently, the most common use case of `AutoPacketFactory::operator+=` only ever attaches one instance of an AutoFilter lambda, but if multiple similar instances are attached, or if the linker performs COMDAT reduction and causes two distinct lambdas to share the same code, an error will result.

Also add a test to guard against a regression here, both in the comparators and in the above folding case.