### PR TITLE
Correct race condition in auto_prev

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -88,7 +88,7 @@ protected:
   /// <summary>
   /// Adds all AutoFilter argument information for a recipient
   /// </summary>
-  void AddSatCounter(SatCounter& satCounter);
+  void AddSatCounterUnsafe(SatCounter& satCounter);
 
   /// <summary>
   /// Marks the specified entry as being unsatisfiable

--- a/autowiring/DispatchQueue.h
+++ b/autowiring/DispatchQueue.h
@@ -107,6 +107,11 @@ public:
   /// <returns>
   /// The total number of all ready and delayed events
   /// </returns>
+  /// <remarks>
+  /// This method will also count dispatchers that are presently underway or presently being deleted.  Thus, calling
+  /// this method from within a dispatcher, or from that dispatcher's destructor, should always return a size of at
+  /// least 1.
+  /// </remarks>
   size_t GetDispatchQueueLength(void) const {return m_count + m_delayedQueue.size();}
 
   /// <summary>

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -75,7 +75,7 @@ DecorationDisposition& AutoPacket::DecorateImmediateUnsafe(const DecorationKey& 
   return dec;
 }
 
-void AutoPacket::AddSatCounter(SatCounter& satCounter) {
+void AutoPacket::AddSatCounterUnsafe(SatCounter& satCounter) {
   for(auto pCur = satCounter.GetAutoFilterInput(); *pCur; pCur++) {
     DecorationKey key(*pCur->ti, pCur->is_shared, pCur->tshift);
     DecorationDisposition& entry = m_decorations[key];
@@ -375,7 +375,7 @@ const SatCounter* AutoPacket::AddRecipient(const AutoFilterDescriptor& descripto
     m_firstCounter = &sat;
 
     // Update satisfaction & Append types from subscriber
-    AddSatCounter(sat);
+    AddSatCounterUnsafe(sat);
   }
 
   if (!sat.remaining)

--- a/src/autowiring/AutoPacketInternal.cpp
+++ b/src/autowiring/AutoPacketInternal.cpp
@@ -20,11 +20,15 @@ void AutoPacketInternal::Initialize(bool isFirstPacket) {
   
   // Find all subscribers with no required or optional arguments:
   std::vector<SatCounter*> callCounters;
-  for (auto* satCounter = m_firstCounter; satCounter; satCounter = satCounter->flink) {
-    // Prime the satisfaction graph for element:
-    AddSatCounter(*satCounter);
-    if (!satCounter->remaining)
-      callCounters.push_back(satCounter);
+
+  {
+    std::lock_guard<std::mutex> lk(m_lock);
+    for (auto* satCounter = m_firstCounter; satCounter; satCounter = satCounter->flink) {
+      // Prime the satisfaction graph for element:
+      AddSatCounterUnsafe(*satCounter);
+      if (!satCounter->remaining)
+        callCounters.push_back(satCounter);
+    }
   }
   
   // Mark timeshifted decorations as unsatisfiable on the first packet


### PR DESCRIPTION
Rename `AddSatCounter` to `AddSatCounterUnsafe`, because this method is unsynchronized.  This oversight created a race condition in `AutoPacketInternal::Initialize`; formerly, this method was called before the packet was ever exposed to the caller.  Now, the method may potentially be invoked while a filter is already running.

Add a pathological test to verify this behavior by making use of the same `AutoPacket` in two thread contexts.

- [x] Merge #521 