### PR TITLE
Deprecate CoreContext::Construct

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -759,9 +759,6 @@ public:
     // Simple coercive transfer:
     return static_cast<JunctionBox<T>&>(All(typeid(T)));
   }
-  
-  template<typename T, typename... Args>
-  std::shared_ptr<T> DEPRECATED(Construct(Args&&... args), "'Construct' is deprecated, use 'Inject' instead");
 
   /// \internal
   /// <summary>
@@ -1224,12 +1221,6 @@ namespace autowiring {
   void InjectCurrent(void){
     CoreContext::InjectCurrent<T>();
   }
-}
-
-// Deprecated, use Inject
-template<typename T, typename... Args>
-std::shared_ptr<T> CoreContext::Construct(Args&&... args) {
-  return Inject<T>(std::forward<Args>(args)...);
 }
 
 /// <summary>


### PR DESCRIPTION
Superceded by `CoreContext::Inject`.  Deprecated since v0.2.3, no known uses in downstream clients.