### PR TITLE
Add a ThreadPool concept for CoreContext

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -21,6 +21,7 @@
 #include "CoreObjectDescriptor.h"
 #include "result_or_default.h"
 #include "TeardownNotifier.h"
+#include "ThreadPool.h"
 #include "TypeRegistry.h"
 #include "TypeUnifier.h"
 
@@ -57,6 +58,8 @@ class JunctionBox;
 namespace autowiring {
   template<typename... Args>
   struct signal_relay_t;
+
+  class ThreadPool;
 }
 
 /// \file
@@ -245,6 +248,13 @@ protected:
   // Clever use of shared pointer to expose the number of outstanding CoreRunnable instances.
   // Destructor does nothing; this is by design.
   std::weak_ptr<CoreObject> m_outstanding;
+
+  // The thread pool used by this context.  By default, a context inherits the thread pool of
+  // its parent, and the global context gets the system thread pool.
+  std::shared_ptr<autowiring::ThreadPool> m_threadPool;
+
+  // The start token for the thread pool, if one exists
+  std::shared_ptr<void> m_startToken;
 
   // Creation rules are allowed to refer to private methods in this type
   template<autowiring::construction_strategy, class T, class... Args>
@@ -1137,6 +1147,49 @@ public:
       ctxt.AddDeferredUnsafe(resultSlot);
     }
   };
+
+  /// <summary>
+  /// Assigns the thread pool handler for this context
+  /// </summary>
+  /// <remarks>
+  /// If the context is currently running, the thread pool will automatically be started.  The pool's
+  /// start token and shared pointer is reset automatically when the context is torn down.  If the
+  /// context has already been shut down (IE, IsShutdown returns true), this method has no effect.
+  ///
+  /// Dispatchers that have been attached to the current thread pool will not be transitioned to the
+  /// new pool.  Changing the thread pool may cause the previously assigned thread pool to be stopped.
+  /// This will cause it to complete all work assigned to it and release resources associated with
+  /// processing.  If there are no other handles to the pool, it may potentially destroy itself.
+  ///
+  /// It is an error to pass nullptr to this method.
+  /// </remarks>
+  void SetThreadPool(std::shared_ptr<autowiring::ThreadPool> threadPool);
+
+  /// <summary>
+  /// Returns the current thread pool
+  /// </summary>
+  /// <remarks>
+  /// If the context has been shut down, (IE, IsShutdown returns true), this method returns nullptr.  Calling
+  /// ThreadPool::Start on the returned shared pointer will not cause dispatchers pended to this context to
+  /// be executed.  To do this, invoke CoreContext::Initiate
+  /// </remarks>
+  std::shared_ptr<autowiring::ThreadPool> GetThreadPool(void) const;
+
+  /// <summary>
+  /// Submits the specified lambda to this context's ThreadPool for processing
+  /// </summary>
+  /// <returns>True if the job has been submitted for execution</returns>
+  /// <remarks>
+  /// The passed thunk will not be executed if the current context has already stopped.
+  /// </remarks>
+  template<class Fx>
+  bool operator+=(Fx&& fx) {
+    auto pool = GetThreadPool();
+    return
+      pool ?
+      pool->Submit(std::make_unique<DispatchThunk<Fx>>(std::forward<Fx&&>(fx))) :
+      false;
+  }
 
   /// <summary>
   /// Adds a post-attachment listener in this context for a particular autowired member.

--- a/autowiring/DispatchThunk.h
+++ b/autowiring/DispatchThunk.h
@@ -30,6 +30,11 @@ public:
   }
 };
 
+template<typename Fx>
+std::unique_ptr<DispatchThunkBase> MakeDispatchThunk(Fx&& fx) {
+  return std::unique_ptr<DispatchThunkBase>(new DispatchThunk<Fx>(std::forward<Fx&&>(fx)));
+}
+
 /// <summary>
 /// A so-called "delayed" dispatch thunk which must not be executed prior to the specified time
 /// </summary>

--- a/autowiring/ManualThreadPool.h
+++ b/autowiring/ManualThreadPool.h
@@ -1,0 +1,78 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "DispatchQueue.h"
+#include "ThreadPool.h"
+
+namespace autowiring {
+
+class ManualThreadPool;
+
+struct ThreadPoolToken {
+  ThreadPoolToken(std::shared_ptr<ManualThreadPool> manualPool) :
+    manualPool(manualPool)
+  {}
+
+  const std::shared_ptr<ManualThreadPool> manualPool;
+
+  // True if the thread owning this token should back out
+  bool cancelled = false;
+
+  /// <summary>
+  /// Causes the thread that has joined the thread pool to leave that pool
+  /// </summary>
+  /// <remarks>
+  /// This method is idempotent.  This method may be called on a token either before or after the
+  /// corresponding thread has begun participating in the pool.
+  /// </remarks>
+  void Leave(void);
+};
+
+/// <summary>
+/// Implements a thread pool that allows callers much more direct control of execution contexts
+/// </summary>
+/// <remarks>
+/// This thread pool implementation does not attempt to create any worker threads to handle work
+/// submitted to it.  Such submissions will accumulate in the internal DispatchQueue until a
+/// thread calls ManualThreadPool::Join.  At that point, the calling thread--referred to as a
+/// pool participant--will be responsible for executing work associated with the queue.
+/// </remarks>
+class ManualThreadPool:
+  public ThreadPool,
+  protected DispatchQueue
+{
+public:
+  ManualThreadPool(void);
+  ~ManualThreadPool(void);
+
+private:
+  // Number of threads currently executing dispatchers
+  std::atomic<size_t> m_outstanding;
+
+  // ThreadPool overrides:
+  void OnStartUnsafe(void);
+  void OnStop(void);
+
+public:
+  using DispatchQueue::WakeAllWaitingThreads;
+
+  /// <summary>
+  /// Provides a shared pointer that a participating thread may use to release itself from the pool
+  /// </summary>
+  /// <remarks>
+  /// The returned token may be used in exactly one call to Join.  Tokens should be reset when
+  /// the join call returns.  Tokens may safely outlive the thread pool that issued them.
+  /// </remarks>
+  std::shared_ptr<ThreadPoolToken> PrepareJoin(void);
+
+  /// <summary>
+  /// Causes the caller to perform work on this thread pool until the pool is stopped
+  /// </summary>
+  /// <returns>False if the passed token was already cancelled when this call was made; true otherwise</returns>
+  /// <param name="token">The token returned by a prior call to PrepareJoin</param>
+  void Join(std::shared_ptr<ThreadPoolToken> token);
+
+  // ThreadPool overrides:
+  bool Submit(std::unique_ptr<DispatchThunkBase>&& thunk);
+};
+
+}

--- a/autowiring/NullPool.h
+++ b/autowiring/NullPool.h
@@ -1,0 +1,47 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "ThreadPool.h"
+#include "DispatchQueue.h"
+
+namespace autowiring {
+
+/// <summary>
+/// A placeholder pool that accumulates work items until the owning context is started
+/// </summary>
+/// <remarks>
+/// This pool type should not be used directly
+/// </remarks>
+class NullPool:
+  public ThreadPool
+{
+public:
+  NullPool(void);
+  ~NullPool(void);
+
+private:
+  std::vector<std::unique_ptr<DispatchThunkBase>> m_dispatchers;
+
+  // This thread pool will be replaced by the specified successor pool when the
+  // owning context is started.  If this member is null, the parent context's
+  // thread pool is taken instead.
+  std::shared_ptr<ThreadPool> m_successor;
+
+public:
+  std::shared_ptr<ThreadPool> GetSuccessor(void) const { return m_successor; }
+
+  /// <summary>
+  /// Sets the pool that will be used by the owning context when the owning context initiates
+  /// </summary>
+  void SetSuccessor(std::shared_ptr<ThreadPool> successor);
+
+  /// <summary>
+  /// Causes all internally held dispatchers to be moved to the successor pool, then clears this pool
+  /// </summary>
+  /// <returns>The populated successor</returns>
+  std::shared_ptr<ThreadPool> MoveDispatchersToSuccessor(void);
+
+  // ThreadPool overrides:
+  std::shared_ptr<void> Start(void) override;
+  bool Submit(std::unique_ptr<DispatchThunkBase>&& thunk) override;
+};
+}

--- a/autowiring/SystemThreadPool.h
+++ b/autowiring/SystemThreadPool.h
@@ -1,0 +1,34 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "ThreadPool.h"
+
+namespace autowiring {
+
+/// <summary>
+/// A thread pool that makes use of the underlying system's APIs
+/// </summary>
+class SystemThreadPool:
+  public ThreadPool
+{
+public:
+  SystemThreadPool(void);
+  ~SystemThreadPool(void);
+
+  // Creates a new platform-specific thread pool
+  static std::shared_ptr<SystemThreadPool> New(void);
+
+  /// <summary>
+  /// Makes a recommendation as to the number of worker threads that should be used to process work
+  /// </summary>
+  /// <remarks>
+  /// Implementations are free to ignore this request.  An implementation may honor this request and
+  /// then immediately change the number of pooled threads.  Passing a value of 0 does not guarantee
+  /// that any threads will exit.
+  ///
+  /// Resizing the number of worker threads may potentially be very expensive on certain systems.
+  /// This method should only be called during setup or during major stateful changes on the system.
+  /// </remarks>
+  virtual void SuggestThreadPoolSize(size_t nThreads) {}
+};
+
+}

--- a/autowiring/SystemThreadPoolStl.h
+++ b/autowiring/SystemThreadPoolStl.h
@@ -1,0 +1,46 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "DispatchQueue.h"
+#include "SystemThreadPool.h"
+#include <thread> 
+#include <vector>
+
+namespace autowiring {
+
+/// <summary>
+/// Implements a thread pool using the STL as a final fallback
+/// </summary>
+/// <remarks>
+/// This implementation avoids using std::async to achieve thread pooling because some systems
+/// do not attempt to reuse threads to run operations enqueued by std::async, resulting in very
+/// poor performance.
+/// </remarks>
+class SystemThreadPoolStl:
+  public SystemThreadPool
+{
+public:
+  SystemThreadPoolStl(void);
+  ~SystemThreadPoolStl(void);
+
+private:
+  // Thunks awaiting execution
+  DispatchQueue m_toBeDone;
+
+  // The current number of outstanding workers
+  std::atomic<size_t> m_outstanding;
+
+  /// <summary>
+  /// Creates a new worker thread to process the dispatch queue
+  /// </summary>
+  void AddWorkerThreadUnsafe(void);
+
+  // ThreadPool overrides
+  void OnStartUnsafe(void) override;
+  void OnStop(void) override;
+
+public:
+  void SuggestThreadPoolSize(size_t nThreads) override;
+  bool Submit(std::unique_ptr<DispatchThunkBase>&& thunk) override;
+};
+
+}

--- a/autowiring/SystemThreadPoolStl.h
+++ b/autowiring/SystemThreadPoolStl.h
@@ -27,7 +27,7 @@ private:
   DispatchQueue m_toBeDone;
 
   // The current number of outstanding workers
-  std::atomic<size_t> m_outstanding;
+  std::atomic<size_t> m_outstanding{0};
 
   /// <summary>
   /// Creates a new worker thread to process the dispatch queue

--- a/autowiring/SystemThreadPoolWin.h
+++ b/autowiring/SystemThreadPoolWin.h
@@ -1,0 +1,41 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "DispatchQueue.h"
+#include "SystemThreadPool.h"
+#include <Windows.h>
+#include <concurrent_queue.h>
+
+namespace autowiring {
+
+/// <summary>
+/// A thread pool that makes use of the underlying system's APIs
+/// </summary>
+class SystemThreadPoolWin:
+  public SystemThreadPool
+{
+public:
+  SystemThreadPoolWin(void);
+  ~SystemThreadPoolWin(void);
+
+private:
+  // Work item for single dispatchers
+  PTP_WORK m_pwkDispatchRundown;
+  PTP_WORK m_pwkSingle;
+
+  // Vector of dispathc queues that need to be run down
+  concurrency::concurrent_queue<std::shared_ptr<DispatchQueue>> m_rundownTargets;
+
+  // Our own internal dispatch queue containing items to be executed:
+  DispatchQueue m_toBeDone;
+
+  // ThreadPool overrides:
+  void OnStartUnsafe(void) override;
+  void OnStop(void) override;
+
+public:
+  // ThreadPool overrides:
+  void Consume(std::shared_ptr<DispatchQueue> dq) override;
+  bool Submit(std::unique_ptr<DispatchThunkBase>&& thunk) override;
+};
+
+}

--- a/autowiring/ThreadPool.h
+++ b/autowiring/ThreadPool.h
@@ -1,0 +1,87 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include <atomic>
+#include <memory>
+#include <mutex>
+
+class DispatchQueue;
+class DispatchThunkBase;
+
+namespace autowiring {
+
+/// <summary>
+/// Generic interface for a thread pool
+/// </summary>
+class ThreadPool:
+  public std::enable_shared_from_this<ThreadPool>
+{
+public:
+  ThreadPool(void) {}
+  virtual ~ThreadPool(void) {}
+
+protected:
+  // Start token:
+  std::mutex m_lock;
+  std::weak_ptr<void> m_startToken;
+
+  /// <summary>
+  /// Called when the thread pool is first started
+  /// </summary>
+  /// <remarks>
+  /// This method is called at most once
+  /// </remarks>
+  virtual void OnStartUnsafe(void) {}
+
+  /// <summary>
+  /// Called when the thread pool is being cleaned up
+  /// </summary>
+  virtual void OnStop(void) {}
+
+public:
+  /// <returns>True if the thread pool is running</returns>
+  bool IsStarted(void) const { return !m_startToken.expired(); }
+
+  /// <summary>
+  /// Begins processing on this thread pool
+  /// </summary>
+  /// <returns>A token that must be held in scope while the thread pool should be started</returns>
+  /// <remarks>
+  /// This method is idempotent.  Unlike CoreThread instances, a thread pool may be restarted.
+  /// The returned shared pointer must be held for as long as the thread pool should be kept running.
+  /// </remarks>
+  virtual std::shared_ptr<void> Start(void);
+
+  /// <summary>
+  /// Causes the thread pool to call all lambdas specified on the passed DispatchQueue
+  /// </summary>
+  /// <remarks>
+  /// The dispatchers on the DispatchQueue are executed sequentially with respect to each other.
+  /// Each dispatcher is guaranteed to be destroyed before the next one is executed.  Dispatchers
+  /// may potentially be executed on different threads, depending on the exact details of the
+  /// ThreadPool's implementation.  There is no guarantee of timeliness of execution provided
+  /// by this implementation; the queue may be emptied before this function returns in some cases,
+  /// or its state may not be changed at all.  The DispatchQueue may be aborted while the pool
+  /// has posession of it; this will cause the ThreadPool to abandon processing of the queue
+  /// in the normal way.
+  ///
+  /// Once the pool has emptied the queue, it stops processing dispatchers from it.  The user
+  /// must call Consume again in order to continue processing.
+  ///
+  /// This method is guaranteed not to block.  The default implementation captures the passed
+  /// queue in a lambda and invokes Submit with this constructed lambda.
+  /// </remarks>
+  virtual void Consume(std::shared_ptr<DispatchQueue> dq);
+
+  /// <summary>
+  /// Adds the specified thunk to be executed by the thread pool at some later time
+  /// </summary>
+  /// <returns>True if the job was successfully accepted, false otherwise</returns>
+  /// <remarks>
+  /// This method may be called even if the thread pool is not currently running.  In that
+  /// case, the job will be enqueued until the thread pool is started, at which time it will
+  /// be submitted for execution.
+  /// </remarks>
+  virtual bool Submit(std::unique_ptr<DispatchThunkBase>&& thunk) = 0;
+};
+
+}

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -131,11 +131,15 @@ set(Autowiring_SRCS
   JunctionBoxEntry.h
   JunctionBoxManager.cpp
   JunctionBoxManager.h
+  ManualThreadPool.h
+  ManualThreadPool.cpp
   member_new_type.h
   MemoEntry.h
   MemoEntry.cpp
   MicroAutoFilter.h
   MicroBolt.h
+  NullPool.h
+  NullPool.cpp
   ObjectPool.h
   ObjectPoolMonitor.cpp
   ObjectPoolMonitor.h
@@ -145,9 +149,15 @@ set(Autowiring_SRCS
   SharedPointerSlot.h
   SlotInformation.cpp
   SlotInformation.h
+  SystemThreadPool.cpp
+  SystemThreadPool.h
+  SystemThreadPoolStl.cpp
+  SystemThreadPoolStl.h
   TeardownNotifier.cpp
   TeardownNotifier.h
   thread_specific_ptr.h
+  ThreadPool.h
+  ThreadPool.cpp
   TypeIdentifier.h
   TypeRegistry.cpp
   TypeRegistry.h
@@ -181,6 +191,8 @@ add_conditional_sources(
 add_windows_sources(Autowiring_SRCS
   auto_future_win.h
   CoreThreadWin.cpp
+  SystemThreadPoolWin.cpp
+  SystemThreadPoolWin.h
   InterlockedExchangeWin.cpp
   thread_specific_ptr_win.h
 )

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -57,8 +57,8 @@ CoreContext::CoreContext(std::shared_ptr<CoreContext> pParent, t_childList::iter
   m_pParent(pParent),
   m_backReference(backReference),
   m_stateBlock(new CoreContextStateBlock),
-  m_threadPool(std::make_shared<NullPool>()),
-  m_junctionBoxManager(new JunctionBoxManager)
+  m_junctionBoxManager(new JunctionBoxManager),
+  m_threadPool(std::make_shared<NullPool>())
 {}
 
 CoreContext::~CoreContext(void) {

--- a/src/autowiring/GlobalCoreContext.cpp
+++ b/src/autowiring/GlobalCoreContext.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "GlobalCoreContext.h"
+#include "SystemThreadPool.h"
 #include <cassert>
 
 GlobalCoreContext::GlobalCoreContext(void):

--- a/src/autowiring/ManualThreadPool.cpp
+++ b/src/autowiring/ManualThreadPool.cpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "ManualThreadPool.h"
+#include "at_exit.h"
+
+using namespace autowiring;
+
+void ThreadPoolToken::Leave(void) {
+  cancelled = true;
+  manualPool->WakeAllWaitingThreads();
+}
+
+ManualThreadPool::ManualThreadPool(void)
+{
+}
+
+ManualThreadPool::~ManualThreadPool(void)
+{
+}
+
+void ManualThreadPool::OnStartUnsafe(void)
+{}
+
+void ManualThreadPool::OnStop(void)
+{}
+
+std::shared_ptr<ThreadPoolToken> ManualThreadPool::PrepareJoin(void) {
+  return std::make_shared<ThreadPoolToken>(
+    std::static_pointer_cast<ManualThreadPool>(shared_from_this())
+  );
+}
+
+void ManualThreadPool::Join(std::shared_ptr<ThreadPoolToken> token) {
+  m_outstanding++;
+  auto clear = MakeAtExit([&] { m_outstanding--; });
+  try {
+    while (!token->cancelled)
+      WaitForEvent();
+  }
+  catch (dispatch_aborted_exception&) {
+    // Dispatch aborted exception, back out
+  }
+  catch (...) {
+    // Unknown, consume exception and end here
+  }
+}
+
+bool ManualThreadPool::Submit(std::unique_ptr<DispatchThunkBase>&& thunk) {
+  // Add some more work
+  AddExisting(std::move(thunk));
+  return true;
+}

--- a/src/autowiring/NullPool.cpp
+++ b/src/autowiring/NullPool.cpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "NullPool.h"
+
+using namespace autowiring;
+
+NullPool::NullPool(void)
+{}
+
+NullPool::~NullPool(void)
+{}
+
+void NullPool::SetSuccessor(std::shared_ptr<ThreadPool> successor) {
+  std::lock_guard<std::mutex> lk(m_lock);
+  m_successor = successor;
+}
+
+std::shared_ptr<ThreadPool> NullPool::MoveDispatchersToSuccessor(void) {
+  std::shared_ptr<ThreadPool> successor;
+  std::vector<std::unique_ptr<DispatchThunkBase>> dispatchers;
+
+  // Transfer over so we hold ownership, then release the lock
+  {
+    std::lock_guard<std::mutex> lk(m_lock);
+
+    // If there is no successor then we have to return here, we can't tear
+    // down lambdas safely from here
+    if (!m_successor)
+      return nullptr;
+
+    successor = std::move(m_successor);
+    m_successor.reset();
+    dispatchers = std::move(m_dispatchers);
+    m_dispatchers.clear();
+  }
+
+  for (auto& dispatcher : dispatchers)
+    successor->Submit(std::move(dispatcher));
+  return successor;
+}
+
+std::shared_ptr<void> NullPool::Start(void) {
+  auto successor = GetSuccessor();
+  if (!successor)
+    return nullptr;
+  return successor->Start();
+}
+
+bool NullPool::Submit(std::unique_ptr<DispatchThunkBase>&& thunk) {
+  m_dispatchers.push_back(std::move(thunk));
+  return true;
+}

--- a/src/autowiring/SystemThreadPool.cpp
+++ b/src/autowiring/SystemThreadPool.cpp
@@ -1,0 +1,11 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "SystemThreadPool.h"
+
+using namespace autowiring;
+
+SystemThreadPool::SystemThreadPool(void)
+{}
+
+SystemThreadPool::~SystemThreadPool(void)
+{}

--- a/src/autowiring/SystemThreadPoolStl.cpp
+++ b/src/autowiring/SystemThreadPoolStl.cpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "SystemThreadPoolStl.h"
+#include "at_exit.h"
+
+using namespace autowiring;
+
+SystemThreadPoolStl::SystemThreadPoolStl(void)
+{}
+
+SystemThreadPoolStl::~SystemThreadPoolStl(void)
+{}
+
+// Used on non-MSVC platforms, but we still want to be able to test the rest of these pool
+// behaviors on MSVC
+#ifndef _MSC_VER
+std::shared_ptr<SystemThreadPool> SystemThreadPool::New(void) {
+  return std::make_shared<SystemThreadPoolStl>();
+}
+#endif
+
+void SystemThreadPoolStl::AddWorkerThreadUnsafe(void) {
+  auto pThis = shared_from_this();
+  std::thread t([this, pThis] {
+    auto clear = MakeAtExit([&] { m_outstanding--; });
+    try {
+      for (;;)
+        m_toBeDone.WaitForEvent();
+    }
+    catch (dispatch_aborted_exception&) {
+      // Dispatch aborted exception, back out
+    }
+    catch (...) {
+      // Unknown, we have nowhere to report this exception, silently fail
+    }
+  });
+  t.detach();
+  m_outstanding++;
+}
+
+void SystemThreadPoolStl::OnStartUnsafe(void) {
+  auto concurrent = std::thread::hardware_concurrency();
+  if (m_outstanding)
+    // Do nothing if the pool size was already set by someone else
+    return;
+
+  // TODO:  Set this number according to std::thread::hardware_concurrency.  This can't
+  // be done right now due to the fact that DispatchQueue has terrible concurrency
+  // performance.
+  while (m_outstanding < 2)
+    AddWorkerThreadUnsafe();
+}
+
+void SystemThreadPoolStl::OnStop(void) {
+  m_toBeDone += [this] { m_toBeDone.Abort(); };
+}
+
+void SystemThreadPoolStl::SuggestThreadPoolSize(size_t nThreads) {
+  std::lock_guard<std::mutex> lk(m_lock);
+  while (m_outstanding < nThreads)
+    AddWorkerThreadUnsafe();
+}
+
+bool SystemThreadPoolStl::Submit(std::unique_ptr<DispatchThunkBase>&& thunk) {
+  // Add some more work
+  m_toBeDone.AddExisting(std::move(thunk));
+
+  // If we don't have anyone to do work, we need to wake someone up:
+  std::lock_guard<std::mutex> lk(m_lock);
+  if (!m_outstanding && !m_startToken.expired())
+    AddWorkerThreadUnsafe();
+
+  return false;
+}

--- a/src/autowiring/SystemThreadPoolStl.cpp
+++ b/src/autowiring/SystemThreadPoolStl.cpp
@@ -47,6 +47,7 @@ void SystemThreadPoolStl::OnStartUnsafe(void) {
   // TODO:  Set this number according to std::thread::hardware_concurrency.  This can't
   // be done right now due to the fact that DispatchQueue has terrible concurrency
   // performance.
+  (void)concurrent;
   while (m_outstanding < 2)
     AddWorkerThreadUnsafe();
 }

--- a/src/autowiring/SystemThreadPoolWin.cpp
+++ b/src/autowiring/SystemThreadPoolWin.cpp
@@ -1,0 +1,79 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "SystemThreadPoolWin.h"
+#include "DispatchThunk.h"
+
+using namespace autowiring;
+
+SystemThreadPoolWin::SystemThreadPoolWin(void) 
+{
+}
+
+SystemThreadPoolWin::~SystemThreadPoolWin(void)
+{
+  if (m_pwkSingle)
+    CloseThreadpoolWork(m_pwkSingle);
+  if (m_pwkDispatchRundown)
+    CloseThreadpoolWork(m_pwkDispatchRundown);
+}
+
+std::shared_ptr<SystemThreadPool> SystemThreadPool::New(void)
+{
+  return std::make_shared<SystemThreadPoolWin>();
+}
+
+void SystemThreadPoolWin::OnStartUnsafe(void) {
+  m_pwkDispatchRundown = CreateThreadpoolWork(
+    [](PTP_CALLBACK_INSTANCE Instance, void* Context, PTP_WORK Work) {
+      auto* pThis = static_cast<SystemThreadPoolWin*>(Context);
+
+      // Grab an arbitrary dispatch queue from the set of pending queues:
+      std::shared_ptr<DispatchQueue> dqEntry;
+      if (!pThis->m_rundownTargets.try_pop(dqEntry))
+        // Short circuit, someone must have got to it already
+        return;
+
+      // Now just dispatch everything in order:
+      dqEntry->DispatchAllEvents();
+    },
+    this,
+    nullptr
+  );
+
+  m_pwkSingle = CreateThreadpoolWork(
+    [](PTP_CALLBACK_INSTANCE Instance, void* Context, PTP_WORK Work) {
+      // Spin down our dispatch queue until it is empty:
+      static_cast<SystemThreadPoolWin*>(Context)->m_toBeDone.DispatchAllEvents();
+    },
+    this,
+    nullptr
+  );
+}
+
+void SystemThreadPoolWin::OnStop(void) {
+  m_toBeDone.Abort();
+
+  std::lock_guard<std::mutex> lk(m_lock);
+  CloseThreadpoolWork(m_pwkSingle);
+  m_pwkSingle = nullptr;
+  CloseThreadpoolWork(m_pwkDispatchRundown);
+  m_pwkDispatchRundown = nullptr;
+}
+
+void SystemThreadPoolWin::Consume(std::shared_ptr<DispatchQueue> dq)
+{
+  // Append the entry and then signal the rundown queue that there is work to be done
+  std::lock_guard<std::mutex> lk(m_lock);
+  m_rundownTargets.push(dq);
+  if (m_pwkDispatchRundown)
+    SubmitThreadpoolWork(m_pwkDispatchRundown);
+}
+
+bool SystemThreadPoolWin::Submit(std::unique_ptr<DispatchThunkBase>&& thunk)
+{
+  std::lock_guard<std::mutex> lk(m_lock);
+  m_toBeDone.AddExisting(std::move(thunk));
+  if (m_pwkSingle)
+    SubmitThreadpoolWork(m_pwkSingle);
+  return true;
+}

--- a/src/autowiring/ThreadPool.cpp
+++ b/src/autowiring/ThreadPool.cpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "ThreadPool.h"
+#include "DispatchQueue.h"
+
+using namespace autowiring;
+
+std::shared_ptr<void> ThreadPool::Start(void) {
+  std::lock_guard<std::mutex> lk(m_lock);
+  auto retVal = m_startToken.lock();
+  if (!retVal) {
+    OnStartUnsafe();
+
+    auto pThis = shared_from_this();
+    retVal.reset(
+      static_cast<void*>(this),
+      [pThis](void*) {
+        pThis->OnStop();
+      }
+    );
+    m_startToken = retVal;
+  }
+  return retVal;
+}
+
+
+void ThreadPool::Consume(std::shared_ptr<DispatchQueue> dq) {
+  Submit(
+    MakeDispatchThunk(
+      [dq] { dq->DispatchAllEvents(); }
+    )
+  );
+}

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -56,6 +56,7 @@ set(AutowiringTest_SRCS
   SatisfiabilityTest.cpp
   ScopeTest.cpp
   SnoopTest.cpp
+  ThreadPoolTest.cpp
   TupleTest.cpp
   TestFixtures/custom_exception.hpp
   TestFixtures/ExitRaceThreaded.hpp

--- a/src/autowiring/test/ThreadPoolTest.cpp
+++ b/src/autowiring/test/ThreadPoolTest.cpp
@@ -22,7 +22,7 @@ TEST_F(ThreadPoolTest, SimpleSubmission) {
   };
 
   auto rs = p->get_future();
-  ASSERT_EQ(std::future_status::ready, rs.wait_for(std::chrono::seconds(30))) << "Thread pool lambda was not dispatched in a timely fashion";
+  ASSERT_EQ(std::future_status::ready, rs.wait_for(std::chrono::seconds(5))) << "Thread pool lambda was not dispatched in a timely fashion";
 }
 
 static void PoolOverload(void) {
@@ -40,7 +40,7 @@ static void PoolOverload(void) {
     };
 
   auto rs = p->get_future();
-  ASSERT_EQ(std::future_status::ready, rs.wait_for(std::chrono::seconds(30))) << "Pool saturation did not complete in a timely fashion";
+  ASSERT_EQ(std::future_status::ready, rs.wait_for(std::chrono::seconds(5))) << "Pool saturation did not complete in a timely fashion";
 }
 
 TEST_F(ThreadPoolTest, PoolOverload) {
@@ -69,7 +69,7 @@ TEST_F(ThreadPoolTest, PendBeforeContextStart) {
   ASSERT_EQ(std::future_status::timeout, f.wait_for(std::chrono::milliseconds(1))) << "A pended lambda was completed before the owning context was intiated";
 
   ctxt->Initiate();
-  ASSERT_EQ(std::future_status::ready, f.wait_for(std::chrono::seconds(30))) << "A lambda did not complete in a timely fashion after its context was started";
+  ASSERT_EQ(std::future_status::ready, f.wait_for(std::chrono::seconds(5))) << "A lambda did not complete in a timely fashion after its context was started";
 
   // Terminate, verify that we don't capture any more lambdas:
   ctxt->SignalShutdown();
@@ -93,7 +93,7 @@ TEST_F(ThreadPoolTest, ManualThreadPoolBehavior) {
   );
 
   auto valFuture = val.get_future();
-  ASSERT_EQ(std::future_status::ready, valFuture.wait_for(std::chrono::seconds(30))) << "Join thread took too much time to start up";
+  ASSERT_EQ(std::future_status::ready, valFuture.wait_for(std::chrono::seconds(5))) << "Join thread took too much time to start up";
   auto token = valFuture.get();
 
   // Set up the context 
@@ -112,9 +112,9 @@ TEST_F(ThreadPoolTest, ManualThreadPoolBehavior) {
 
   // Wait for everything to get hit:
   auto hitDoneFuture = hitDone.get_future();
-  ASSERT_EQ(std::future_status::ready, hitDoneFuture.wait_for(std::chrono::seconds(30))) << "Manual pool did not dispatch lambdas in a timely fashion";
+  ASSERT_EQ(std::future_status::ready, hitDoneFuture.wait_for(std::chrono::seconds(5))) << "Manual pool did not dispatch lambdas in a timely fashion";
 
   // Verify that cancellation of the token causes the manual thread to back out
   token->Leave();
-  ASSERT_EQ(std::future_status::ready, launch.wait_for(std::chrono::seconds(30))) << "Token cancellation did not correctly release a single waiting thread";
+  ASSERT_EQ(std::future_status::ready, launch.wait_for(std::chrono::seconds(5))) << "Token cancellation did not correctly release a single waiting thread";
 }

--- a/src/autowiring/test/ThreadPoolTest.cpp
+++ b/src/autowiring/test/ThreadPoolTest.cpp
@@ -2,6 +2,7 @@
 #include "stdafx.h"
 #include <autowiring/autowiring.h>
 #include <autowiring/ManualThreadPool.h>
+#include <autowiring/NullPool.h>
 #include <autowiring/SystemThreadPoolStl.h>
 #include FUTURE_HEADER
 
@@ -12,6 +13,12 @@ class ThreadPoolTest:
 TEST_F(ThreadPoolTest, SimpleSubmission) {
   AutoCurrentContext ctxt;
   ctxt->Initiate();
+
+  // Simple validation
+  auto pool = ctxt->GetThreadPool();
+  ASSERT_NE(nullptr, pool.get()) << "Pool can never be null on an initiated context";
+  ASSERT_EQ(nullptr, dynamic_cast<autowiring::NullPool*>(pool.get())) << "After context initiation, the pool should not be a null pool";
+  ASSERT_TRUE(pool->IsStarted()) << "Pool was not started when the enclosing context was initiated";
 
   // Submit a job and then block for its completion.  Use a promise to ensure that
   // the job is being executed in some other thread context.

--- a/src/autowiring/test/ThreadPoolTest.cpp
+++ b/src/autowiring/test/ThreadPoolTest.cpp
@@ -1,0 +1,120 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include <autowiring/autowiring.h>
+#include <autowiring/ManualThreadPool.h>
+#include <autowiring/SystemThreadPoolStl.h>
+#include FUTURE_HEADER
+
+class ThreadPoolTest:
+  public testing::Test
+{};
+
+TEST_F(ThreadPoolTest, SimpleSubmission) {
+  AutoCurrentContext ctxt;
+  ctxt->Initiate();
+
+  // Submit a job and then block for its completion.  Use a promise to ensure that
+  // the job is being executed in some other thread context.
+  auto p = std::make_shared<std::promise<void>>();
+
+  *ctxt += [&] {
+    p->set_value();
+  };
+
+  auto rs = p->get_future();
+  ASSERT_EQ(std::future_status::ready, rs.wait_for(std::chrono::seconds(30))) << "Thread pool lambda was not dispatched in a timely fashion";
+}
+
+static void PoolOverload(void) {
+  AutoCurrentContext ctxt;
+  ctxt->Initiate();
+
+  size_t cap = 10000;
+  auto ctr = std::make_shared<std::atomic<int>>(cap);
+  auto p = std::make_shared<std::promise<void>>();
+
+  for (size_t i = cap; i--;)
+    *ctxt += [=] {
+      if (!--*ctr)
+        p->set_value();
+    };
+
+  auto rs = p->get_future();
+  ASSERT_EQ(std::future_status::ready, rs.wait_for(std::chrono::seconds(30))) << "Pool saturation did not complete in a timely fashion";
+}
+
+TEST_F(ThreadPoolTest, PoolOverload) {
+  ::PoolOverload();
+}
+
+// On systems that don't have any OS-specific thread pool customizations, this method is redundant
+// On systems that do, this method ensures parity of behavior
+TEST_F(ThreadPoolTest, StlPoolTest) {
+  AutoCurrentContext ctxt;
+  auto pool = std::make_shared<autowiring::SystemThreadPoolStl>();
+  ctxt->SetThreadPool(pool);
+  pool->SuggestThreadPoolSize(2);
+  ::PoolOverload();
+}
+
+TEST_F(ThreadPoolTest, PendBeforeContextStart) {
+  AutoCurrentContext ctxt;
+
+  // Pend
+  auto barr = std::make_shared<std::promise<void>>();
+  *ctxt += [barr] { barr->set_value(); };
+  ASSERT_EQ(2UL, barr.use_count()) << "Lambda was not correctly captured by an uninitiated context";
+
+  std::future<void> f = barr->get_future();
+  ASSERT_EQ(std::future_status::timeout, f.wait_for(std::chrono::milliseconds(1))) << "A pended lambda was completed before the owning context was intiated";
+
+  ctxt->Initiate();
+  ASSERT_EQ(std::future_status::ready, f.wait_for(std::chrono::seconds(30))) << "A lambda did not complete in a timely fashion after its context was started";
+
+  // Terminate, verify that we don't capture any more lambdas:
+  ctxt->SignalShutdown();
+  ASSERT_FALSE(*ctxt += [barr] {}) << "Lambda append operation incorrectly evaluated to true";
+  ASSERT_TRUE(barr.unique()) << "Lambda was incorrectly captured by a context that was already terminated";
+}
+
+TEST_F(ThreadPoolTest, ManualThreadPoolBehavior) {
+  // Make the manual pool that will be used for this test:
+  auto pool = std::make_shared<autowiring::ManualThreadPool>();
+
+  // Launch a thread that will join the pool:
+  std::promise<std::shared_ptr<autowiring::ThreadPoolToken>> val;
+  auto launch = std::async(
+    std::launch::async,
+    [pool, &val] {
+      auto token = pool->PrepareJoin();
+      val.set_value(token);
+      pool->Join(token);
+    }
+  );
+
+  auto valFuture = val.get_future();
+  ASSERT_EQ(std::future_status::ready, valFuture.wait_for(std::chrono::seconds(30))) << "Join thread took too much time to start up";
+  auto token = valFuture.get();
+
+  // Set up the context 
+  AutoCurrentContext ctxt;
+  ctxt->SetThreadPool(pool);
+  ctxt->Initiate();
+
+  // Pend some lambdas to be executed by our worker thread:
+  std::promise<void> hitDone;
+  std::atomic<int> hitCount{10};
+  for (size_t i = hitCount; i--; )
+    *ctxt += [&] {
+      if (!--hitCount)
+        hitDone.set_value();
+    };
+
+  // Wait for everything to get hit:
+  auto hitDoneFuture = hitDone.get_future();
+  ASSERT_EQ(std::future_status::ready, hitDoneFuture.wait_for(std::chrono::seconds(30))) << "Manual pool did not dispatch lambdas in a timely fashion";
+
+  // Verify that cancellation of the token causes the manual thread to back out
+  token->Leave();
+  ASSERT_EQ(std::future_status::ready, launch.wait_for(std::chrono::seconds(30))) << "Token cancellation did not correctly release a single waiting thread";
+}

--- a/src/autowiring/test/ThreadPoolTest.cpp
+++ b/src/autowiring/test/ThreadPoolTest.cpp
@@ -30,7 +30,7 @@ static void PoolOverload(void) {
   ctxt->Initiate();
 
   size_t cap = 10000;
-  auto ctr = std::make_shared<std::atomic<int>>(cap);
+  auto ctr = std::make_shared<std::atomic<size_t>>(cap);
   auto p = std::make_shared<std::promise<void>>();
 
   for (size_t i = cap; i--;)


### PR DESCRIPTION
The thread pool concept allows users to attach a lambda to the context to be executed by that context's thread pool.  By default, contexts receive the thread pool of their parent, and the global context gets the default thread pool for the system.  Contexts assign their thread pool to the thread pool of their parent upon initiation (not construction).  Prior to initiation, contexts hold the null thread pool, which is an instance of NullPool that simply accumulates dispatchers until the parent context is initiated, shut down, or destroyed.

Setting a context's thread pool will not cause the context to release its reference to the NullPool.  Instead, the provided thread pool will be held until the context is started, and when this happens, all dispatchers will be transferred to the requested pool and then the requested pool will be initiated.

Jobs added to a context's thread pool will not be run until the context is started.

- [x] Builds and tests pass on Windows x86
- [x] Builds and tests pass on Windows x64
- [x] Builds and tests pass on Mac