### PR TITLE
Removed the virtual keyword when inheriting from CoreRunnable.

### DIFF
--- a/autowiring/BasicThread.h
+++ b/autowiring/BasicThread.h
@@ -62,7 +62,7 @@ enum class ThreadPriority {
 /// </remarks>
 class BasicThread:
   public ContextMember,
-  public virtual CoreRunnable
+  public CoreRunnable
 {
 public:
   /// Creates a BasicThread object.


### PR DESCRIPTION
This really doesn't do anything except cause errors with auto_signal.  There's a separate issue & unit test exposing that particular problem now, so we can remove this safely.