### PR TITLE
Fix DispatchQueue destructor reentrancy, correct invalid use of m_pHead

### DIFF
--- a/autowiring/DispatchQueue.h
+++ b/autowiring/DispatchQueue.h
@@ -107,6 +107,11 @@ public:
   /// <returns>
   /// The total number of all ready and delayed events
   /// </returns>
+  /// <remarks>
+  /// This method will also count dispatchers that are presently underway or presently being deleted.  Thus, calling
+  /// this method from within a dispatcher, or from that dispatcher's destructor, should always return a size of at
+  /// least 1.
+  /// </remarks>
   size_t GetDispatchQueueLength(void) const {return m_count + m_delayedQueue.size();}
 
   /// <summary>


### PR DESCRIPTION
A lock is being held by `DispatchQueue::Abort` during a control transfer to a lambda deleter, creating a potential reentrancy.  The lock doesn't need to be held in order to process teardown, thus it should be released before teardown is attempted.