### PR TITLE
Deprecate InitiateCoreThreads

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -884,7 +884,6 @@ public:
   /// Starts all registered threads and enables events and the flow of filter graph packets.
   /// </summary>
   void Initiate(void);
-  void DEPRECATED(InitiateCoreThreads(void), "InitiateCoreThreads is deprecated, use Initiate instead");
 
   /// <summary>
   /// Begins shutdown of this context, optionally waiting for child contexts and threads to also shut

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -467,10 +467,6 @@ void CoreContext::Initiate(void) {
   TryTransitionChildrenState();
 }
 
-void CoreContext::InitiateCoreThreads(void) {
-  Initiate();
-}
-
 void CoreContext::SignalShutdown(bool wait, ShutdownMode shutdownMode) {
   // As we signal shutdown, there may be a CoreRunnable that is in the "running" state.  If so,
   // then we will skip that thread as we signal the list of threads to shutdown.


### PR DESCRIPTION
Superceded by `CoreContext::Initiate`.  Deprecated since v0.1.0