### PR TITLE
Fix bug in AreAnyDispatchersReady

### DIFF
--- a/autowiring/DispatchQueue.h
+++ b/autowiring/DispatchQueue.h
@@ -102,7 +102,7 @@ public:
   /// <returns>
   /// True if there are curerntly any dispatchers ready for execution--IE, DispatchEvent would return true
   /// </returns>
-  bool AreAnyDispatchersReady(void) const { return !!m_count; }
+  bool AreAnyDispatchersReady(void) const { return !!m_pHead; }
 
   /// <returns>
   /// The total number of all ready and delayed events


### PR DESCRIPTION
This method could spuriously return true.  The count is not a correct way to determine whether dispatchers are ready in a concurrent environment because it includes dispatchers that are presently running; only when the head of the linked list is empty should this method return false.