### PR TITLE
Eliminate `operator bool` in auto_in

### DIFF
--- a/autowiring/auto_in.h
+++ b/autowiring/auto_in.h
@@ -24,10 +24,6 @@ private:
   const T& m_value;
 
 public:
-  DEPRECATED(operator bool(void) const, "This test is unnecessary, auto_in will always be satisfied") {
-    return true;
-  }
-
   operator const T&() const { return m_value; }
   const T& operator*(void) const { return m_value; }
   const T* operator->(void) const { return &m_value; }


### PR DESCRIPTION
This method trivially returns `false` due to changes in `auto_in`.  Deprecated since v0.3.0.  About time we got rid of it.