### PR TITLE
Don't bother continuing with example compilation if unit tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,18 +54,7 @@ before_script:
 
 script:
   # Build Autowriring, run unit tests, and install
-  - make -j 8 || make
-  - ctest --output-on-failure
-  - sudo make install
-
-  # Package
-  - sudo cpack || (cat _CPack_Packages/Linux/TGZ/InstallOutput.log; exit 1)
-
-  # Build examples from installed Autowiring
-  - cd examples
-    && cmake . -Dautowiring_ARCHITECTURE=x64
-    && make
-    && cd ..
+  - ./scripts/build_test_install.sh
 
 after_failure:
   - cat Testing/Temporary/LastTest.log 2> /dev/null

--- a/scripts/build_test_install.sh
+++ b/scripts/build_test_install.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+make -j 8 || make || exit 1
+
+ctest --output-on-failure && sudo make install || exit 2
+
+sudo cpack || (cat _CPack_Packages/Linux/TGZ/InstallOutput.log; exit 3)
+
+# Build examples from installed Autowiring
+cd examples
+cmake . -Dautowiring_ARCHITECTURE=x64 && make || exit 4


### PR DESCRIPTION
Mistakes that cause unit tests to fail generally do not cause packaging failures; these tests are orthogonal for a reason.  Therefore, short-circuit the build process if unit test failure is detected.