### PR TITLE
Reduce test failure output clutter

### DIFF
--- a/src/autowiring/test/AnySharedPointerTest.cpp
+++ b/src/autowiring/test/AnySharedPointerTest.cpp
@@ -92,7 +92,7 @@ TEST_F(AnySharedPointerTest, SlotReassignment) {
 
   // Recast to another shared pointer, verify reference count goes down:
   slot = sharedPointerB;
-  EXPECT_EQ(2, sharedPointerB.use_count()) << "Reference count was not incremented properly during a shared pointer hold";
+  ASSERT_EQ(2, sharedPointerB.use_count()) << "Reference count was not incremented properly during a shared pointer hold";
   ASSERT_TRUE(sharedPointerA.unique()) << "Destructor was not properly invoked for a shared pointer slot";
 
   // Now change the type completely, verify proper release:
@@ -128,7 +128,7 @@ TEST_F(AnySharedPointerTest, SlotDuplication) {
     ASSERT_FALSE(slot1->empty()) << "A slot initialized from a shared pointer was incorrectly marked as empty";
 
     // Verify the type came across:
-    EXPECT_EQ(typeid(auto_id<bool>), slot1->type()) << "Dynamic initialization did not correctly adjust the dynamic type";
+    ASSERT_EQ(typeid(auto_id<bool>), slot1->type()) << "Dynamic initialization did not correctly adjust the dynamic type";
 
     // Now copy it over:
     slot2 = slot1;

--- a/src/autowiring/test/AutoConfigListingTest.cpp
+++ b/src/autowiring/test/AutoConfigListingTest.cpp
@@ -187,8 +187,8 @@ TEST_F(AutoConfigListingTest, NestedContexts) {
   ASSERT_EQ(42, *mcc_sibling->cfg) << "Config value not set in descendant context";
   ASSERT_EQ(42, *mcc_inner->cfg) << "Config value not set in descendant context";
   ASSERT_EQ(42, *mcc_leaf->cfg) << "Config value not set in desendant context";
-  EXPECT_TRUE(acm_middle->IsInherited("Namespace1.XYZ")) << "Inherited key not marked as such";
-  EXPECT_TRUE(acm_leaf->IsInherited("Namespace1.XYZ")) << "Inherited key not marked as such";
+  ASSERT_TRUE(acm_middle->IsInherited("Namespace1.XYZ")) << "Inherited key not marked as such";
+  ASSERT_TRUE(acm_leaf->IsInherited("Namespace1.XYZ")) << "Inherited key not marked as such";
   
   // Set middle, inner shouldn't be able to be set from outer after this
   bool callback_hit1 = false;

--- a/src/autowiring/test/AutoConfigParserTest.cpp
+++ b/src/autowiring/test/AutoConfigParserTest.cpp
@@ -62,6 +62,6 @@ struct MyConfigurableClass {
 TEST_F(AutoConfigParserTest, VerifyCorrectDeconstruction) {
   AutoRequired<MyConfigurableClass> mcc;
 
-  EXPECT_STREQ("Namespace1.XYZ", mcc->m_myName->m_key.c_str())
+  ASSERT_STREQ("Namespace1.XYZ", mcc->m_myName->m_key.c_str())
     << "Configuration variable name was not correctly extracted";
 }

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -176,8 +176,8 @@ TEST_F(AutoConfigTest, NestedContexts) {
   ASSERT_EQ(42, *mcc_sibling->cfg) << "Config value not set in descendant context";
   ASSERT_EQ(42, *mcc_inner->cfg) << "Config value not set in descendant context";
   ASSERT_EQ(42, *mcc_leaf->cfg) << "Config value not set in desendant context";
-  EXPECT_TRUE(mcc_middle->cfg->IsInherited()) << "Inherited key not marked as such";
-  EXPECT_TRUE(mcc_leaf->cfg->IsInherited()) << "Inherited key not marked as such";
+  ASSERT_TRUE(mcc_middle->cfg->IsInherited()) << "Inherited key not marked as such";
+  ASSERT_TRUE(mcc_leaf->cfg->IsInherited()) << "Inherited key not marked as such";
   
   // Set middle, inner shouldn't be able to be set from outer after this
   bool callback_hit1 = false;

--- a/src/autowiring/test/AutoFilterSequencing.cpp
+++ b/src/autowiring/test/AutoFilterSequencing.cpp
@@ -145,7 +145,7 @@ public:
   void AutoFilter(int current, auto_prev<int> prev) {
     ++m_called;
     if (prev) {
-      EXPECT_EQ(m_prev_value, *prev) << "auto_prev isn't set to the previous value";
+      ASSERT_EQ(m_prev_value, *prev) << "auto_prev isn't set to the previous value";
     } else {
       m_num_empty_prev++;
     }
@@ -279,7 +279,7 @@ public:
   void AutoFilter(int current, auto_prev<int, 2> prev) {
     ++m_called;
     if (prev) {
-      EXPECT_EQ(m_prev_prev_value, *prev) << "auto_prev isn't set to the previous value";
+      ASSERT_EQ(m_prev_prev_value, *prev) << "auto_prev isn't set to the previous value";
     } else {
       m_num_empty_prev++;
     }

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -54,13 +54,13 @@ TEST_F(AutoFilterTest, VerifySimpleFilter) {
   packet->Decorate(Decoration<0>());
 
   // Verify that no hit takes place with inadequate decoration:
-  EXPECT_FALSE(filterA->m_called) << "Filter called prematurely with insufficient decoration";
+  ASSERT_FALSE(filterA->m_called) << "Filter called prematurely with insufficient decoration";
 
   // Now decorate with the other requirement of the filter:
   packet->Decorate(Decoration<1>());
 
   // A hit should have taken place at this point:
-  EXPECT_LT(0, filterA->m_called) << "Filter was not called even though it was fully satisfied";
+  ASSERT_LT(0, filterA->m_called) << "Filter was not called even though it was fully satisfied";
 }
 
 template<int N>
@@ -76,7 +76,7 @@ TEST_F(AutoFilterTest, VerifyTypeUsage) {
   ASSERT_EQ(0, filterA->m_called) << "AutoFilter called with incomplete arguments";
   packet->Decorate(ChildDecoration<1>()); // Does not fulfill second requirement
   ASSERT_EQ(0, filterA->m_called) << "AutoFilter using derived type";
-  EXPECT_NO_THROW(packet->Decorate(Decoration<1>(2))) << "Decoration with parent type conflicts with derived type";
+  ASSERT_NO_THROW(packet->Decorate(Decoration<1>(2))) << "Decoration with parent type conflicts with derived type";
   ASSERT_EQ(1, filterA->m_called) << "AutoFilter was not called when all arguments were available";
   ASSERT_EQ(2, filterA->m_one.i) << "AutoFilter was called using derived type instead of parent";
 }
@@ -123,22 +123,22 @@ TEST_F(AutoFilterTest, VerifyNoMultiDecorate) {
   // Obtain a packet and attempt redundant introduction:
   auto packet = factory->NewPacket();
   packet->Decorate(Decoration<0>());
-  EXPECT_ANY_THROW(packet->Decorate(Decoration<0>())) << "Redundant decoration did not throw an exception as expected";
+  ASSERT_ANY_THROW(packet->Decorate(Decoration<0>())) << "Redundant decoration did not throw an exception as expected";
 
   // Verify that a call has not yet been made
-  EXPECT_FALSE(filterA->m_called) << "A call made on an idempotent packet decoration";
+  ASSERT_FALSE(filterA->m_called) << "A call made on an idempotent packet decoration";
 
   // Now finish saturating the filter and ensure we get a call:
   packet->Decorate(Decoration<1>());
-  EXPECT_LT(0, filterA->m_called) << "Filter was not called after being fully satisfied";
+  ASSERT_LT(0, filterA->m_called) << "Filter was not called after being fully satisfied";
 
   //NOTE: A typedef will throw an exception
   typedef Decoration<0> isDeco0type;
-  EXPECT_ANY_THROW(packet->Decorate(isDeco0type())) << "Typedef failed to throw exception";
+  ASSERT_ANY_THROW(packet->Decorate(isDeco0type())) << "Typedef failed to throw exception";
 
   //NOTE: A shared_ptr to an existing type will throw an exception
   auto sharedDeco0 = std::make_shared<Decoration<0>>();
-  EXPECT_ANY_THROW(packet->Decorate(sharedDeco0)) << "Reduction of shared_ptr to base type failed";
+  ASSERT_ANY_THROW(packet->Decorate(sharedDeco0)) << "Reduction of shared_ptr to base type failed";
 
   //NOTE: Inheritance will not throw an exception
   class ofDeco0alias: public Decoration<0> {};
@@ -150,9 +150,8 @@ TEST_F(AutoFilterTest, VerifyNoMultiDecorate) {
 
   // Verify that DecorateImmedaite also yields an exception
   Decoration<0> localDeco0;
-  EXPECT_ANY_THROW(packet->DecorateImmediate(localDeco0)) << "Redundant immediate decoration did not throw an exception as expected";
-
-  EXPECT_ANY_THROW(packet->DecorateImmediate(Decoration<2>(), Decoration<2>())) << "Repeated type in immediate decoration was not identified as an error";
+  ASSERT_ANY_THROW(packet->DecorateImmediate(localDeco0)) << "Redundant immediate decoration did not throw an exception as expected";
+  ASSERT_ANY_THROW(packet->DecorateImmediate(Decoration<2>(), Decoration<2>())) << "Repeated type in immediate decoration was not identified as an error";
 }
 
 TEST_F(AutoFilterTest, VerifyInterThreadDecoration) {
@@ -166,7 +165,7 @@ TEST_F(AutoFilterTest, VerifyInterThreadDecoration) {
   packet->Decorate(Decoration<1>());
 
   // Verify that the recipient has NOT yet received the message:
-  EXPECT_FALSE(filterB->m_called) << "A call was made to a thread which should not have been able to process it";
+  ASSERT_FALSE(filterB->m_called) << "A call was made to a thread which should not have been able to process it";
 
   // Wake up the barrier and post a quit message:
   filterB->Continue();
@@ -174,7 +173,7 @@ TEST_F(AutoFilterTest, VerifyInterThreadDecoration) {
   filterB->Wait();
 
   // Verify that the filter method has been called
-  EXPECT_LT(0, filterB->m_called) << "A deferred filter method was not called as expected";
+  ASSERT_LT(0, filterB->m_called) << "A deferred filter method was not called as expected";
 }
 
 TEST_F(AutoFilterTest, VerifyTeardownArrangement) {
@@ -231,14 +230,14 @@ TEST_F(AutoFilterTest, VerifyAntiDecorate) {
     // Obtain a new packet and mark an unsatisfiable decoration:
     auto packet = factory->NewPacket();
     packet->Unsatisfiable<Decoration<0>>();
-    EXPECT_ANY_THROW(packet->Decorate(Decoration<0>())) << "Decoration succeeded on a decoration marked unsatisfiable";
+    ASSERT_ANY_THROW(packet->Decorate(Decoration<0>())) << "Decoration succeeded on a decoration marked unsatisfiable";
   }
 
   {
     // Obtain a new packet and try to make a satisfied decoration unsatisfiable.
     auto packet = factory->NewPacket();
     packet->Decorate(Decoration<0>());
-    EXPECT_ANY_THROW(packet->Unsatisfiable<Decoration<0>>()) << "Succeeded in marking an already-existing decoration as unsatisfiable";
+    ASSERT_ANY_THROW(packet->Unsatisfiable<Decoration<0>>()) << "Succeeded in marking an already-existing decoration as unsatisfiable";
   }
 }
 
@@ -275,21 +274,21 @@ TEST_F(AutoFilterTest, VerifyReflexiveReciept) {
   auto packet = factory->NewPacket();
 
   // The mere act of obtaining a packet should have triggered filterD to be fired:
-  EXPECT_LT(0, filterD->m_called) << "Trivial filter with AutoPacket argument was not called as expected";
-  EXPECT_NO_THROW(packet->Get<Decoration<2>>()) << "Decoration on creation failed";
+  ASSERT_LT(0, filterD->m_called) << "Trivial filter with AutoPacket argument was not called as expected";
+  ASSERT_NO_THROW(packet->Get<Decoration<2>>()) << "Decoration on creation failed";
 
   // The mere act of obtaining a packet should have triggered filterD to be fired:
-  EXPECT_LT(0, filterE->m_called) << "Trivial filter with no arguments was not called as expected";
+  ASSERT_LT(0, filterE->m_called) << "Trivial filter with no arguments was not called as expected";
 
   // The mere act of obtaining a packet should have triggered filterD to be fired:
-  EXPECT_LT(0, filterD->m_called) << "Trivial filter was not called as expected";
+  ASSERT_LT(0, filterD->m_called) << "Trivial filter was not called as expected";
 
   // Decorate--should satisfy filterC
   packet->Decorate(Decoration<0>());
-  EXPECT_LT(0, filterC->m_called) << "FilterC should have been satisfied with one decoration";
+  ASSERT_LT(0, filterC->m_called) << "FilterC should have been satisfied with one decoration";
 
   // FilterC should have also satisfied filterA:
-  EXPECT_LT(0, filterA->m_called) << "FilterA should have been satisfied by FilterC";
+  ASSERT_LT(0, filterA->m_called) << "FilterA should have been satisfied by FilterC";
 }
 
 TEST_F(AutoFilterTest, VerifyReferenceBasedInput) {
@@ -566,7 +565,7 @@ TEST_F(AutoFilterTest, PostHocSatisfactionAttempt) {
 
   packet1->DecorateImmediate(Decoration<2>());
 
-  EXPECT_LT(0, fg2->m_called) << "An AutoFilter was not called when all of its inputs were simultaneously available";
+  ASSERT_LT(0, fg2->m_called) << "An AutoFilter was not called when all of its inputs were simultaneously available";
 }
 
 TEST_F(AutoFilterTest, AutoOutTest) {

--- a/src/autowiring/test/AutoParameterTest.cpp
+++ b/src/autowiring/test/AutoParameterTest.cpp
@@ -25,7 +25,7 @@ TEST_F(AutoParameterTest, VerifyCorrectDeconstruction) {
   AutoRequired<MyParamClass1> mpc;
   auto& param = mpc->m_param;
   
-  EXPECT_STREQ("AutoParam.MyParamClass1::MyIntParam1", param.m_key.c_str())
+  ASSERT_STREQ("AutoParam.MyParamClass1::MyIntParam1", param.m_key.c_str())
     << "Configuration variable name was not correctly extracted";
 }
 

--- a/src/autowiring/test/AutowiringTest.cpp
+++ b/src/autowiring/test/AutowiringTest.cpp
@@ -168,14 +168,14 @@ TEST_F(AutowiringTest, StaticNewWithArgs) {
     AutoCreateContext ctxt;
     ASSERT_NO_THROW(ctxt->Inject<StaticNewInt>()) << "Exception throws while injecting member";
     AutowiredFast<StaticNewInt> obj(ctxt);
-    EXPECT_EQ(42, obj->getValue()) << "Wrong constructor called";
+    ASSERT_EQ(42, obj->getValue()) << "Wrong constructor called";
     ctxt->SignalShutdown(true);
   }
   {
     AutoCreateContext ctxt;
     ASSERT_NO_THROW(auto obj = ctxt->Inject<StaticNewInt>(std::unique_ptr<int>(new int(1337)))) << "Exception throws while injecting member";
     AutowiredFast<StaticNewInt> obj(ctxt);
-    EXPECT_EQ(1337, obj->getValue()) << "Wrong constructor called";
+    ASSERT_EQ(1337, obj->getValue()) << "Wrong constructor called";
     ctxt->SignalShutdown(true);
   }
 }

--- a/src/autowiring/test/AutowiringUtilitiesTest.cpp
+++ b/src/autowiring/test/AutowiringUtilitiesTest.cpp
@@ -18,7 +18,7 @@ class Thread1:
   virtual void Run(){
     s_thread_specific_int.reset(new int(4));
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    EXPECT_EQ(4, *s_thread_specific_int);
+    ASSERT_EQ(4, *s_thread_specific_int);
   }
 };
 
@@ -28,7 +28,7 @@ class Thread2:
   virtual void Run() {
     s_thread_specific_int.reset(new int(3));
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    EXPECT_EQ(3, *s_thread_specific_int);
+    ASSERT_EQ(3, *s_thread_specific_int);
   }
 };
 
@@ -46,6 +46,6 @@ TEST_F(AutowiringUtilitiesTest, ThreadSpecificPtr) {
   
   std::this_thread::sleep_for(std::chrono::milliseconds(50));
   
-  EXPECT_EQ(5, *s_thread_specific_int);
+  ASSERT_EQ(5, *s_thread_specific_int);
   AutoCurrentContext()->SignalShutdown(true);
 }

--- a/src/autowiring/test/BoltTest.cpp
+++ b/src/autowiring/test/BoltTest.cpp
@@ -91,7 +91,7 @@ TEST_F(BoltTest, VerifySimpleInjection) {
   // Verify that the SimpleObject didn't accidentally get injected out here:
   {
     Autowired<SimpleObject> so;
-    EXPECT_FALSE(so.IsAutowired()) << "Object was injected into an outer scope by a bolt";
+    ASSERT_FALSE(so.IsAutowired()) << "Object was injected into an outer scope by a bolt";
   }
 
   // Verify that the objecT DID get autowired where we expected it to be autowired
@@ -116,10 +116,10 @@ TEST_F(BoltTest, VerifyMapping) {
   std::shared_ptr<CoreContext> createdContext = simpleCreator.CreateContext(L"Simple2").first;
 
   // Verify we have a hit our bolt:
-  EXPECT_TRUE(myListener->hit) << "The listener callback was not hit as expected";
+  ASSERT_TRUE(myListener->hit) << "The listener callback was not hit as expected";
 
   // Verify that the correct context was created:
-  EXPECT_EQ(createdContext, myListener->createdContext) << "The context set to current for the listener callback was not the context that got created";
+  ASSERT_EQ(createdContext, myListener->createdContext) << "The context set to current for the listener callback was not the context that got created";
 }
 
 TEST_F(BoltTest, VerifyCreationBubbling) {
@@ -143,7 +143,7 @@ TEST_F(BoltTest, VerifyCreationBubbling) {
   simpleCreator->CreateContext(L"Simple");
 
   // Check the listener to verify we had a hit:
-  EXPECT_TRUE(listener->hit) << "The listener callback was not hit as expected";
+  ASSERT_TRUE(listener->hit) << "The listener callback was not hit as expected";
 }
 
 TEST_F(BoltTest, VerifyMultipleInjection) {
@@ -156,7 +156,7 @@ TEST_F(BoltTest, VerifyMultipleInjection) {
   // Verify that the SimpleObject didn't accidentally get injected out here:
   {
     Autowired<SimpleObject> so;
-    EXPECT_FALSE(so.IsAutowired()) << "Object was injected into an outer scope by a bolt";
+    ASSERT_FALSE(so.IsAutowired()) << "Object was injected into an outer scope by a bolt";
   }
 
   // Verify that the objecT DID get autowired where we expected it to be autowired
@@ -176,7 +176,7 @@ TEST_F(BoltTest, EmptyBolt) {
   AutoCurrentContext ctxt;
   AutoEnable<InjectsIntoEverything>();
   Autowired<CountObject> so;
-  EXPECT_FALSE(so.IsAutowired()) << "CountObject injected into outer context";
+  ASSERT_FALSE(so.IsAutowired()) << "CountObject injected into outer context";
 
   AutoCreateContext created;
   {

--- a/src/autowiring/test/ContextCleanupTest.cpp
+++ b/src/autowiring/test/ContextCleanupTest.cpp
@@ -14,7 +14,7 @@ TEST_F(ContextCleanupTest, ValidateTeardownOrder) {
   class WeakPtrChecker {
   public:
     ~WeakPtrChecker(void) {
-      EXPECT_TRUE(self.expired()) << "Shared pointer to this was not expired at destructor time";
+      ASSERT_TRUE(self.expired()) << "Shared pointer to this was not expired at destructor time";
     }
 
     std::weak_ptr<WeakPtrChecker> self;
@@ -63,12 +63,12 @@ TEST_F(ContextCleanupTest, VerifyContextDtor) {
     contextVerifier = subContext;
 
     // Verify the use count is what we expect at this point, should be just the pointer itself:
-    EXPECT_EQ(1, contextVerifier.use_count()) << "Unexpected reference count on CoreContext";
+    ASSERT_EQ(1, contextVerifier.use_count()) << "Unexpected reference count on CoreContext";
 
     {
       // Now make the context current, and check the new count
       CurrentContextPusher pshr(subContext);
-      EXPECT_EQ(2, contextVerifier.use_count()) << "Context currency assignment altered use count unexpectedly";
+      ASSERT_EQ(2, contextVerifier.use_count()) << "Context currency assignment altered use count unexpectedly";
 
       // Generate a new simple object:
       AutoRequired<SimpleObject> simple;
@@ -77,28 +77,28 @@ TEST_F(ContextCleanupTest, VerifyContextDtor) {
       // Each CoreObjectDescriptor instance holds 2 strong references to SimpleObject, as CoreObject type and as ContextMember type.
       // One instance is held in CoreContext::m_concreteTypes and the other in the CoreContext::m_typeMemos.
       // Finally, once more reference is held by the shared_ptr<SimpleObject> inheritance of simple.
-      EXPECT_EQ(5, objVerifier.use_count()) << "Unexpected number of references to a newly constructed object";
+      ASSERT_EQ(5, objVerifier.use_count()) << "Unexpected number of references to a newly constructed object";
 
       // Reference count should be unchanged:
-      EXPECT_EQ(2, contextVerifier.use_count()) << "Reference count changed unexpectedly after addition of an object";
+      ASSERT_EQ(2, contextVerifier.use_count()) << "Reference count changed unexpectedly after addition of an object";
 
       // Eliminate the thread reference to this context:
       auto ref = subContext;
-      EXPECT_EQ(3, ref.use_count()) << "Pointer copy didn't increment the context reference count as expected";
+      ASSERT_EQ(3, ref.use_count()) << "Pointer copy didn't increment the context reference count as expected";
       subContextWeak = subContext;
     }
 
     // Pop should decrement the reference count by two:  Once for the actual Autowired instance, and
     // again for the Autowired smart pointer itself.  This context will then be the only remaining
     // reference, and when it goes out of scope, the context will go away.
-    EXPECT_EQ(1, subContextWeak.use_count()) << "Pop didn't decrement the context reference count as expected";
+    ASSERT_EQ(1, subContextWeak.use_count()) << "Pop didn't decrement the context reference count as expected";
   }
 
   // The weak pointer to the context should be invalid by now:
-  EXPECT_TRUE(contextVerifier.expired()) << "CoreContext still had " << contextVerifier.use_count() << " reference(s)";
+  ASSERT_TRUE(contextVerifier.expired()) << "CoreContext still had " << contextVerifier.use_count() << " reference(s)";
 
   // The object should be gone, but will still be around if the context still exists:
-  EXPECT_TRUE(objVerifier.expired()) << "SimpleObject still had " << objVerifier.use_count() << " reference(s)";
+  ASSERT_TRUE(objVerifier.expired()) << "SimpleObject still had " << objVerifier.use_count() << " reference(s)";
 }
 
 TEST_F(ContextCleanupTest, VerifyThreadCleanup) {
@@ -113,7 +113,7 @@ TEST_F(ContextCleanupTest, VerifyThreadCleanup) {
   context->Initiate();
 
   // No exit initially:
-  EXPECT_FALSE(context->Wait(std::chrono::milliseconds(10))) << "Core context completed prematurely";
+  ASSERT_FALSE(context->Wait(std::chrono::milliseconds(10))) << "Core context completed prematurely";
 
   Autowired<SimpleThreaded> simple;
   ASSERT_TRUE(simple) << "Couldn't autowire the SimpleThreaded object";
@@ -122,7 +122,7 @@ TEST_F(ContextCleanupTest, VerifyThreadCleanup) {
   context->SignalShutdown();
 
   // Now we verify that exiting happens promptly:
-  EXPECT_TRUE(context->Wait(std::chrono::milliseconds(100))) << "Context did not exit in a timely fashion";
+  ASSERT_TRUE(context->Wait(std::chrono::milliseconds(100))) << "Context did not exit in a timely fashion";
 }
 
 class ReceivesTeardownNotice:
@@ -235,6 +235,6 @@ TEST_F(ContextCleanupTest, VerifyThreadShutdownInterleave) {
   ctxt->SignalShutdown(true);
 
   // At this point, the thread must have returned AND released its shared pointer to the enclosing context
-  EXPECT_EQ(initCount, ctxt.use_count()) << "Context thread persisted even after it should have fallen out of scope";
+  ASSERT_EQ(initCount, ctxt.use_count()) << "Context thread persisted even after it should have fallen out of scope";
 }
 

--- a/src/autowiring/test/ContextCleanupTest.cpp
+++ b/src/autowiring/test/ContextCleanupTest.cpp
@@ -14,7 +14,7 @@ TEST_F(ContextCleanupTest, ValidateTeardownOrder) {
   class WeakPtrChecker {
   public:
     ~WeakPtrChecker(void) {
-      ASSERT_TRUE(self.expired()) << "Shared pointer to this was not expired at destructor time";
+      EXPECT_TRUE(self.expired()) << "Shared pointer to this was not expired at destructor time";
     }
 
     std::weak_ptr<WeakPtrChecker> self;

--- a/src/autowiring/test/ContextCreatorTest.cpp
+++ b/src/autowiring/test/ContextCreatorTest.cpp
@@ -87,7 +87,7 @@ TEST_F(ContextCreatorTest, ValidateSimpleEviction) {
   ASSERT_TRUE(ctxtWeak.expired()) << "Expected the context to be destroyed";
 
   // Verify that our creator is now empty:
-  EXPECT_EQ(0UL, creator->GetSize()) << "Context creator is non-empty after all created contexts were destroyed";
+  ASSERT_EQ(0UL, creator->GetSize()) << "Context creator is non-empty after all created contexts were destroyed";
 }
 
 TEST_F(ContextCreatorTest, ValidateMultipleEviction) {
@@ -144,7 +144,7 @@ TEST_F(ContextCreatorTest, ValidateMultipleEviction) {
   ASSERT_TRUE(wait_status) << "All teardown listeners didn't trigger, counter still at " << counter;
 
   // Validate that everything expires:
-  EXPECT_EQ(static_cast<size_t>(0), creator->GetSize()) << "Not all contexts were evicted as expected";
+  ASSERT_EQ(static_cast<size_t>(0), creator->GetSize()) << "Not all contexts were evicted as expected";
 }
 
 TEST_F(ContextCreatorTest, ClearAndTeardown) {
@@ -177,7 +177,7 @@ TEST_F(ContextCreatorTest, ClearAndTeardown) {
   ASSERT_TRUE(ctxtWeak.expired()) << "Expected the context to be destroyed";
 
   // Verify that our creator is now empty:
- // EXPECT_EQ(0UL, creator->GetSize()) << "Context creator is non-empty after all created contexts were destroyed";
+ // ASSERT_EQ(0UL, creator->GetSize()) << "Context creator is non-empty after all created contexts were destroyed";
 }
 
 TEST_F(ContextCreatorTest, VoidKeyType) {
@@ -185,20 +185,20 @@ TEST_F(ContextCreatorTest, VoidKeyType) {
 
   {
     std::shared_ptr<CoreContext> ctxt = vc->CreateContext();
-    EXPECT_EQ(1UL, vc->GetSize()) << "Requested that a context be created, but the void creator did not have any members";
+    ASSERT_EQ(1UL, vc->GetSize()) << "Requested that a context be created, but the void creator did not have any members";
 
-    EXPECT_EQ(1UL, vc->GetSize()) << "A created context was apparently destroyed after firing bolts";
-    EXPECT_EQ(0UL, vc->m_totalDestroyed) << "The void creator received a NotifyContextDestroyed call unexpectedly early";
+    ASSERT_EQ(1UL, vc->GetSize()) << "A created context was apparently destroyed after firing bolts";
+    ASSERT_EQ(0UL, vc->m_totalDestroyed) << "The void creator received a NotifyContextDestroyed call unexpectedly early";
 
     vc->Clear(true);
 
     //Make another one to check about collisions
     std::shared_ptr<CoreContext> ctxt2 = vc->CreateContext();
-    EXPECT_EQ(1UL, vc->GetSize()) << "Second void context creation failed!";
+    ASSERT_EQ(1UL, vc->GetSize()) << "Second void context creation failed!";
   }
 
-  EXPECT_EQ(0UL, vc->GetSize()) << "A void context creator was not correctly updated when its dependent context went out of scope";
-  EXPECT_EQ(2UL, vc->m_totalDestroyed) << "The void creator did not receive the expected number of NotifyContextDestroyed calls";
+  ASSERT_EQ(0UL, vc->GetSize()) << "A void context creator was not correctly updated when its dependent context went out of scope";
+  ASSERT_EQ(2UL, vc->m_totalDestroyed) << "The void creator did not receive the expected number of NotifyContextDestroyed calls";
 }
 
 struct mySigil {};

--- a/src/autowiring/test/ContextMapTest.cpp
+++ b/src/autowiring/test/ContextMapTest.cpp
@@ -30,12 +30,12 @@ TEST_F(ContextMapTest, VerifySimple) {
 
     // We should be able to find this context now:
     std::shared_ptr<CoreContext> found = mp.Find("context_simple");
-    EXPECT_TRUE(!!found.get()) << "Failed to find a context that was just inserted into a context map";
+    ASSERT_TRUE(!!found.get()) << "Failed to find a context that was just inserted into a context map";
   }
 
   // We shouldn't be able to find it now that it's gone out of scope:
   std::shared_ptr<CoreContext> notFound = mp.Find("context_simple");
-  EXPECT_FALSE(!!notFound.get()) << "Context was not evicted as expected when it went out of scope";
+  ASSERT_FALSE(!!notFound.get()) << "Context was not evicted as expected when it went out of scope";
 }
 
 TEST_F(ContextMapTest, VerifyWithThreads) {
@@ -69,7 +69,7 @@ TEST_F(ContextMapTest, VerifyWithThreads) {
 
     // Relock the weak context, verify that we get back the same pointer:
     auto relocked = weakContext.lock();
-    EXPECT_EQ(relocked, context) << "Mapped context pointer was not identical to a previously stored context pointer";
+    ASSERT_EQ(relocked, context) << "Mapped context pointer was not identical to a previously stored context pointer";
 
     // Terminate whole context
     context->SignalTerminate();
@@ -81,7 +81,7 @@ TEST_F(ContextMapTest, VerifyWithThreads) {
   {
     // Verify that the context is gone now that everything in it has stopped running
     auto ctxt = mp.Find("context_withthreads");
-    EXPECT_FALSE(ctxt) << "Context was not properly evicted from the map";
+    ASSERT_FALSE(ctxt) << "Context was not properly evicted from the map";
 
     // Just return early if the context was empty as we expected, the next part of this test is for diagnostics
     if(!ctxt)
@@ -95,7 +95,7 @@ TEST_F(ContextMapTest, VerifyWithThreads) {
     // but this one succeeds, it could be due to race conditions in CoreThread
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     ctxt = mp.Find("context_withthreads");
-    EXPECT_FALSE(ctxt) << "Context was not properly evicted even after waiting for a time to ensure eviction";
+    ASSERT_FALSE(ctxt) << "Context was not properly evicted even after waiting for a time to ensure eviction";
   }
 }
 
@@ -176,7 +176,7 @@ TEST_F(ContextMapTest, VerifyWithThreadsPathological) {
 
   // Clear the context collection:
   contexts.clear();
-  EXPECT_EQ(0UL, mp.size()) << "Context map did not empty as expected";
+  ASSERT_EQ(0UL, mp.size()) << "Context map did not empty as expected";
 }
 
 TEST_F(ContextMapTest, AdjacentCleanupTest) {
@@ -231,10 +231,10 @@ TEST_F(ContextMapTest, VerifySimpleEnumeration) {
     }
   );
 
-  EXPECT_EQ(3UL, count) << "Failed to enumerate all expected context pointers";
-  EXPECT_EQ(1UL, found.count("context_se_1")) << "Failed to find map element '1'";
-  EXPECT_EQ(1UL, found.count("context_se_2")) << "Failed to find map element '2'";
-  EXPECT_EQ(1UL, found.count("context_se_3")) << "Failed to find map element '3'";
+  ASSERT_EQ(3UL, count) << "Failed to enumerate all expected context pointers";
+  ASSERT_EQ(1UL, found.count("context_se_1")) << "Failed to find map element '1'";
+  ASSERT_EQ(1UL, found.count("context_se_2")) << "Failed to find map element '2'";
+  ASSERT_EQ(1UL, found.count("context_se_3")) << "Failed to find map element '3'";
 }
 
 TEST_F(ContextMapTest, VerifyRangeBasedEnumeration) {

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -247,9 +247,9 @@ TEST_F(CoreContextTest, InitiateOrder) {
     middleCtxt->Initiate();
     outerCtxt->Initiate();
     
-    EXPECT_TRUE(outerCtxt->IsRunning()) << "Context not running after begin initiated";
-    EXPECT_TRUE(middleCtxt->IsRunning()) << "Context not running after begin initiated";
-    EXPECT_TRUE(innerCtxt->IsRunning()) << "Context not running after begin initiated";
+    ASSERT_TRUE(outerCtxt->IsRunning()) << "Context not running after begin initiated";
+    ASSERT_TRUE(middleCtxt->IsRunning()) << "Context not running after begin initiated";
+    ASSERT_TRUE(innerCtxt->IsRunning()) << "Context not running after begin initiated";
     
     outerCtxt->SignalShutdown(true);
   }
@@ -264,9 +264,9 @@ TEST_F(CoreContextTest, InitiateOrder) {
     middleCtxt->Initiate();
     innerCtxt->Initiate();
     
-    EXPECT_TRUE(outerCtxt->IsRunning()) << "Context not running after begin initiated";
-    EXPECT_TRUE(middleCtxt->IsRunning()) << "Context not running after begin initiated";
-    EXPECT_TRUE(innerCtxt->IsRunning()) << "Context not running after begin initiated";
+    ASSERT_TRUE(outerCtxt->IsRunning()) << "Context not running after begin initiated";
+    ASSERT_TRUE(middleCtxt->IsRunning()) << "Context not running after begin initiated";
+    ASSERT_TRUE(innerCtxt->IsRunning()) << "Context not running after begin initiated";
     
     outerCtxt->SignalShutdown(true);
   }
@@ -281,9 +281,9 @@ TEST_F(CoreContextTest, InitiateOrder) {
     innerCtxt->Initiate();
     outerCtxt->Initiate();
     
-    EXPECT_TRUE(outerCtxt->IsRunning()) << "Context not running after begin initiated";
-    EXPECT_TRUE(middleCtxt->IsRunning()) << "Context not running after begin initiated";
-    EXPECT_TRUE(innerCtxt->IsRunning()) << "Context not running after begin initiated";
+    ASSERT_TRUE(outerCtxt->IsRunning()) << "Context not running after begin initiated";
+    ASSERT_TRUE(middleCtxt->IsRunning()) << "Context not running after begin initiated";
+    ASSERT_TRUE(innerCtxt->IsRunning()) << "Context not running after begin initiated";
     
     outerCtxt->SignalShutdown(true);
   }
@@ -305,9 +305,9 @@ TEST_F(CoreContextTest, InitiateMultipleChildren) {
 
     outerCtxt->Initiate();
 
-    EXPECT_TRUE(child1->IsRunning());
-    EXPECT_TRUE(child2->IsRunning());
-    EXPECT_TRUE(child3->IsRunning());
+    ASSERT_TRUE(child1->IsRunning());
+    ASSERT_TRUE(child2->IsRunning());
+    ASSERT_TRUE(child3->IsRunning());
 
     outerCtxt->SignalShutdown(true);
   }
@@ -324,9 +324,9 @@ TEST_F(CoreContextTest, InitiateMultipleChildren) {
 
     outerCtxt->Initiate();
 
-    EXPECT_TRUE(child1->IsRunning());
-    EXPECT_FALSE(child2->IsInitiated());
-    EXPECT_TRUE(child3->IsRunning());
+    ASSERT_TRUE(child1->IsRunning());
+    ASSERT_FALSE(child2->IsInitiated());
+    ASSERT_TRUE(child3->IsRunning());
 
     outerCtxt->SignalShutdown(true);
   }
@@ -343,9 +343,9 @@ TEST_F(CoreContextTest, InitiateMultipleChildren) {
     child1->Initiate();
     child3->Initiate();
 
-    EXPECT_TRUE(child1->IsRunning());
-    EXPECT_FALSE(child2->IsInitiated());
-    EXPECT_TRUE(child3->IsRunning());
+    ASSERT_TRUE(child1->IsRunning());
+    ASSERT_FALSE(child2->IsInitiated());
+    ASSERT_TRUE(child3->IsRunning());
 
     outerCtxt->SignalShutdown(true);
   }

--- a/src/autowiring/test/CoreJobTest.cpp
+++ b/src/autowiring/test/CoreJobTest.cpp
@@ -82,9 +82,9 @@ TEST_F(CoreJobTest, VerifyTeardown) {
   };
 
   ctxt->SignalShutdown(true);
-  EXPECT_TRUE(check1) << "Lambda 1 didn't finish";
-  EXPECT_TRUE(check2) << "Lambda 2 didn't finish";
-  EXPECT_TRUE(check3) << "Lambda 3 didn't finish";
+  ASSERT_TRUE(check1) << "Lambda 1 didn't finish";
+  ASSERT_TRUE(check2) << "Lambda 2 didn't finish";
+  ASSERT_TRUE(check3) << "Lambda 3 didn't finish";
 }
 
 struct SimpleListen{
@@ -111,7 +111,7 @@ TEST_F(CoreJobTest, VerifyNoEventReceivers){
   ASSERT_FALSE(listener->m_flag) << "Flag was initialized improperly";
 
   fire(&SimpleListen::SetFlag)();
-  EXPECT_FALSE(listener->m_flag) << "Lister recived event event though it wasn't initiated";
+  ASSERT_FALSE(listener->m_flag) << "Lister recived event event though it wasn't initiated";
 }
 
 TEST_F(CoreJobTest, AbandonedDispatchers) {
@@ -150,9 +150,9 @@ TEST_F(CoreJobTest, RecursiveAdd) {
   cj->Wait();
   
   // Verify that all lambdas on the CoreThread got called as expected:
-  EXPECT_TRUE(first) << "Appended lambda didn't set value";
-  EXPECT_TRUE(second) << "Appended lambda didn't set value";
-  EXPECT_TRUE(third) << "Appended lambda didn't set value";
+  ASSERT_TRUE(first) << "Appended lambda didn't set value";
+  ASSERT_TRUE(second) << "Appended lambda didn't set value";
+  ASSERT_TRUE(third) << "Appended lambda didn't set value";
 }
 
 TEST_F(CoreJobTest, RaceCondition) {

--- a/src/autowiring/test/DispatchQueueTest.cpp
+++ b/src/autowiring/test/DispatchQueueTest.cpp
@@ -45,8 +45,8 @@ TEST_F(DispatchQueueTest, SimpleEvents) {
     count += 5 ;
   };
   
-  EXPECT_EQ(2, num);
-  EXPECT_EQ(6, count);
+  ASSERT_EQ(2, num);
+  ASSERT_EQ(6, count);
 }
 
 TEST_F(DispatchQueueTest, PathologicalStartAndStop){

--- a/src/autowiring/test/DtorCorrectnessTest.cpp
+++ b/src/autowiring/test/DtorCorrectnessTest.cpp
@@ -80,8 +80,8 @@ TEST_F(DtorCorrectnessTest, VerifyFiringDtors) {
 
   // Try firing some events and validate the invariant:
   cdl(&CtorDtorListener::DoFired)(CtorDtorCopyCounter());
-  EXPECT_LE(2UL, CtorDtorCopyCounter::s_construction) << "Counter constructors were not invoked the expected number of times when fired";
-  EXPECT_EQ(0, CtorDtorCopyCounter::s_outstanding) << "Counter mismatch under event firing";
+  ASSERT_LE(2UL, CtorDtorCopyCounter::s_construction) << "Counter constructors were not invoked the expected number of times when fired";
+  ASSERT_EQ(0, CtorDtorCopyCounter::s_outstanding) << "Counter mismatch under event firing";
 }
 
 TEST_F(DtorCorrectnessTest, VerifyDeferringDtors) {
@@ -114,14 +114,14 @@ TEST_F(DtorCorrectnessTest, VerifyDeferringDtors) {
   listener2->Wait();
 
   // Verify that we actually hit something:
-  EXPECT_TRUE(listener1->m_hitDeferred) << "Failed to hit listener #1's deferred call";
-  EXPECT_TRUE(listener2->m_hitDeferred) << "Failed to hit listener #2's deferred call";
+  ASSERT_TRUE(listener1->m_hitDeferred) << "Failed to hit listener #1's deferred call";
+  ASSERT_TRUE(listener2->m_hitDeferred) << "Failed to hit listener #2's deferred call";
 
   // Release all of our pointers:
   listener1.reset();
   listener2.reset();
 
   // Verify hit counts:
-  EXPECT_LE(2UL, CtorDtorCopyCounter::s_construction) << "Counter constructors were not invoked the expected number of times when deferred";
-  EXPECT_EQ(0, CtorDtorCopyCounter::s_outstanding) << "Counter mismatch under deferred events";
+  ASSERT_LE(2UL, CtorDtorCopyCounter::s_construction) << "Counter constructors were not invoked the expected number of times when deferred";
+  ASSERT_EQ(0, CtorDtorCopyCounter::s_outstanding) << "Counter mismatch under deferred events";
 }

--- a/src/autowiring/test/EventReceiverTest.cpp
+++ b/src/autowiring/test/EventReceiverTest.cpp
@@ -28,9 +28,9 @@ TEST_F(EventReceiverTest, SimpleMethodCall) {
   sender(&CallableInterface::OneArg)(100);
 
   // Verify that stuff happens even when the thread isn't running:
-  EXPECT_TRUE(receiver->m_zero);
-  EXPECT_TRUE(receiver->m_one);
-  EXPECT_EQ(100, receiver->m_oneArg);
+  ASSERT_TRUE(receiver->m_zero);
+  ASSERT_TRUE(receiver->m_one);
+  ASSERT_EQ(100, receiver->m_oneArg);
 
   // Unblock:
   receiver->Proceed();
@@ -44,8 +44,8 @@ TEST_F(EventReceiverTest, VerifyNoReceive) {
   AutoFired<CallableInterfaceDeferred> sender;
 
   // Try to defer these calls, should not be delivered anywhere:
-  EXPECT_NO_THROW(sender(&CallableInterfaceDeferred::ZeroArgsDeferred)());
-  EXPECT_NO_THROW(sender(&CallableInterfaceDeferred::OneArgDeferred)(100));
+  ASSERT_NO_THROW(sender(&CallableInterfaceDeferred::ZeroArgsDeferred)());
+  ASSERT_NO_THROW(sender(&CallableInterfaceDeferred::OneArgDeferred)(100));
 
   // Unblock:
   receiver->Proceed();
@@ -59,8 +59,8 @@ TEST_F(EventReceiverTest, VerifyNoReceive) {
   receiver->Wait();
 
   // Verify that no call was not made accidentally
-  EXPECT_FALSE(receiver->m_zero) << "A zero-argument call was pended to a dispatcher not marked ready";
-  EXPECT_FALSE(receiver->m_one) << "A single-argument call was pended to a dispatcher not marked ready";
+  ASSERT_FALSE(receiver->m_zero) << "A zero-argument call was pended to a dispatcher not marked ready";
+  ASSERT_FALSE(receiver->m_one) << "A single-argument call was pended to a dispatcher not marked ready";
 }
 
 TEST_F(EventReceiverTest, DeferredInvoke) {
@@ -76,9 +76,9 @@ TEST_F(EventReceiverTest, DeferredInvoke) {
   sender(&CallableInterfaceDeferred::AllDoneDeferred)();
 
   // Verify that nothing is hit yet:
-  EXPECT_FALSE(receiver->m_zero) << "Zero-argument call made prematurely";
-  EXPECT_FALSE(receiver->m_one) << "One-argument call made prematurely";
-  EXPECT_TRUE(receiver->IsRunning()) << "Receiver is terminated";
+  ASSERT_FALSE(receiver->m_zero) << "Zero-argument call made prematurely";
+  ASSERT_FALSE(receiver->m_one) << "One-argument call made prematurely";
+  ASSERT_TRUE(receiver->IsRunning()) << "Receiver is terminated";
 
   // Unblock:
   receiver->Proceed();
@@ -87,9 +87,9 @@ TEST_F(EventReceiverTest, DeferredInvoke) {
   receiver->Wait();
 
   // Validate deferred firing:
-  EXPECT_TRUE(receiver->m_zero) << "Zero argument call was not properly deferred";
-  EXPECT_TRUE(receiver->m_one) << "Single argument call was not properly deferred";
-  EXPECT_EQ(101, receiver->m_oneArg) << "Argument was not correctly propagated through a deferred call";
+  ASSERT_TRUE(receiver->m_zero) << "Zero argument call was not properly deferred";
+  ASSERT_TRUE(receiver->m_one) << "Single argument call was not properly deferred";
+  ASSERT_EQ(101, receiver->m_oneArg) << "Argument was not correctly propagated through a deferred call";
 }
 
 TEST_F(EventReceiverTest, NontrivialCopy) {
@@ -111,8 +111,8 @@ TEST_F(EventReceiverTest, NontrivialCopy) {
   sender(&CallableInterfaceDeferred::AllDoneDeferred)();
 
   // Verify that nothing is hit yet:
-  EXPECT_TRUE(receiver->m_myVec.empty()) << "Event handler invoked before barrier was hit; it should have been deferred";
-  EXPECT_TRUE(receiver->IsRunning()) << "Receiver is terminated";
+  ASSERT_TRUE(receiver->m_myVec.empty()) << "Event handler invoked before barrier was hit; it should have been deferred";
+  ASSERT_TRUE(receiver->IsRunning()) << "Receiver is terminated";
 
   // Unblock:
   receiver->Proceed();
@@ -123,7 +123,7 @@ TEST_F(EventReceiverTest, NontrivialCopy) {
   // Validate our vectors:
   ASSERT_EQ(10, (int)receiver->m_myVec.size()) << "Receiver was not populated correctly with a vector";
   for(int i = 0; i < s_numElems; i++)
-    EXPECT_EQ(i, ascending[i]) << "Element at offset " << i << " was incorrectly copied";
+    ASSERT_EQ(i, ascending[i]) << "Element at offset " << i << " was incorrectly copied";
 }
 
 TEST_F(EventReceiverTest, VerifyNoUnnecessaryCopies) {
@@ -177,7 +177,7 @@ TEST_F(EventReceiverTest, VerifyNoUnnecessaryCopies) {
   // copy from the the Defer call, and one again when the deferred method is passed
   // the DispatchQueue
   CopyCounter& finalCtr = receiver->m_myCtr;
-  EXPECT_LE(finalCtr.m_count, 2) << "Transfer object was copied too many times";
+  ASSERT_LE(finalCtr.m_count, 2) << "Transfer object was copied too many times";
 }
 
 TEST_F(EventReceiverTest, VerifyDescendantContextWiring) {
@@ -205,25 +205,25 @@ TEST_F(EventReceiverTest, VerifyDescendantContextWiring) {
       sender(&CallableInterface::ZeroArgs)();
 
       // Verify that it gets caught:
-      EXPECT_TRUE(rcvr->m_zero) << "Event receiver in descendant context was not properly autowired";
+      ASSERT_TRUE(rcvr->m_zero) << "Event receiver in descendant context was not properly autowired";
 
       subCtxt->SignalShutdown(true);
     }
 
     // Verify subcontext is gone:
-    EXPECT_TRUE(subCtxtWeak.expired()) << "Subcontext endured outside of its intended scope";
+    ASSERT_TRUE(subCtxtWeak.expired()) << "Subcontext endured outside of its intended scope";
 
     // Verify the reference count on the event receiver
-    EXPECT_EQ(1, rcvrCopy.use_count()) << "Detected a leaked reference to an event receiver";
+    ASSERT_EQ(1, rcvrCopy.use_count()) << "Detected a leaked reference to an event receiver";
 
     // Fire the event again--shouldn't be captured by the receiver because its context is gone
     rcvrCopy->m_zero = false;
     sender(&CallableInterface::ZeroArgs)();
-    EXPECT_FALSE(rcvrCopy->m_zero) << "Event receiver was still wired even after its enclosing context was removed";
+    ASSERT_FALSE(rcvrCopy->m_zero) << "Event receiver was still wired even after its enclosing context was removed";
   }
 
   // The parent context had better not be holding a reference at this point
-  EXPECT_TRUE(rcvrWeak.expired()) << "Event receiver reference still being held after its context and all shared references are gone";
+  ASSERT_TRUE(rcvrWeak.expired()) << "Event receiver reference still being held after its context and all shared references are gone";
 
   // Fire the event again, this shouldn't cause anything to blow up!
   sender(&CallableInterface::ZeroArgs)();
@@ -314,9 +314,9 @@ TEST_F(EventReceiverTest, VerifyDirectInvocation) {
   ctxt->Invoke(&CallableInterface::OneArg)(100);
 
   // Verify that stuff happens even when the thread isn't running:
-  EXPECT_TRUE(receiver->m_zero);
-  EXPECT_TRUE(receiver->m_one);
-  EXPECT_EQ(100, receiver->m_oneArg);
+  ASSERT_TRUE(receiver->m_zero);
+  ASSERT_TRUE(receiver->m_one);
+  ASSERT_EQ(100, receiver->m_oneArg);
 
   // Unblock:
   receiver->Proceed();
@@ -331,7 +331,7 @@ TEST_F(EventReceiverTest, NoEventsAfterShutdown) {
   ci(&CallableInterface::ZeroArgs)();
 
   // Verify that the callable interface didn't get the event after shutdown
-  EXPECT_FALSE(receiver->m_zero) << "A context member caught an event after its enclosing context was torn down";
+  ASSERT_FALSE(receiver->m_zero) << "A context member caught an event after its enclosing context was torn down";
 }
 
 class PassByValueInterface {
@@ -388,8 +388,8 @@ TEST_F(EventReceiverTest, VerifyMultiplePassByRef) {
   // Fire the "pass by ref" event:
   sender(&PassByValueInterface::ConstStringRefArg)(passByRef);
   // Verify that the value received matches what we sent both receivers:
-  EXPECT_EQ(passByRef, receiver1->value());
-  EXPECT_EQ(passByRef, receiver2->value());
+  ASSERT_EQ(passByRef, receiver1->value());
+  ASSERT_EQ(passByRef, receiver2->value());
 
   receiver1->Stop();
   receiver2->Stop();
@@ -408,8 +408,8 @@ TEST_F(EventReceiverTest, VerifyMultiplePassByValue) {
   sender(&PassByValueInterface::StringArg)(passByValue);
 
   // Verify that the value received matches what we sent both receivers:
-  EXPECT_EQ(passByValue, receiver1->value());
-  EXPECT_EQ(passByValue, receiver2->value());
+  ASSERT_EQ(passByValue, receiver1->value());
+  ASSERT_EQ(passByValue, receiver2->value());
 
   receiver1->Stop();
   receiver2->Stop();
@@ -439,7 +439,7 @@ TEST_F(EventReceiverTest, VerifyNoActionWhileStopped) {
   ASSERT_FALSE(sr->IsRunning()) << "CoreThread was running in a context that was not started";
 
   // Fire events at the outer scope--this should succeed but should not be picked up by the CoreThread:
-  //EXPECT_ANY_THROW(ciOuter(&CallableInterface::ZeroArgs)()) << "Firing and event before context is initiated didn't throw exception";
+  //ASSERT_ANY_THROW(ciOuter(&CallableInterface::ZeroArgs)()) << "Firing and event before context is initiated didn't throw exception";
   ASSERT_FALSE(sr->m_zero) << "A member of an uninitialized context incorrectly received an event";
 
   //ciOuterDeferred(&CallableInterfaceDeferred::ZeroArgsDeferred)();
@@ -463,7 +463,7 @@ TEST_F(EventReceiverTest, VerifyCorrectContext){
   
   AutoFired<CallableInterface> fire(outerCtxt);
   fire(&CallableInterface::ZeroArgs)();
-  EXPECT_TRUE(receiver->m_zero) << "AutoFired was created with the current context instead of the passed in context";
+  ASSERT_TRUE(receiver->m_zero) << "AutoFired was created with the current context instead of the passed in context";
 }
 
 TEST_F(EventReceiverTest, EventChain){

--- a/src/autowiring/test/ExceptionFilterTest.cpp
+++ b/src/autowiring/test/ExceptionFilterTest.cpp
@@ -64,7 +64,7 @@ public:
       throw;
     } catch(tracking_exception&) {
     } catch(custom_exception& custom) {
-      EXPECT_EQ(100, custom.m_value) << "A filtered custom exception did not have the expected member field value";
+      ASSERT_EQ(100, custom.m_value) << "A filtered custom exception did not have the expected member field value";
       m_specific = true;
     } catch(...) {
       m_generic = true;
@@ -76,7 +76,7 @@ public:
     try {
       throw;
     } catch(custom_exception& custom) {
-      EXPECT_EQ(200, custom.m_value) << "A fired exception did not have the expected value, probable copy malfunction";
+      ASSERT_EQ(200, custom.m_value) << "A fired exception did not have the expected value, probable copy malfunction";
       m_fireSpecific = true;
     } catch(...) {
       m_generic = true;
@@ -96,7 +96,7 @@ TEST_F(ExceptionFilterTest, AUTOTHROW_ExceptionDestruction) {
   thrower->Wait();
 
   // Verify that the exception was destroyed the correct number of times:
-  EXPECT_EQ(0UL, tracking_exception::s_count) << "Exception was not destroyed the correct number of times";
+  ASSERT_EQ(0UL, tracking_exception::s_count) << "Exception was not destroyed the correct number of times";
 }
 
 TEST_F(ExceptionFilterTest, CheckThrowThrow) {
@@ -107,7 +107,7 @@ TEST_F(ExceptionFilterTest, CheckThrowThrow) {
     }
   };
 
-  EXPECT_THROW(throw example(), std::exception) << "An exception type which throws from its ctor did not throw the expected type";
+  ASSERT_THROW(throw example(), std::exception) << "An exception type which throws from its ctor did not throw the expected type";
 }
 
 TEST_F(ExceptionFilterTest, AUTOTHROW_ThreadThrowsCheck) {
@@ -122,9 +122,9 @@ TEST_F(ExceptionFilterTest, AUTOTHROW_ThreadThrowsCheck) {
   thrower->Wait();
 
   // Hopefully the filter got hit in the right spot:
-  EXPECT_TRUE(filter->m_hit) << "Filter was not invoked for a thrown exception";
-  EXPECT_TRUE(filter->m_specific) << "Filter did not correctly detect the exception type";
-  EXPECT_FALSE(filter->m_generic) << "Filter did not correctly filter out a specific exception";
+  ASSERT_TRUE(filter->m_hit) << "Filter was not invoked for a thrown exception";
+  ASSERT_TRUE(filter->m_specific) << "Filter did not correctly detect the exception type";
+  ASSERT_FALSE(filter->m_generic) << "Filter did not correctly filter out a specific exception";
 }
 
 TEST_F(ExceptionFilterTest, SimpleFilterCheck) {
@@ -140,10 +140,10 @@ TEST_F(ExceptionFilterTest, SimpleFilterCheck) {
   AutoRequired<ThrowsWhenFired<>> fireThrower;
 
   // Add something to fire the exception:
-  EXPECT_NO_THROW(broadcaster(&ThrowingListener::DoThrow)());
+  ASSERT_NO_THROW(broadcaster(&ThrowingListener::DoThrow)());
 
   // Verify that the exception was filtered properly by the generic filter:
-  EXPECT_TRUE(filter->m_fireSpecific) << "Filter was not invoked on a Fired exception";
+  ASSERT_TRUE(filter->m_fireSpecific) << "Filter was not invoked on a Fired exception";
 }
 
 TEST_F(ExceptionFilterTest, FireContainmentCheck) {
@@ -159,13 +159,13 @@ TEST_F(ExceptionFilterTest, FireContainmentCheck) {
   ctxt->Inject<ThrowsWhenFired<>>();
 
   // Now cause the exception to occur:
-  EXPECT_NO_THROW(broadcaster(&ThrowingListener::DoThrow)());
+  ASSERT_NO_THROW(broadcaster(&ThrowingListener::DoThrow)());
 
   // Verify that the context containing the fire thrower was torn down:
-  EXPECT_TRUE(ctxt->IsShutdown()) << "An unhandled exception from a fire call in a context should have signalled it to stop";
+  ASSERT_TRUE(ctxt->IsShutdown()) << "An unhandled exception from a fire call in a context should have signalled it to stop";
 
   // Verify that the parent context was protected:
-  EXPECT_FALSE(AutoCurrentContext()->IsShutdown()) << "An unhandled exception incorrectly terminated a parent context";
+  ASSERT_FALSE(AutoCurrentContext()->IsShutdown()) << "An unhandled exception incorrectly terminated a parent context";
 }
 
 TEST_F(ExceptionFilterTest, AUTOTHROW_EnclosedThrowCheck) {
@@ -186,7 +186,7 @@ TEST_F(ExceptionFilterTest, AUTOTHROW_EnclosedThrowCheck) {
   ASSERT_TRUE(subCtxt->Wait(std::chrono::seconds(5))) << "Context did not terminate in a timely fashion";
 
   // Verify that the filter caught the exception:
-  EXPECT_TRUE(filter->m_hit) << "Filter operating in a superior context did not catch an exception thrown from a child context";
+  ASSERT_TRUE(filter->m_hit) << "Filter operating in a superior context did not catch an exception thrown from a child context";
 }
 
 TEST_F(ExceptionFilterTest, VerifyThrowingRecipients) {
@@ -201,7 +201,7 @@ TEST_F(ExceptionFilterTest, VerifyThrowingRecipients) {
   tl(&ThrowingListener::DoThrow)();
 
   // Verify that BOTH are hit:
-  EXPECT_TRUE(v200->hit && v201->hit) << "Expected all receivers of a fired event will be processed, even if some throw exceptions";
+  ASSERT_TRUE(v200->hit && v201->hit) << "Expected all receivers of a fired event will be processed, even if some throw exceptions";
 }
 
 TEST_F(ExceptionFilterTest, ExceptionFirewall) {
@@ -232,8 +232,8 @@ TEST_F(ExceptionFilterTest, VerifySimpleConfinement) {
   tl(&ThrowingListener::DoThrow)();
 
   // Verify that the parent scope wasn't incorrectly terminated:
-  EXPECT_FALSE(ctxt->IsShutdown()) << "Parent scope was terminated incorrectly due to an exception sourced by a child context";
+  ASSERT_FALSE(ctxt->IsShutdown()) << "Parent scope was terminated incorrectly due to an exception sourced by a child context";
 
   // Verify that the child scope was terminated as expected:
-  EXPECT_TRUE(child->IsShutdown()) << "An event recipient in a child scope threw an exception and the child context was not correctly terminated";
+  ASSERT_TRUE(child->IsShutdown()) << "An event recipient in a child scope threw an exception and the child context was not correctly terminated";
 }

--- a/src/autowiring/test/GlobalInitTest.cpp
+++ b/src/autowiring/test/GlobalInitTest.cpp
@@ -29,11 +29,11 @@ void GlobalInitTest::TearDown(void) {
 TEST_F(GlobalInitTest, VerifyGlobalExists) {
   // Verify that we at least get a global scope
   std::shared_ptr<GlobalCoreContext> global = GlobalCoreContext::Get();
-  EXPECT_TRUE(!!global.get());
+  ASSERT_TRUE(!!global.get());
 
   // There should only be three references:  The one we have, the global
   // reference, and the thread-current reference
-  EXPECT_EQ(global.use_count(), 3) << "Unexpected global use count after bare initialization";
+  ASSERT_EQ(global.use_count(), 3) << "Unexpected global use count after bare initialization";
 }
 
 struct Simple {
@@ -46,9 +46,9 @@ TEST_F(GlobalInitTest, VerifySimpleContext) {
 
   // Obtain reference:
   std::shared_ptr<GlobalCoreContext> global = GlobalCoreContext::Get();
-  EXPECT_TRUE(!!global.get());
+  ASSERT_TRUE(!!global.get());
 
   // Verify that initialization happened as we expected:
   Autowired<SimpleObject> simpleObj;
-  EXPECT_TRUE(!!simpleObj.get());
+  ASSERT_TRUE(!!simpleObj.get());
 }

--- a/src/autowiring/test/InterlockedRoutinesTest.cpp
+++ b/src/autowiring/test/InterlockedRoutinesTest.cpp
@@ -19,8 +19,8 @@ void CheckFn() {
   void* pExchanged = exchange_acquire(&dest, exchangeVal);
 
   // Verify all known states:
-  EXPECT_EQ(&spot, pExchanged) << "Return value of exchange_acquire as incorrect";
-  EXPECT_EQ(nullptr, dest) << "Exchange destination was not properly assigned";
+  ASSERT_EQ(&spot, pExchanged) << "Return value of exchange_acquire as incorrect";
+  ASSERT_EQ(nullptr, dest) << "Exchange destination was not properly assigned";
 }
 
 TEST_F(InterlockedRoutinesTest, VerifyExchangeAcquire) {
@@ -41,16 +41,16 @@ TEST_F(InterlockedRoutinesTest, VerifyCompareExchange) {
 
   // A compare-exchange that is known to fail:
   pExchanged = compare_exchange(&dest, &spot2, &spot3);
-  EXPECT_EQ(&spot1, dest) << "Exchanged values even though the comparand was not equal";
-  EXPECT_EQ(&spot1, pExchanged) << "Returned exchange value was not the value of dest";
+  ASSERT_EQ(&spot1, dest) << "Exchanged values even though the comparand was not equal";
+  ASSERT_EQ(&spot1, pExchanged) << "Returned exchange value was not the value of dest";
 
   // Reset:
   dest = &spot1;
 
   // A compare-exchange that should succeed:
   pExchanged = compare_exchange(&dest, &spot2, &spot1);
-  EXPECT_EQ(&spot2, dest) << "Destination was not given a correct value";
-  EXPECT_EQ(&spot1, pExchanged) << "Return value under a successful exchange was not the original value";
+  ASSERT_EQ(&spot2, dest) << "Destination was not given a correct value";
+  ASSERT_EQ(&spot1, pExchanged) << "Return value under a successful exchange was not the original value";
 }
 
 TEST_F(InterlockedRoutinesTest, VerifyCompareExchangePathological) {
@@ -109,5 +109,5 @@ TEST_F(InterlockedRoutinesTest, VerifyCompareExchangePathological) {
   // Verify that no illegal transitions have taken place by ensuring the count is precisely
   // the count we expect:
   size_t offset = (char*)counter - &base;
-  EXPECT_EQ(offset, threadCount) << "Interlocked exchange under heavy contention failed to honor interlocking requirements";
+  ASSERT_EQ(offset, threadCount) << "Interlocked exchange under heavy contention failed to honor interlocking requirements";
 }

--- a/src/autowiring/test/MultiInheritTest.cpp
+++ b/src/autowiring/test/MultiInheritTest.cpp
@@ -28,10 +28,10 @@ class MultiInheritDerived:
 {
 public:
   MultiInheritDerived(void) {
-    EXPECT_TRUE(Base::m_member.IsAutowired()) << "Base AutoRequired member was not initialized properly";
-    EXPECT_EQ(100, Base::m_member->m_i) << "Autowired instance was not properly constructed";
-    EXPECT_TRUE(m_secondMember.IsAutowired()) << "Failed to autowire a type which should have been injected in this context";
-    EXPECT_EQ(m_member.get(), m_secondMember.get()) << "Autowiring idempotency was violated";
+    ASSERT_TRUE(Base::m_member.IsAutowired()) << "Base AutoRequired member was not initialized properly";
+    ASSERT_EQ(100, Base::m_member->m_i) << "Autowired instance was not properly constructed";
+    ASSERT_TRUE(m_secondMember.IsAutowired()) << "Failed to autowire a type which should have been injected in this context";
+    ASSERT_EQ(m_member.get(), m_secondMember.get()) << "Autowiring idempotency was violated";
   }
 
   Autowired<Shared> m_secondMember;
@@ -50,7 +50,7 @@ TEST_F(MultiInheritTest, VerifyCast) {
   ASSERT_TRUE(wiredPobj.IsAutowired()) << "Autowiring failed for a multi-inheritance object";
 
   // Verify that we get a pObj back with correct casting:
-  EXPECT_EQ(obj.get(), wiredPobj.get()) << "Autowiring failed on a multiple inheritance object";
+  ASSERT_EQ(obj.get(), wiredPobj.get()) << "Autowiring failed on a multiple inheritance object";
 }
 
 TEST_F(MultiInheritTest, VerifyBaseInitializer) {
@@ -60,5 +60,5 @@ TEST_F(MultiInheritTest, VerifyBaseInitializer) {
   MultiInheritDerived derived;
 
   // Expect that something autowires when we're done at least:
-  EXPECT_TRUE(derived.m_member.IsAutowired());
+  ASSERT_TRUE(derived.m_member.IsAutowired());
 }

--- a/src/autowiring/test/MultiInheritTest.cpp
+++ b/src/autowiring/test/MultiInheritTest.cpp
@@ -28,10 +28,10 @@ class MultiInheritDerived:
 {
 public:
   MultiInheritDerived(void) {
-    ASSERT_TRUE(Base::m_member.IsAutowired()) << "Base AutoRequired member was not initialized properly";
-    ASSERT_EQ(100, Base::m_member->m_i) << "Autowired instance was not properly constructed";
-    ASSERT_TRUE(m_secondMember.IsAutowired()) << "Failed to autowire a type which should have been injected in this context";
-    ASSERT_EQ(m_member.get(), m_secondMember.get()) << "Autowiring idempotency was violated";
+    EXPECT_TRUE(Base::m_member.IsAutowired()) << "Base AutoRequired member was not initialized properly";
+    EXPECT_EQ(100, Base::m_member->m_i) << "Autowired instance was not properly constructed";
+    EXPECT_TRUE(m_secondMember.IsAutowired()) << "Failed to autowire a type which should have been injected in this context";
+    EXPECT_EQ(m_member.get(), m_secondMember.get()) << "Autowiring idempotency was violated";
   }
 
   Autowired<Shared> m_secondMember;

--- a/src/autowiring/test/ObjectPoolTest.cpp
+++ b/src/autowiring/test/ObjectPoolTest.cpp
@@ -23,7 +23,7 @@ TEST_F(ObjectPoolTest, VerifyOutstandingLimit) {
 
   // Verify that grabbing a third object fails:
   pool(obj3);
-  EXPECT_TRUE(obj3 == nullptr) << "Object pool issued more objects than it was authorized to issue";
+  ASSERT_TRUE(obj3 == nullptr) << "Object pool issued more objects than it was authorized to issue";
 }
 
 class LifeCycle {
@@ -180,7 +180,7 @@ TEST_F(ObjectPoolTest, DISABLED_VerifyAsynchronousUsage) {
     // still outstanding.
     {
       auto obj4 = pool.WaitFor(std::chrono::milliseconds(1));
-      EXPECT_TRUE(obj4 == nullptr) << "Pool issued another element even though it should have hit its outstanding limit";
+      ASSERT_TRUE(obj4 == nullptr) << "Pool issued another element even though it should have hit its outstanding limit";
     }
 
     // Now we kick off threads:
@@ -195,7 +195,7 @@ TEST_F(ObjectPoolTest, DISABLED_VerifyAsynchronousUsage) {
   // This should return more or less right away as objects become available:
   {
     auto obj4 = pool.WaitFor(std::chrono::milliseconds(10));
-    EXPECT_TRUE(obj4 != nullptr) << "Object pool failed to be notified that it received a new element";
+    ASSERT_TRUE(obj4 != nullptr) << "Object pool failed to be notified that it received a new element";
   }
 
   // Cause the thread to quit:
@@ -258,8 +258,8 @@ TEST_F(ObjectPoolTest, EmptyPoolIssuance) {
 
   // Verify properties now that we've zeroized the limit:
   pool.SetOutstandingLimit(0);
-  EXPECT_ANY_THROW(pool.SetOutstandingLimit(1)) << "An attempt to alter a zeroized outstanding limit did not throw an exception as expected";
-  EXPECT_ANY_THROW(pool.Wait()) << "An attempt to obtain an element on an empty pool did not throw an exception as expected";
+  ASSERT_ANY_THROW(pool.SetOutstandingLimit(1)) << "An attempt to alter a zeroized outstanding limit did not throw an exception as expected";
+  ASSERT_ANY_THROW(pool.Wait()) << "An attempt to obtain an element on an empty pool did not throw an exception as expected";
 
   // Now see if we can delay for the thread to back out:
   ctxt->Initiate();

--- a/src/autowiring/test/PostConstructTest.cpp
+++ b/src/autowiring/test/PostConstructTest.cpp
@@ -102,7 +102,7 @@ class FailedAutowiringInstance {
 TEST_F(PostConstructTest, VerifyNaiveBehavior) {
   // Create a context and add just the naive class, to verify the problematic behavior:
   AutoCurrentContext ctxt;
-  EXPECT_THROW(ctxt->Inject<Naive>(), std::exception) << "Naive class didn't throw an exception as expected";
+  ASSERT_THROW(ctxt->Inject<Naive>(), std::exception) << "Naive class didn't throw an exception as expected";
 }
 
 TEST_F(PostConstructTest, VerifyExpectedDeferrmentCount) {
@@ -112,7 +112,7 @@ TEST_F(PostConstructTest, VerifyExpectedDeferrmentCount) {
   ctxt->Inject<Smarter>();
 
   // Now test the count:
-  EXPECT_EQ(
+  ASSERT_EQ(
     1UL,
     ((ContextExposer&)*ctxt).DeferredCount()
   ) << "Unexpected number of deferred initializers";
@@ -127,14 +127,14 @@ TEST_F(PostConstructTest, VerifySmartBehavior) {
   // Check that we can get the item we just injected
   Autowired<Smarter> smarter;
   ASSERT_TRUE(smarter.IsAutowired()) << "Slot was not satisfied as expected";
-  EXPECT_EQ(1, smarter->value) << "Unexpected initial value of SmarterA instance";
+  ASSERT_EQ(1, smarter->value) << "Unexpected initial value of SmarterA instance";
 
   // Now inject A, and see if delayed autowiring has taken place:
   ctxt->Inject<A>();
-  EXPECT_FALSE(!smarter->m_a.get()) << "Autowired member was not wired as expected";
+  ASSERT_FALSE(!smarter->m_a.get()) << "Autowired member was not wired as expected";
 
   // Verify the value was updated by the notification routine
-  EXPECT_EQ(2, smarter->value) << "Post-construction notification routine wasn't invoked as expected";
+  ASSERT_EQ(2, smarter->value) << "Post-construction notification routine wasn't invoked as expected";
 }
 
 TEST_F(PostConstructTest, VerifySmartBehaviorWithInheritance) {
@@ -145,13 +145,13 @@ TEST_F(PostConstructTest, VerifySmartBehaviorWithInheritance) {
 
   //Initially value should be one, which is the default
   Autowired<SmarterInterface> smarterI;
-  EXPECT_EQ(1, smarterI->value) << "Unexpected initial value of SmarterA instance";
+  ASSERT_EQ(1, smarterI->value) << "Unexpected initial value of SmarterA instance";
 
   //Now add Implementation and check the wiring
   ctxt->Inject<Implementation>();
-  EXPECT_FALSE(!smarterI->m_interface.get()) << "Autowired subclass was not wired as expected";
+  ASSERT_FALSE(!smarterI->m_interface.get()) << "Autowired subclass was not wired as expected";
 
-  EXPECT_EQ(2, smarterI->value) << "Post-construction notification routine wasn't invoked on subclass";
+  ASSERT_EQ(2, smarterI->value) << "Post-construction notification routine wasn't invoked on subclass";
 }
 
 TEST_F(PostConstructTest, VerifyLoopingFailedAutowiring) {
@@ -270,7 +270,7 @@ TEST_F(PostConstructTest, ContextNotifyWhenAutowired) {
   );
 
   // Should only be two uses, at this point, of the capture of the above lambda:
-  EXPECT_EQ(2L, called.use_count()) << "Unexpected number of references held in a capture lambda";
+  ASSERT_EQ(2L, called.use_count()) << "Unexpected number of references held in a capture lambda";
 
   // Create another entry that will add another slot to the deferred list:
   Autowired<SimpleObject> sobj;

--- a/src/autowiring/test/ScopeTest.cpp
+++ b/src/autowiring/test/ScopeTest.cpp
@@ -11,7 +11,7 @@ class ScopeTest:
 TEST_F(ScopeTest, VerifyGlobalExists) {
   // Verify that we at least get a global scope
   AutoGlobalContext global;
-  EXPECT_TRUE(nullptr != global.get()) << "Failed to autowire the global context";
+  ASSERT_TRUE(nullptr != global.get()) << "Failed to autowire the global context";
 }
 
 class A : public ContextMember {};
@@ -31,18 +31,18 @@ TEST_F(ScopeTest, VerifyInherit) {
     CurrentContextPusher pusher;
     pContext->SetCurrent();
 
-    EXPECT_TRUE(ctxt.get() != pContext.get()) << "Failed to create a sub-context";
+    ASSERT_TRUE(ctxt.get() != pContext.get()) << "Failed to create a sub-context";
 
     //try and autowire a member from the parent context
     Autowired<A> autoA;
-    EXPECT_FALSE(!autoA.get()) << "Autowired member not wired from parent context";
+    ASSERT_FALSE(!autoA.get()) << "Autowired member not wired from parent context";
 
     //add a member in the subcontext
     pContext->Inject<B>();
   }
 
   Autowired<B> autoB;
-  EXPECT_TRUE(!autoB.get()) << "Autowired member wired from sub-context";
+  ASSERT_TRUE(!autoB.get()) << "Autowired member wired from sub-context";
 }
 
 struct NoSimpleConstructor:
@@ -71,8 +71,8 @@ TEST_F(ScopeTest, StaticInject){
   Autowired<A> preA;
   Autowired<B> preB;
 
-  EXPECT_FALSE(preA.IsAutowired());
-  EXPECT_FALSE(preB.IsAutowired());
+  ASSERT_FALSE(preA.IsAutowired());
+  ASSERT_FALSE(preB.IsAutowired());
 
   CoreContext::InjectCurrent<A>();
   CoreContext::InjectCurrent<B>();
@@ -80,8 +80,8 @@ TEST_F(ScopeTest, StaticInject){
   Autowired<A> a;
   Autowired<B> b;
 
-  EXPECT_TRUE(a.IsAutowired());
-  EXPECT_TRUE(b.IsAutowired());
+  ASSERT_TRUE(a.IsAutowired());
+  ASSERT_TRUE(b.IsAutowired());
 }
 
 TEST_F(ScopeTest, VerifyAutowireSpecifiedContext){
@@ -92,7 +92,7 @@ TEST_F(ScopeTest, VerifyAutowireSpecifiedContext){
   subCtxt->Inject<A>();
 
   Autowired<A> aWired(subCtxt);
-  EXPECT_TRUE(aWired) << "Autowired member not wired from the passed context";
+  ASSERT_TRUE(aWired) << "Autowired member not wired from the passed context";
 }
 
 TEST_F(ScopeTest, VerifyAutoRequireSpecifiedContext){
@@ -101,8 +101,8 @@ TEST_F(ScopeTest, VerifyAutoRequireSpecifiedContext){
   Autowired<SimpleObject> aWired(subCtxt);
   Autowired<SimpleObject> aFail;
 
-  EXPECT_TRUE(aWired) << "Autorequired member not added to the passed context";
-  EXPECT_FALSE(aFail) << "Autorequired member added to the wrong context";
+  ASSERT_TRUE(aWired) << "Autorequired member not added to the passed context";
+  ASSERT_FALSE(aFail) << "Autorequired member added to the wrong context";
 }
 
 //This mangles the heap! why??  Using SimpleObject instead of A works fine!
@@ -127,7 +127,7 @@ TEST_F(ScopeTest, AutowiringOrdering) {
     CurrentContextPusher pshr(inner1);
 
     AutoRequired<A> a2;
-    EXPECT_FALSE(a.IsAutowired());
+    ASSERT_FALSE(a.IsAutowired());
   }
 
   // AutoRequire in outer context, Autowire in inner
@@ -136,8 +136,8 @@ TEST_F(ScopeTest, AutowiringOrdering) {
     CurrentContextPusher pshr(inner2);
 
     Autowired<B> b2;
-    EXPECT_TRUE(b.IsAutowired());
-    EXPECT_EQ(b->GetContext(), outer);
+    ASSERT_TRUE(b.IsAutowired());
+    ASSERT_EQ(b->GetContext(), outer);
   }
 
   // AutoRequire in outer context, AutoRequire in inner
@@ -146,8 +146,8 @@ TEST_F(ScopeTest, AutowiringOrdering) {
     CurrentContextPusher pshr(inner3);
 
     AutoRequired<C> c2;
-    EXPECT_TRUE(c2.IsAutowired());
-    EXPECT_NE(c->GetContext(), c2->GetContext());
+    ASSERT_TRUE(c2.IsAutowired());
+    ASSERT_NE(c->GetContext(), c2->GetContext());
   }
 
   // Autowire in outer context, Autowire in inner

--- a/src/autowiring/test/SnoopTest.cpp
+++ b/src/autowiring/test/SnoopTest.cpp
@@ -90,14 +90,14 @@ TEST_F(SnoopTest, VerifySimpleSnoop) {
     firer(&UpBroadcastListener::SimpleCall)();
 
     // Verify that the child itself got the message:
-    EXPECT_TRUE(childMember->m_simpleCall) << "Message not received by another member of the same context";
+    ASSERT_TRUE(childMember->m_simpleCall) << "Message not received by another member of the same context";
   }
 
   // Verify that the parent got the message:
-  EXPECT_TRUE(parentMember->m_simpleCall) << "Parent context snooper didn't receive a message broadcast by the child context";
+  ASSERT_TRUE(parentMember->m_simpleCall) << "Parent context snooper didn't receive a message broadcast by the child context";
 
   // Verify that the OTHER member got nothing:
-  EXPECT_FALSE(ignored->m_simpleCall) << "A member in a parent context received a child-context message even though it didn't request to snoop that context";
+  ASSERT_FALSE(ignored->m_simpleCall) << "A member in a parent context received a child-context message even though it didn't request to snoop that context";
 }
 
 TEST_F(SnoopTest, VerifyUnsnoop) {
@@ -120,10 +120,10 @@ TEST_F(SnoopTest, VerifyUnsnoop) {
     firer(&UpBroadcastListener::SimpleCall)();
 
     // The local listener should have gotten something
-    EXPECT_TRUE(childMember->m_simpleCall) << "Message not received by a local listener after Unsnoop call";
+    ASSERT_TRUE(childMember->m_simpleCall) << "Message not received by a local listener after Unsnoop call";
   }
 
-  EXPECT_FALSE(parentMember->m_simpleCall) << "ParentMember snooper received an event, even after an Unsnoop call was made";
+  ASSERT_FALSE(parentMember->m_simpleCall) << "ParentMember snooper received an event, even after an Unsnoop call was made";
 }
 
 TEST_F(SnoopTest, AmbiguousReciept) {
@@ -152,7 +152,7 @@ TEST_F(SnoopTest, AmbiguousReciept) {
   ASSERT_TRUE(ubl.HasListeners()) << "Apparently no listeners exist after subcontext destruction";
 
   ubl(&UpBroadcastListener::SimpleCall)();
-  EXPECT_TRUE(parent->m_simpleCall) << "Snooped parent did not receive an event as expected when snooped context was destroyed";
+  ASSERT_TRUE(parent->m_simpleCall) << "Snooped parent did not receive an event as expected when snooped context was destroyed";
 }
 
 TEST_F(SnoopTest, AvoidDoubleReciept) {
@@ -271,10 +271,10 @@ TEST_F(SnoopTest, AntiCyclicRemoval) {
   
   AutoFired<SimpleEvent> ubl;
   ubl(&SimpleEvent::ZeroArgs)();
-  EXPECT_EQ(1, removeself->counter) << "Received event";
+  ASSERT_EQ(1, removeself->counter) << "Received event";
   
   ubl(&SimpleEvent::ZeroArgs)();
-  EXPECT_EQ(1, removeself->counter) << "Received event even though unsnooped";
+  ASSERT_EQ(1, removeself->counter) << "Received event even though unsnooped";
 }
 
 
@@ -302,8 +302,8 @@ TEST_F(SnoopTest, SimplePackets) {
   
   // Now compleletly satisfy filter. Should snoop across contexts
   packet->Decorate(Decoration<1>());
-  EXPECT_TRUE(!!filter->m_called) << "A snooper did not receive an AutoPacket originating in a snooped context";
-  EXPECT_FALSE(detachedFilter->m_called) << "Received a packet from a different context";
+  ASSERT_TRUE(!!filter->m_called) << "A snooper did not receive an AutoPacket originating in a snooped context";
+  ASSERT_FALSE(detachedFilter->m_called) << "Received a packet from a different context";
   
   //reset
   filter->m_called = false;
@@ -312,7 +312,7 @@ TEST_F(SnoopTest, SimplePackets) {
   auto packet2 = factory->NewPacket();
   packet2->Decorate(Decoration<0>());
   packet2->Decorate(Decoration<1>());
-  EXPECT_FALSE(!!filter->m_called) << "Unsnoop didn't work";
+  ASSERT_FALSE(!!filter->m_called) << "Unsnoop didn't work";
 }
 
 TEST_F(SnoopTest, CanSnoopAutowired) {

--- a/src/autowiring/test/TeardownNotifierTest.cpp
+++ b/src/autowiring/test/TeardownNotifierTest.cpp
@@ -21,7 +21,7 @@ TEST_F(TeardownNotifierTest, VerifySingleNotification) {
     member->AddTeardownListener([&hit] {hit = true;});
   }
 
-  EXPECT_TRUE(hit) << "Teardown listener was not hit as expected during context teardown";
+  ASSERT_TRUE(hit) << "Teardown listener was not hit as expected during context teardown";
 }
 
 TEST_F(TeardownNotifierTest, ReferenceMemberInTeardown) {
@@ -44,7 +44,7 @@ TEST_F(TeardownNotifierTest, ReferenceMemberInTeardown) {
     });
   }
 
-  EXPECT_TRUE(hit) << "Failed to reference a member of a context in it's teardown listener";
+  ASSERT_TRUE(hit) << "Failed to reference a member of a context in it's teardown listener";
 }
 
 TEST_F(TeardownNotifierTest, CanAutowireInTeardown) {

--- a/src/autowiring/test/UuidTest.cpp
+++ b/src/autowiring/test/UuidTest.cpp
@@ -10,22 +10,22 @@ DECLARE_UUID(MyX, "01234567-89AB-CDEF-FEDC-BA9876543210"){};
 
 TEST_F(UuidTest, VerifySimpleUuid) {
   // Verify table properties:
-  EXPECT_EQ(0xE, UUID_MAPPING_TABLE['e' - '0']) << "Hex character 'e' in the mapping table was not correctly mapped"; 
-  EXPECT_EQ(0xA, UUID_MAPPING_TABLE['A' - '0']) << "Hex character 'A' in the mapping table was not correctly mapped";
+  ASSERT_EQ(0xE, UUID_MAPPING_TABLE['e' - '0']) << "Hex character 'e' in the mapping table was not correctly mapped"; 
+  ASSERT_EQ(0xA, UUID_MAPPING_TABLE['A' - '0']) << "Hex character 'A' in the mapping table was not correctly mapped";
   
   // Verify the queried UUID:
   uuid test_uuid = uuid_of<MyX>::Uuid();
 
-  EXPECT_EQ(0x1234567UL, test_uuid.Data1) << "Data1 was not defined properly";
+  ASSERT_EQ(0x1234567UL, test_uuid.Data1) << "Data1 was not defined properly";
   
-  EXPECT_EQ(0x89ABUL, test_uuid.Data2) << "Data2 was not defined properly";
-  EXPECT_EQ(0xCDEFUL, test_uuid.Data3) << "Data3 was not defined properly";
-  EXPECT_EQ(0x1032547698badcfe, (long long&) test_uuid.Data4) << "Data4 was not defined properly";
+  ASSERT_EQ(0x89ABUL, test_uuid.Data2) << "Data2 was not defined properly";
+  ASSERT_EQ(0xCDEFUL, test_uuid.Data3) << "Data3 was not defined properly";
+  ASSERT_EQ(0x1032547698badcfe, (long long&) test_uuid.Data4) << "Data4 was not defined properly";
 }
 
 TEST_F(UuidTest, VerifyEquivalence) {
   const uuid one("{5D0060CA-16CB-4E75-89A8-8ED13AA15672}");
   const uuid two("5D0060CA-16CB-4E75-89A8-8ED13AA15672");
 
-  EXPECT_EQ(one, two) << "The two acceptable formats for a UUID did not evaluate to equivalence";
+  ASSERT_EQ(one, two) << "The two acceptable formats for a UUID did not evaluate to equivalence";
 }


### PR DESCRIPTION
Every single one of these must pass, and later failures tend to just contaminate the output with useless messaging.  Tighten down from `EXPECT` to `ASSERT` wherever successive failures reveal no additional information--which, in our case, is _all_ of them.