### PR TITLE
Move MemoEntry to its own header

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -17,6 +17,7 @@
 #include "InvokeRelay.h"
 #include "JunctionBoxManager.h"
 #include "member_new_type.h"
+#include "MemoEntry.h"
 #include "CoreObjectDescriptor.h"
 #include "result_or_default.h"
 #include "TeardownNotifier.h"
@@ -154,26 +155,6 @@ public:
   /// </summary>
   /// \sa AutoGlobalContext, GlobalCoreContext
   static std::shared_ptr<CoreContext> GetGlobal(void);
-
-  /// \internal
-  /// <summary>
-  /// Represents a single entry, together with any deferred elements waiting on the satisfaction of this entry
-  /// </summary>
-  struct MemoEntry {
-    // The first deferrable autowiring which requires this type, if one exists:
-    DeferrableAutowiring* pFirst = nullptr;
-
-    // A back reference to the concrete type from which this memo was generated.  This field may be null
-    // if there is no corresponding concrete type.
-    const CoreObjectDescriptor* pObjTraits;
-
-    // Once this memo entry is satisfied, this will contain the AnySharedPointer instance that performs
-    // the satisfaction
-    AnySharedPointer m_value;
-
-    // A flag to determine if this memo entry was set from the current context.
-    bool m_local = true;
-  };
 
 protected:
   // A pointer to the parent context

--- a/autowiring/MemoEntry.h
+++ b/autowiring/MemoEntry.h
@@ -1,0 +1,29 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "AnySharedPointer.h"
+
+struct CoreObjectDescriptor;
+class DeferrableAutowiring;
+
+/// \internal
+/// <summary>
+/// Represents a single entry, together with any deferred elements waiting on the satisfaction of this entry
+/// </summary>
+struct MemoEntry {
+  MemoEntry(void);
+
+  // The first deferrable autowiring which requires this type, if one exists:
+  DeferrableAutowiring* pFirst = nullptr;
+
+  // A back reference to the concrete type from which this memo was generated.  This field may be null
+  // if there is no corresponding concrete type.
+  const CoreObjectDescriptor* pObjTraits;
+
+  // Once this memo entry is satisfied, this will contain the AnySharedPointer instance that performs
+  // the satisfaction
+  AnySharedPointer m_value;
+
+  // A flag to determine if this memo entry was set from the current context.
+  bool m_local = true;
+};
+

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -132,6 +132,8 @@ set(Autowiring_SRCS
   JunctionBoxManager.cpp
   JunctionBoxManager.h
   member_new_type.h
+  MemoEntry.h
+  MemoEntry.cpp
   MicroAutoFilter.h
   MicroBolt.h
   NewAutoFilter.h

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -330,7 +330,7 @@ void CoreContext::FindByType(AnySharedPointer& reference, bool localOnly) const 
   FindByTypeUnsafe(reference, localOnly);
 }
 
-CoreContext::MemoEntry& CoreContext::FindByTypeUnsafe(AnySharedPointer& reference, bool localOnly) const {
+MemoEntry& CoreContext::FindByTypeUnsafe(AnySharedPointer& reference, bool localOnly) const {
   const std::type_info& type = reference->type();
 
   // If we've attempted to search for this type before, we will return the value of the memo immediately:

--- a/src/autowiring/MemoEntry.cpp
+++ b/src/autowiring/MemoEntry.cpp
@@ -1,0 +1,5 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "MemoEntry.h"
+
+MemoEntry::MemoEntry(void) {}

--- a/src/autowiring/stdafx.h
+++ b/src/autowiring/stdafx.h
@@ -12,6 +12,9 @@
   #endif
 
   #include <algorithm>
+  #include <atomic>
+  #include <chrono>
+  #include <exception>
   #include <functional>
   #include <future>
   #include <iosfwd>


### PR DESCRIPTION
This type will be gaining more responsibilities, should be moved to a location by itself to give it room to grow.