### PR TITLE
Refactor Signal Relay, use NotifyOnAutowired instead

### DIFF
--- a/autowiring/AutoConfig.h
+++ b/autowiring/AutoConfig.h
@@ -78,7 +78,7 @@ public:
       auto parent_ctxt = m_context.lock()->GetParentContext();
       AutowiredFast<AutoConfigVar<T, TKey...>> parentVar(parent_ctxt);
       *parentVar -= m_parentRegistration;
-      m_parentRegistration = nullptr;
+      m_parentRegistration.reset();
       OnSetLocally();
     }
 
@@ -93,13 +93,13 @@ public:
   }
 
   // Add a callback for when this config value changes
-  t_OnChangedSignal::registration_t* operator+=(std::function<void(const T&)>&& fx) {
+  autowiring::registration_t operator+=(std::function<void(const T&)>&& fx) {
     return onChangedSignal += [fx](const AutoConfigVarBase& var){
       fx(reinterpret_cast<const AutoConfigVar<T,TKey...>*>(&var)->m_value);
     };
   }
 
-  void operator-=(t_OnChangedSignal::registration_t* node) { onChangedSignal -= node; }
+  void operator-=(autowiring::registration_t node) { onChangedSignal -= node; }
 
 private:
   T m_value;

--- a/autowiring/AutoConfig.h
+++ b/autowiring/AutoConfig.h
@@ -75,9 +75,6 @@ public:
     RunValidation(newValue);
 
     if (m_parentRegistration) {
-      auto parent_ctxt = m_context.lock()->GetParentContext();
-      AutowiredFast<AutoConfigVar<T, TKey...>> parentVar(parent_ctxt);
-      *parentVar -= m_parentRegistration;
       m_parentRegistration.reset();
       OnSetLocally();
     }

--- a/autowiring/AutoConfig.h
+++ b/autowiring/AutoConfig.h
@@ -33,7 +33,6 @@ public:
       }
     }
 
-    onChangedSignal(*this);
   }
 
   AutoConfigVar() :

--- a/autowiring/AutoConfigBase.h
+++ b/autowiring/AutoConfigBase.h
@@ -24,7 +24,7 @@ public:
 
   // True if this config was set at all
   bool IsConfigured() const { return m_isConfigured; }
-  bool IsInherited() const { return m_parentRegistration != nullptr; }
+  bool IsInherited() const { return (bool)m_parentRegistration; }
   //True if the config was set from within this context (isn't inherited)
   bool IsLocal() const { return IsConfigured() && !IsInherited(); }
 
@@ -39,5 +39,5 @@ protected:
   void OnSetLocally();
 
   bool m_isConfigured;
-  t_OnChangedSignal::registration_t* m_parentRegistration;
+  autowiring::registration_t m_parentRegistration;
 };

--- a/autowiring/AutoConfigListing.h
+++ b/autowiring/AutoConfigListing.h
@@ -100,7 +100,7 @@ public:
 
   // Add a callback for when a key is set in this context.  Is immediately called on all
   // currently existing values in the order they were created.
-  onAddSignal_t::registration_t* AddCallback(onAddSignal_t::function_t&& fx);
+  autowiring::registration_t AddCallback(std::function<void(const AutoConfigVarBase&)>&& fx);
 
   // Returns a list of all keys which have been set from this context.
   const std::vector<std::string>& GetLocalKeys() const { return m_orderedKeys; }

--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -216,7 +216,7 @@ protected:
   template<class T, class Fn>
   class AutoFactoryFn;
 
-  // This is a list of concrete types, indexed by the true type of each element.
+  // Simple list of concrete types
   std::list<CoreObjectDescriptor> m_concreteTypes;
 
   // This is a memoization map used to memoize any already-detected interfaces.
@@ -1209,36 +1209,6 @@ public:
   /// Unregisters a slot as a recipient of potential autowiring
   /// </summary>
   void CancelAutowiringNotification(DeferrableAutowiring* pDeferrable);
-
-  /// <returns>
-  /// A slots-and-signals type relay for a specific type
-  /// </returns>
-  template<typename T, typename... Args>
-  autowiring::signal_relay_t<Args...>& RelayForType(autowiring::signal<void(Args...)> T::*handler) {
-    typedef typename SelectTypeUnifier<T>::type TActual;
-
-    // Get the table first
-    auto registration = Inject<autowiring::signal_relay_registration_table>();
-
-    // Find the basis offset between T and TActual.  This is the address of the first member of T
-    // relative to the base of TActual.
-    size_t basis =
-      reinterpret_cast<size_t>(
-        static_cast<T*>(
-          reinterpret_cast<TActual*>(1)
-        )
-      ) - 1;
-
-    // Find the offset and return the relay
-    return
-      static_cast<autowiring::signal_relay_t<Args...>&>(
-        *registration->GetSignalRelay(
-          typeid(TActual),
-          basis +
-          reinterpret_cast<size_t>(&(static_cast<T*>(nullptr)->*handler))
-        )
-      );
-  }
 
   /// <summary>
   /// Utility debug method for writing a snapshot of this context to the specified output stream

--- a/autowiring/auto_signal.h
+++ b/autowiring/auto_signal.h
@@ -3,6 +3,7 @@
 #include "Decompose.h"
 #include <atomic>
 #include <functional>
+#include <list>
 #include <memory>
 #include <mutex>
 #include <unordered_map>

--- a/autowiring/auto_signal.h
+++ b/autowiring/auto_signal.h
@@ -44,7 +44,7 @@ namespace autowiring {
     /// <summary>
     /// Removes the signal node identified on the rhs without requiring full type information
     /// </summary>
-    virtual void operator-=(internal::signal_node_base* rhs);
+    virtual void operator-=(internal::signal_node_base* rhs) = 0;
 
     /// <summary>
     /// Removes the specified registration

--- a/autowiring/auto_signal.h
+++ b/autowiring/auto_signal.h
@@ -170,7 +170,7 @@ namespace autowiring {
       auto iter = m_listeners.begin();
       while (iter != m_listeners.end()) {
         auto callee = iter;
-        std::lock_guard<std::mutex>(m_lock), ++iter;
+        (std::lock_guard<std::mutex>)m_lock, ++iter;
         (**callee)(args...);
       }
     }

--- a/autowiring/auto_signal.h
+++ b/autowiring/auto_signal.h
@@ -1,16 +1,11 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Decompose.h"
-
 #include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
-
-namespace autowiring {
-  struct signal_relay_registration_table;
-}
 
 /// <summary>
 /// Implements an asynchronous signal concept as an AutoFired alternative
@@ -19,255 +14,160 @@ namespace autowiring {
   template<typename T>
   struct signal;
 
-  struct signal_relay;
+  struct registration_t;
 
   namespace internal {
-    // Linked list entry
-    struct signal_node_base {
-      signal_node_base(void) :
-        pFlink(nullptr),
-        pBlink(nullptr)
-      {}
+    struct signal_node_base {};
 
-      virtual ~signal_node_base(void) {}
-
-      // Forward and backward linkages:
-      signal_node_base* pFlink;
-      signal_node_base* pBlink;
-      
-      /// <summary>
-      /// Inserts a node after the current one
-      /// </summary>
-      void insert_after(signal_node_base* node) {
-        node->pBlink = this;
-        node->pFlink = pFlink;
-        if (pFlink)
-          pFlink->pBlink = node;
-        pFlink = node;
-      }
-
-      /// <summary>
-      /// Removes this node from the list it's in.
-      /// </summary>
-      /// <remarks>
-      /// If you call this function, you are assuming responsibility for the memory and 
-      /// are expected to call delete on the node.
-      /// </remarks>
-      /// <returns>
-      /// A pointer to itself for easier chaining of operations.
-      /// </returns>
-      signal_node_base* remove() {
-        // Clear linkage
-        if (this->pBlink)
-          this->pBlink->pFlink = this->pFlink;
-        if (this->pFlink)
-          this->pFlink->pBlink = this->pBlink;
-
-        this->pBlink = this->pFlink = nullptr;
-        return this;
-      }
+    template<typename... Args>
+    struct signal_node_t_base:
+      signal_node_base
+    {
+      virtual void operator()(Args... args) = 0;
     };
 
     // Holds a reference to one of the signal holders
-    template<typename... Args>
-    struct signal_node :
-      signal_node_base
+    template<typename Fn, typename... Args>
+    struct signal_node_t :
+      signal_node_t_base<Args...>
     {
-      signal_node(const signal_node& rhs) = delete;
+      signal_node_t(Fn&& fn) : fn(fn) {}
+      const Fn fn;
 
-      signal_node(std::function<void(Args...)>&& fn) :
-        fn(std::move(fn))
-      {}
-      
-      //Functions where the first argument is a signal_node<...> or base type are also ok.
-      signal_node(std::function<void(signal_node<Args...>*, Args...)>&& newFn) :
-        fn([this, newFn](Args... args){ newFn(this, args...); })
-      {}
-      
-      const std::function<void(Args...)> fn;
-
-      /// <summary>
-      /// Appends the specified handler to this list of nodes.
-      /// </summary>
-      template<typename t_Fn>
-      typename std::enable_if<Decompose<decltype(&t_Fn::operator())>::N == sizeof...(Args), signal_node<Args...>*>::type
-      operator+=(t_Fn fn) {
-        auto retVal = new signal_node<Args...>(std::function<void(Args...)>(std::forward<t_Fn>(fn)));
-        insert_after(retVal);
-        return retVal;
-      }
-
-      template<typename t_Fn>
-      typename std::enable_if<Decompose<decltype(&t_Fn::operator())>::N == sizeof...(Args) + 1, signal_node<Args...>*>::type
-        operator+=(t_Fn fn) {
-        auto retVal = new signal_node<Args...>(std::function<void(signal_node<Args...>*,Args...)>(std::forward<t_Fn>(fn)));
-        insert_after(retVal);
-        return retVal;
+      virtual void operator()(Args... args) override {
+        fn(args...);
       }
     };
-
-    struct signal_registration_base {
-      signal_registration_base(void);
-
-      // Associates signal entries with their corresponding relays
-      std::unordered_map<size_t, std::shared_ptr<signal_relay>> entries;
-    };
-
-    /// <summary>
-    /// Associates offsets in type T with signals in that type
-    /// </summary>
-    template<class T>
-    struct signal_registration:
-      signal_registration_base
-    {};
-
-    /// <summary>
-    /// Obtains the signal relay for the specified member type:
-    /// </summary>
-    std::shared_ptr<signal_relay> ObtainRelay(void* pMember);
   }
 
-  /// <summary>
-  /// Associates abstract offsets with signal relays
-  /// </summary>
-  /// <remarks>
-  /// One of these registration tables exists per context.
-  /// </remarks>
-  struct signal_relay_registration_table {
-    struct registration {
-      registration(const std::type_info* ti, size_t offset) :
-        ti(ti),
-        offset(offset)
-      {}
-
-      const std::type_info* ti;
-      size_t offset;
-
-      bool operator==(const registration& rhs) const {
-        return *ti == *rhs.ti && offset == rhs.offset;
-      }
-    };
-
-    struct registration_hash {
-      size_t operator()(const registration& reg) const {
-        return reg.ti->hash_code() + reg.offset;
-      }
-    };
-
-    // Lock for the table:
-    std::mutex lock;
+  struct signal_base {
+    /// <summary>
+    /// Removes the signal node identified on the rhs without requiring full type information
+    /// </summary>
+    virtual void operator-=(internal::signal_node_base* rhs);
 
     /// <summary>
-    /// Associates an offset in the relay registration with a signal relay
+    /// Removes the specified registration
     /// </summary>
-    /// <remarks>
-    /// This map assumes that users have some other way of inferring the types on the key side.
-    /// </remarks>
-    std::unordered_map<registration, std::shared_ptr<signal_relay>, registration_hash> table;
-
-    /// <summary>
-    /// Creates or returns the relay at the specified offset
-    /// </summary>
-    std::shared_ptr<signal_relay> GetSignalRelay(const std::type_info& ti, size_t offset);
+    void operator-=(const registration_t& reg);
   };
 
-  /// <summary>
-  /// Stores a signal 
-  /// </summary>
-  /// <remarks>
-  /// This is functionally a sentinal head of the linked list.
-  /// </remarks>
-  struct signal_relay :
-    internal::signal_node_base
+  struct registration_t
   {
-    signal_relay(void) {}
+    registration_t(void) = default;
 
-    ~signal_relay(void) override {
-      // Standard linked list cleaup
-      internal::signal_node_base* next = nullptr;
-      for (auto cur = pFlink; cur; cur = next) {
-        next = cur->pFlink;
-        delete cur; //don't bother unlinking..
-      }
+    registration_t(signal_base* parent, internal::signal_node_base* entry) :
+      parent(parent),
+      entry(entry)
+    {}
+
+    signal_base* parent = nullptr;
+    internal::signal_node_base* entry;
+
+    explicit operator bool(void) const { return !!parent; }
+
+    bool operator==(const registration_t& rhs) const {
+      return parent == rhs.parent && entry == rhs.entry;
     }
 
-    /// <summary>
-    /// Searches the list for this node and deletes it, or throws if it is not found.
-    /// </summary>
-    void operator-=(signal_node_base* node) {
-      signal_node_base* cur;
-      for (cur = pFlink; cur != nullptr; cur = cur->pFlink) {
-        if (cur == node){
-          node->remove();
-          delete node;
-          return;
-        }
-      }
-
-      throw std::runtime_error("Attempted to remove node which is not part of this list.");
+    void reset(void) {
+      if (parent)
+        *parent -= entry;
+      parent = nullptr;
     }
-  };
-
-  /// <summary>
-  /// Descriptor type used to add entries that will be constructed in a signal relay
-  /// </summary>
-  template<typename... Args>
-  struct signal_relay_t:
-    signal_relay
-  {
-    internal::signal_node<Args...>* GetHead(void) const {
-      return static_cast<internal::signal_node<Args...>*>(pFlink);
-    }
-
-    /// <summary>
-    /// Attaches the specified handler to this signal
-    /// </summary>
-    template<typename t_Fn>
-    internal::signal_node<Args...>* operator+=(t_Fn fn) {
-      return *reinterpret_cast<internal::signal_node<Args...>*>(this) += std::forward<t_Fn>(fn);
-    }
-
   };
 
   /// <summary>
   /// A signal registration entry, for use as an embedded member variable of a context member.
   /// </summary>
   template<typename... Args>
-  struct signal<void(Args...)>
+  struct signal<void(Args...)>:
+    signal_base
   {
-  public:
-    signal(void) :
-      m_relay(
-        std::static_pointer_cast<signal_relay_t<Args...>>(
-          internal::ObtainRelay(this)
-        )
-      )
-    {}
+    typedef std::shared_ptr<internal::signal_node_t_base<Args...>> entry_t;
 
   private:
-    const std::shared_ptr<signal_relay_t<Args...>> m_relay;
+    // Listeners and the corresponding lock:
+    mutable std::mutex m_lock;
+    std::vector<entry_t> m_listeners;
+
+    // Perfect match override:
+    template<typename Fn>
+    entry_t make_registration(Fn fn, void (Fn::*)(Args...) const) {
+      return std::make_shared<
+        internal::signal_node_t<Fn, Args...>
+      >(std::forward<Fn>(fn));
+    }
+
+    template<class Fn>
+    struct Forwarder:
+      internal::signal_node_t_base<Args...>
+    {
+      Forwarder(signal* parent, Fn&& fn) :
+        parent(parent),
+        fn(std::forward<Fn&&>(fn))
+      {}
+
+      signal*const parent;
+      const Fn fn;
+
+      void operator()(Args... args) override {
+        registration_t reg{parent, this};
+        fn(&reg, args...);
+      }
+    };
+
+    template<typename Fn>
+    entry_t make_registration(Fn fn, void (Fn::*)(registration_t*, Args...) const) {
+      return std::make_shared<Forwarder<Fn>>(this, std::forward<Fn>(fn));
+    }
 
   public:
-    typedef internal::signal_node<Args...> registration_t;
-    typedef std::function<void(Args...)> function_t;
 
-    template<typename t_Fn>
-    registration_t* operator+=(t_Fn fn) { return *m_relay += std::forward<t_Fn>(fn); }
+    /// <summary>
+    /// Attaches the specified handler to this signal
+    /// </summary>
+    template<typename Fn>
+    registration_t operator+=(Fn fn) {
+      auto entry = make_registration<Fn>(std::forward<Fn>(fn), &Fn::operator());
 
-    void operator-=(registration_t* node) { return *m_relay -= node; }
+      std::lock_guard<std::mutex> lk(m_lock);
+      m_listeners.push_back(entry);
+      return {this, entry.get()};
+    }
+
+    void operator-=(internal::signal_node_base* rhs) override {
+      std::lock_guard<std::mutex> lk(m_lock);
+      for (size_t i = 0; i < m_listeners.size(); i++)
+        if (m_listeners[i].get() == rhs) {
+          m_listeners[i] = m_listeners.back();
+          m_listeners.pop_back();
+          return;
+        }
+      throw std::runtime_error("Attempted to remove node which is not part of this list.");
+    }
+
+    using signal_base::operator-=;
+
+    /// <summary>
+    /// Unregisters the specified registration object and clears its status
+    /// </summary>
+    /// <remarks>
+    /// This method does not guarantee that the named registration object will not be called after
+    /// this method returns in multithreaded cases.  The handler is only guaranteed not to be called
+    /// if `rhs.unique()` is true.
+    /// </remarks>
+    void operator-=(entry_t rhs) {
+      *this -= rhs.get();
+    }
 
     /// <summary>
     /// Raises the signal and invokes all attached handlers
     /// </summary>
     void operator()(Args... args) const {
-      auto cur = m_relay->GetHead();
-      while(cur) {
-        //Grab the next pointer before we evaluate incase the current node is deleted by it's
-        //function.
-        auto next = static_cast<decltype(cur)>(cur->pFlink);
-        cur->fn(args...);
-        cur = next;
-      }
+      // Take a copy of the callee set:
+      for (auto& callee : ((std::lock_guard<std::mutex>)m_lock, m_listeners))
+        (*callee)(args...);
     }
   };
 }

--- a/src/autowiring/AutoConfigBase.cpp
+++ b/src/autowiring/AutoConfigBase.cpp
@@ -8,9 +8,7 @@
 AutoConfigVarBase::AutoConfigVarBase(const std::type_info& ti, bool configured) :
   ContextMember(),
   m_key(autowiring::ExtractKey(ti)),
-  onChangedSignal(),
-  m_isConfigured(configured),
-  m_parentRegistration(nullptr)
+  m_isConfigured(configured)
 {
   m_name = m_key.c_str();
 }

--- a/src/autowiring/AutoConfigListing.cpp
+++ b/src/autowiring/AutoConfigListing.cpp
@@ -93,7 +93,7 @@ void AutoConfigListing::AddOnChanged(const std::string& key, std::function<void(
   (*config).onChangedSignal += std::move(fx);
 }
 
-AutoConfigListing::onAddSignal_t::registration_t* AutoConfigListing::AddCallback(onAddSignal_t::function_t&& fx) {
+autowiring::registration_t AutoConfigListing::AddCallback(std::function<void(const AutoConfigVarBase&)>&& fx) {
   std::lock_guard<std::mutex> lk(m_lock);
 
   for (auto& key : m_orderedKeys) {

--- a/src/autowiring/auto_signal.cpp
+++ b/src/autowiring/auto_signal.cpp
@@ -7,29 +7,6 @@
 using namespace autowiring;
 using namespace autowiring::internal;
 
-signal_registration_base::signal_registration_base(void) {
-
-}
-
-std::shared_ptr<signal_relay> signal_relay_registration_table::GetSignalRelay(const std::type_info& ti, size_t offset)
-{
-  std::lock_guard<std::mutex> lk(lock);
-  auto& retVal = table[registration(&ti, offset)];
-  if (!retVal)
-    retVal = std::make_shared<signal_relay>();
-  return retVal;
-}
-
-std::shared_ptr<signal_relay> autowiring::internal::ObtainRelay(void* pMember)
-{
-  auto location = SlotInformationStackLocation::CurrentStackLocation();
-  if (!location || !location->Encloses(pMember))
-    // Signal is being constructed outside of an autowired member, we need to create a default relay
-    return std::make_shared<signal_relay>();
-
-  // Signal is being constructed as a member, the registration table should know where the relay is
-  return AutoRequired<signal_relay_registration_table>()->GetSignalRelay(
-    location->stump.ti,
-    location->Offset(pMember)
-  );
+void signal_base::operator-=(const registration_t& reg) {
+  *this -= reg.entry;
 }

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -68,7 +68,7 @@ TEST_F(AutoConfigTest, VerifyBasicSignals) {
 
   int handler_direct_called = 0;
   int handler_direct_value = 0;
-  auto* registration = *cfg2 += [&](const int& var) {
+  auto registration = *cfg2 += [&](const int& var) {
     ++handler_direct_called;
     handler_direct_value = var;
   };

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -4,7 +4,13 @@
 
 class AutoConfigTest:
   public testing::Test
-{};
+{
+public:
+  void TearDown() {
+    // Always drop the global context when tests are done
+    GlobalCoreContext::Release();
+  }
+};
 
 struct Namespace1 {};
 struct Namespace2 {};
@@ -53,17 +59,17 @@ TEST_F(AutoConfigTest, VerifyBasicSignals) {
   };
 
   AutoConfig<int, Namespace1, XYZ> cfg1(1);
-  ASSERT_EQ(handler_called, 1) << "OnChanged not triggered by construction";
-  ASSERT_EQ(handler_value_read, 1) << "Bad value read in OnChanged";
+  ASSERT_EQ(handler_called, 0) << "OnChanged triggered by construction";
+  ASSERT_EQ(handler_value_read, 0) << "Bad value read in OnChanged";
 
   *cfg1 = 20;
-  ASSERT_EQ(handler_called, 2) << "OnChanged not triggered by assignement";
+  ASSERT_EQ(handler_called, 1) << "OnChanged not triggered by assignement";
   ASSERT_EQ(handler_value_read, 20) << "Bad value read in OnChanged";
 
   AutoConfig<int, Namespace1, XYZ> cfg2;
   *cfg2 = 2;
 
-  ASSERT_EQ(handler_called, 3) << "OnChanged not triggred by assignement from alternate autowired instance";
+  ASSERT_EQ(handler_called, 2) << "OnChanged not triggred by assignement from alternate autowired instance";
   ASSERT_EQ(handler_value_read, 2) << "Bad value read in OnChanged";
 
   int handler_direct_called = 0;

--- a/src/autowiring/test/AutoSignalTest.cpp
+++ b/src/autowiring/test/AutoSignalTest.cpp
@@ -41,6 +41,7 @@ TEST_F(AutoSignalTest, SimpleSignalTest) {
 
 TEST_F(AutoSignalTest, SignalWithAutowiring) {
   bool handler_called = false;
+  bool handler2_called = false;
   int val = 202;
 
   {
@@ -55,11 +56,16 @@ TEST_F(AutoSignalTest, SignalWithAutowiring) {
     // Inject type type after the signal has been registered
     AutoRequired<RaisesASignal>();
 
+    ras(&RaisesASignal::signal) += [&](int v) {
+      handler2_called = true;
+    };
+
     // Now raise the signal, see what happens:
     ras->signal(55);
 
     // Verify that the handler got called with the correct value:
     ASSERT_TRUE(handler_called) << "Signal handler was not invoked";
+    ASSERT_TRUE(handler2_called) << "Second Signal handler was not invoked";
     ASSERT_EQ(55, val) << "Signal handler not called with the correct parameter as expected";
   }
 

--- a/src/autowiring/test/AutoSignalTest.cpp
+++ b/src/autowiring/test/AutoSignalTest.cpp
@@ -80,7 +80,6 @@ struct RaisesASignalDerived : public RaisesASignal {
 
 };
 
-
 TEST_F(AutoSignalTest, SignalWithAutowiringDerived) {
   bool handler_called = false;
   bool wired = false;

--- a/src/autowiring/test/AutoSignalTest.cpp
+++ b/src/autowiring/test/AutoSignalTest.cpp
@@ -249,12 +249,13 @@ TEST_F(AutoSignalTest, CallOrdering) {
   bool handler_called1 = false;
   bool handler_called2 = false;
 
-  //handlers are inserted at the begining, so this will be called last.
+  //handlers are inserted at the end, so this will be called first.
+  signal1 += [&] { handler_called1 = true; };
+
   signal1 += [&] {
-    ASSERT_TRUE(handler_called2);
-    handler_called1 = true;
+    ASSERT_TRUE(handler_called1) << "Handler1 was not called before handler2";
+    handler_called2 = true;
   };
-  signal1 += [&] { handler_called2 = true; };
 
   signal1();
 


### PR DESCRIPTION
By removing the Signal Relay structure and using more established facilities, the signal code becomes vastly simpler and we get proper support for autowiring signals from base classes.