### PR TITLE
Fix Android build

### DIFF
--- a/src/autowiring/benchmark/DispatchQueueBm.cpp
+++ b/src/autowiring/benchmark/DispatchQueueBm.cpp
@@ -2,7 +2,7 @@
 #include "stdafx.h"
 #include "DispatchQueueBm.h"
 #include "Benchmark.h"
-#include <future>
+#include FUTURE_HEADER
 #include <thread>
 
 Benchmark DispatchQueueBm::Dispatch(void) {

--- a/src/autowiring/test/DispatchQueueTest.cpp
+++ b/src/autowiring/test/DispatchQueueTest.cpp
@@ -158,6 +158,5 @@ TEST_F(DispatchQueueTest, BarrierWithAbort) {
   ct->Abort();
 
   ASSERT_EQ(std::future_status::ready, f.wait_for(std::chrono::seconds(5))) << "Barrier did not abort fast enough";
-  bool rs;
-  ASSERT_ANY_THROW(rs = f.get()) << "Barrier call returned " << std::boolalpha << rs << " instead of throwing an exception";
+  ASSERT_ANY_THROW(f.get()) << "Barrier call returned instead of throwing an exception";
 }


### PR DESCRIPTION
Currently we still require boost::future, and gcc 4.8 complains if we try to print the return value from a noreturn function in DispatchQueueTest.