### PR TITLE
Deprecate CoreThread::Ready

### DIFF
--- a/autowiring/BasicThread.h
+++ b/autowiring/BasicThread.h
@@ -138,8 +138,6 @@ protected:
   /// <param name="pusher">The last reference to the enclosing context held by this thread</param>
   virtual void DoRunLoopCleanup(std::shared_ptr<CoreContext>&& ctxt, std::shared_ptr<CoreObject>&& refTracker);
 
-  void DEPRECATED(Ready(void) const, "Do not call this method, the concept of thread readiness is now deprecated") {}
-
   /// \internal Only implemented on Windows (as of 0.4.1).
   /// <summary>
   /// Boosts thread priority while an instance of this type exists.

--- a/autowiring/CoreThread.h
+++ b/autowiring/CoreThread.h
@@ -37,8 +37,6 @@ public:
   virtual ~CoreThread(void);
 
 protected:
-  void DEPRECATED(Ready(void) const, "Do not call this method, the concept of thread readiness is now deprecated") {}
-
   /// <summary>
   /// Overridden here so we can rundown the dispatch queue
   /// </summary>


### PR DESCRIPTION
This method has been deprecated since v0.1.0, time to get rid of it.