### PR TITLE
make_unique does not need to be defined in MSVC

### DIFF
--- a/autowiring/C++11/memory.h
+++ b/autowiring/C++11/memory.h
@@ -2,4 +2,8 @@
 #pragma once
 
 #include <memory>
-#include "make_unique.h"
+
+// MSVC already implements make_unique
+#ifndef _MSC_VER
+  #include "make_unique.h"
+#endif


### PR DESCRIPTION
This function is already present in MSVC, prevent the inclusion of this header on that platform.