### PR TITLE
Make better use of precompiled header

### DIFF
--- a/src/autowiring/stdafx.h
+++ b/src/autowiring/stdafx.h
@@ -7,10 +7,29 @@
 // Only include these headers in cases where a pch can be generated
 // Currently this is only supported on MSVC
 #ifdef _MSC_VER
-  #include <thread>
   #ifndef NOMINMAX
     #define NOMINMAX
   #endif
+
+  #include <algorithm>
+  #include <functional>
+  #include <future>
+  #include <iosfwd>
+  #include <list>
+  #include <map>
+  #include <memory>
+  #include <mutex>
+  #include <queue>
+  #include <set>
+  #include <sstream>
+  #include <string>
+  #include <thread>
+  #include <tuple>
+  #include <type_traits>
+  #include <typeindex>
+  #include <unordered_map>
+  #include <unordered_set>
+  #include <vector>
 #endif
   
 #ifndef _MSC_VER


### PR DESCRIPTION
These headers are used pretty much everywhere in autowiring.  New compile time is 50% of what it was on MSVC.

Before: 33.87s
After: 17.77s