### PR TITLE
Eliminate BasicThread::m_completed

### DIFF
--- a/autowiring/BasicThread.h
+++ b/autowiring/BasicThread.h
@@ -85,9 +85,6 @@ protected:
   // Run condition:
   bool m_running = false;
 
-  // Legacy field, some clients still refer to this
-  bool& DEPRECATED_MEMBER(m_completed, "Use IsCompleted instead");
-
   // The current thread priority
   ThreadPriority m_priority = ThreadPriority::Default;
 

--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -10,8 +10,7 @@
 
 BasicThread::BasicThread(const char* pName):
   ContextMember(pName),
-  m_state(std::make_shared<BasicThreadStateBlock>()),
-  m_completed(m_state->m_completed)
+  m_state(std::make_shared<BasicThreadStateBlock>())
 {}
 
 BasicThread::~BasicThread(void) {


### PR DESCRIPTION
Superceded by `BasicThread::IsCompleted`  Deprecated since v0.4.4, time to eliminate it.