### PR TITLE
Rename GetAutoFilterInput to GetAutoFilterArguments

### DIFF
--- a/autowiring/AutoFilterArgument.h
+++ b/autowiring/AutoFilterArgument.h
@@ -6,10 +6,10 @@
 /// <summary>
 /// AutoFilter argument disposition
 /// </summary>
-struct AutoFilterDescriptorInput {
-  AutoFilterDescriptorInput(void) = default;
+struct AutoFilterArgument {
+  AutoFilterArgument(void) = default;
 
-  AutoFilterDescriptorInput(
+  AutoFilterArgument(
     bool is_input,
     bool is_output,
     bool is_shared,
@@ -38,11 +38,11 @@ struct AutoFilterDescriptorInput {
 };
 
 template<typename T>
-struct AutoFilterDescriptorInputT:
-  AutoFilterDescriptorInput
+struct AutoFilterArgumentT:
+  AutoFilterArgument
 {
-  AutoFilterDescriptorInputT(void) :
-    AutoFilterDescriptorInput(
+  AutoFilterArgumentT(void) :
+    AutoFilterArgument(
       auto_arg<T>::is_input,
       auto_arg<T>::is_output,
       auto_arg<T>::is_shared,

--- a/autowiring/AutoFilterDescriptor.h
+++ b/autowiring/AutoFilterDescriptor.h
@@ -88,7 +88,7 @@ public:
   const std::type_info* GetType() const { return m_pType; }
   size_t GetArity(void) const { return m_arity; }
   size_t GetRequiredCount(void) const { return m_requiredCount; }
-  const AutoFilterDescriptorInput* GetAutoFilterInput(void) const { return m_pArgs; }
+  const AutoFilterDescriptorInput* GetAutoFilterArguments(void) const { return m_pArgs; }
   bool IsDeferred(void) const { return m_deferred; }
   const std::type_info* GetAutoFilterTypeInfo(void) const { return m_pType; }
 

--- a/autowiring/AutoFilterDescriptor.h
+++ b/autowiring/AutoFilterDescriptor.h
@@ -3,7 +3,7 @@
 #include "AnySharedPointer.h"
 #include "altitude.h"
 #include "auto_arg.h"
-#include "AutoFilterDescriptorInput.h"
+#include "AutoFilterArgument.h"
 #include "CallExtractor.h"
 #include "Decompose.h"
 #include "has_autofilter.h"
@@ -33,7 +33,7 @@ struct AutoFilterDescriptorStub {
   /// is required to carry information about the type of the proper member function to be called; t_extractedCall is
   /// required to be instantiated by the caller and point to the AutoFilter proxy routine.
   /// </summary>
-  AutoFilterDescriptorStub(const std::type_info* pType, autowiring::altitude altitude, const AutoFilterDescriptorInput* pArgs, bool deferred, t_extractedCall pCall) :
+  AutoFilterDescriptorStub(const std::type_info* pType, autowiring::altitude altitude, const AutoFilterArgument* pArgs, bool deferred, t_extractedCall pCall) :
     m_pType(pType),
     m_altitude(altitude),
     m_pArgs(pArgs),
@@ -61,7 +61,7 @@ protected:
   // This subscriber's argument types
   // NOTE: This is a reference to a static generated list,
   // therefore it MUST be const and MUST be shallow-copied.
-  const AutoFilterDescriptorInput* m_pArgs = nullptr;
+  const AutoFilterArgument* m_pArgs = nullptr;
 
   // Set if this is a deferred subscriber.  Deferred subscribers cannot receive immediate-style
   // decorations, and have additional handling considerations when dealing with non-copyable
@@ -88,7 +88,7 @@ public:
   const std::type_info* GetType() const { return m_pType; }
   size_t GetArity(void) const { return m_arity; }
   size_t GetRequiredCount(void) const { return m_requiredCount; }
-  const AutoFilterDescriptorInput* GetAutoFilterArguments(void) const { return m_pArgs; }
+  const AutoFilterArgument* GetAutoFilterArguments(void) const { return m_pArgs; }
   bool IsDeferred(void) const { return m_deferred; }
   const std::type_info* GetAutoFilterTypeInfo(void) const { return m_pType; }
 
@@ -98,7 +98,7 @@ public:
   /// <remarks>
   /// Returns nullptr when no argument is of the requested type.
   /// </remarks>
-  const AutoFilterDescriptorInput* GetArgumentType(const std::type_info* argType) {
+  const AutoFilterArgument* GetArgumentType(const std::type_info* argType) {
     for(auto pArg = m_pArgs; *pArg; pArg++) {
       if (pArg->ti == argType) {
         return pArg;
@@ -164,7 +164,7 @@ struct AutoFilterDescriptor:
         T,
         CallExtractor<decltype(&T::AutoFilter)>::deferred ? autowiring::altitude::Dispatch : autowiring::altitude::Standard
       >::value,
-      Decompose<decltype(&T::AutoFilter)>::template Enumerate<AutoFilterDescriptorInput, AutoFilterDescriptorInputT>::types,
+      Decompose<decltype(&T::AutoFilter)>::template Enumerate<AutoFilterArgument, AutoFilterArgumentT>::types,
       CallExtractor<decltype(&T::AutoFilter)>::deferred,
       &CallExtractor<decltype(&T::AutoFilter)>::template Call<&T::AutoFilter>
     )
@@ -182,7 +182,7 @@ struct AutoFilterDescriptor:
       AnySharedPointer(std::make_shared<Fn>(std::forward<Fn>(fn))),
       &typeid(Fn),
       altitude,
-      CallExtractor<decltype(&Fn::operator())>::template Enumerate<AutoFilterDescriptorInput, AutoFilterDescriptorInputT>::types,
+      CallExtractor<decltype(&Fn::operator())>::template Enumerate<AutoFilterArgument, AutoFilterArgumentT>::types,
       false,
       &CallExtractor<decltype(&Fn::operator())>::template Call<&Fn::operator()>
     )
@@ -206,7 +206,7 @@ struct AutoFilterDescriptor:
   ///
   /// The caller is responsible for decomposing the desired routine into the target AutoFilter call
   /// </summary>
-  AutoFilterDescriptor(const AnySharedPointer& autoFilter, const std::type_info* pType, autowiring::altitude altitude, const AutoFilterDescriptorInput* pArgs, bool deferred, t_extractedCall pCall) :
+  AutoFilterDescriptor(const AnySharedPointer& autoFilter, const std::type_info* pType, autowiring::altitude altitude, const AutoFilterArgument* pArgs, bool deferred, t_extractedCall pCall) :
     AutoFilterDescriptorStub(pType, altitude, pArgs, deferred, pCall),
     m_autoFilter(autoFilter)
   {}
@@ -227,7 +227,7 @@ struct AutoFilterDescriptor:
       // The remainder is fairly straightforward
       &typeid(pfn),
       altitude,
-      CallExtractor<decltype(pfn)>::template Enumerate<AutoFilterDescriptorInput, AutoFilterDescriptorInputT>::types,
+      CallExtractor<decltype(pfn)>::template Enumerate<AutoFilterArgument, AutoFilterArgumentT>::types,
       false,
       CallExtractor<decltype(pfn)>::Call
     )

--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -3,7 +3,7 @@
 #include "AnySharedPointer.h"
 #include "at_exit.h"
 #include "auto_id.h"
-#include "AutoFilterDescriptorInput.h"
+#include "AutoFilterArgument.h"
 #include "DecorationDisposition.h"
 #include "demangle.h"
 #include "is_any.h"
@@ -22,7 +22,7 @@ class AutoPacketFactory;
 class AutoPacketProfiler;
 class CoreContext;
 struct AutoFilterDescriptor;
-struct AutoFilterDescriptorInput;
+struct AutoFilterArgument;
 
 template<class MemFn>
 struct Decompose;
@@ -541,7 +541,7 @@ public:
   /// by this filter have been satisfied on this packet.  When this function returns, the specified filter will have
   /// been called.
   /// </remarks>
-  bool Wait(std::condition_variable& cv, const AutoFilterDescriptorInput* inputs, std::chrono::nanoseconds duration = std::chrono::nanoseconds::max());
+  bool Wait(std::condition_variable& cv, const AutoFilterArgument* inputs, std::chrono::nanoseconds duration = std::chrono::nanoseconds::max());
 
   /// <summary>
   /// Blocks until the passed lambda function can be called
@@ -566,7 +566,7 @@ public:
 
     // Add the filter that will ultimately be invoked
     *this += std::move(autoFilter);
-    return Wait(cv, Decompose<decltype(&Fx::operator())>::template Enumerate<AutoFilterDescriptorInput, AutoFilterDescriptorInputT>::types, duration);
+    return Wait(cv, Decompose<decltype(&Fx::operator())>::template Enumerate<AutoFilterArgument, AutoFilterArgumentT>::types, duration);
   }
 
   /// <summary>
@@ -575,9 +575,9 @@ public:
   template<class... Decorations>
   bool Wait(std::condition_variable& cv)
   {
-    static const AutoFilterDescriptorInput inputs [] = {
+    static const AutoFilterArgument inputs [] = {
       static_cast<auto_arg<Decorations>*>(nullptr)...,
-      AutoFilterDescriptorInput()
+      AutoFilterArgument()
     };
 
     return Wait(cv, inputs, std::chrono::nanoseconds::max());
@@ -589,9 +589,9 @@ public:
   template<class... Args>
   bool Wait(std::chrono::nanoseconds duration, std::condition_variable& cv)
   {
-    static const AutoFilterDescriptorInput inputs [] = {
-      AutoFilterDescriptorInputT<Args>()...,
-      AutoFilterDescriptorInput()
+    static const AutoFilterArgument inputs [] = {
+      AutoFilterArgumentT<Args>()...,
+      AutoFilterArgument()
     };
 
     return Wait(cv, inputs, duration);

--- a/src/autonet/AutoNetServerImpl.cpp
+++ b/src/autonet/AutoNetServerImpl.cpp
@@ -226,7 +226,7 @@ void AutoNetServerImpl::NewObject(CoreContext& ctxt, const CoreObjectDescriptor&
     // Check if type implements an AutoFilter
     if (!object.subscriber.empty()) {
       Json::object args;
-      for (auto pArg = object.subscriber.GetAutoFilterInput(); *pArg; ++pArg) {
+      for (auto pArg = object.subscriber.GetAutoFilterArguments(); *pArg; ++pArg) {
         args[autowiring::demangle(pArg->ti)] = Json::object{
           {"id", autowiring::demangle(pArg->ti)},
           {"isInput", pArg->is_input},

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -413,7 +413,7 @@ std::shared_ptr<CoreContext> AutoPacket::GetContext(void) const {
   return m_parentFactory->GetContext();
 }
 
-bool AutoPacket::Wait(std::condition_variable& cv, const AutoFilterDescriptorInput* inputs, std::chrono::nanoseconds duration) {
+bool AutoPacket::Wait(std::condition_variable& cv, const AutoFilterArgument* inputs, std::chrono::nanoseconds duration) {
   auto stub = std::make_shared<SignalStub>(*this, cv);
 
   // This ad-hoc filter detects when all the requested decorations have been added, and then

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -76,7 +76,7 @@ DecorationDisposition& AutoPacket::DecorateImmediateUnsafe(const DecorationKey& 
 }
 
 void AutoPacket::AddSatCounterUnsafe(SatCounter& satCounter) {
-  for(auto pCur = satCounter.GetAutoFilterInput(); *pCur; pCur++) {
+  for(auto pCur = satCounter.GetAutoFilterArguments(); *pCur; pCur++) {
     DecorationKey key(*pCur->ti, pCur->is_shared, pCur->tshift);
     DecorationDisposition& entry = m_decorations[key];
 
@@ -101,7 +101,7 @@ void AutoPacket::AddSatCounterUnsafe(SatCounter& satCounter) {
     if (pCur->is_output) {
       if(!entry.m_publishers.empty())
         for (SatCounter* subscriber : entry.m_subscribers)
-          for(auto pOther = subscriber->GetAutoFilterInput(); *pOther; pOther++)
+          for(auto pOther = subscriber->GetAutoFilterArguments(); *pOther; pOther++)
             if (!pOther->is_multi) {
               std::stringstream ss;
               ss << "Added identical data broadcasts of type " << autowiring::demangle(pCur->ti) << " with existing subscriber.";

--- a/src/autowiring/AutoPacketGraph.cpp
+++ b/src/autowiring/AutoPacketGraph.cpp
@@ -34,7 +34,7 @@ void AutoPacketGraph::LoadEdges() {
   m_factory->AppendAutoFiltersTo(descriptors);
   
   for (auto& descriptor : descriptors) {
-    for(auto pCur = descriptor.GetAutoFilterInput(); *pCur; pCur++) {
+    for(auto pCur = descriptor.GetAutoFilterArguments(); *pCur; pCur++) {
       const std::type_info& type_info = *pCur->ti;
       
       // Skip the AutoPacketGraph

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -27,7 +27,7 @@ set(Autowiring_SRCS
   AutoConfigParser.cpp
   AutoConfigParser.hpp
   AutoFilterDescriptor.h
-  AutoFilterDescriptorInput.h
+  AutoFilterArgument.h
   AutoFuture.cpp
   AutoFuture.h
   AutoInjectable.cpp

--- a/src/autowiring/test/AutoFilterMultiDecorateTest.cpp
+++ b/src/autowiring/test/AutoFilterMultiDecorateTest.cpp
@@ -20,7 +20,7 @@ TEST_F(AutoFilterMultiDecorateTest, EnumerateDecorationsTest) {
   AutoFilterDescriptor desc(sample);
 
   size_t i = 0;
-  for (auto* pCur = desc.GetAutoFilterInput(); *pCur; pCur++)
+  for (auto* pCur = desc.GetAutoFilterArguments(); *pCur; pCur++)
     i++;
 
   ASSERT_EQ(1, i) << "AutoFilterDescriptor parsed an incorrect number of arguments from a lambda";

--- a/src/autowiring/test/DecoratorTest.cpp
+++ b/src/autowiring/test/DecoratorTest.cpp
@@ -23,7 +23,7 @@ TEST_F(DecoratorTest, VerifyCorrectExtraction) {
   // Run our prop extractor based on a known decorator:
   AutoRequired<FilterA> filterA;
   AutoFilterDescriptor desc(static_cast<std::shared_ptr<FilterA>&>(filterA));
-  for(const AutoFilterDescriptorInput* cur = desc.GetAutoFilterArguments(); *cur; cur++)
+  for(const AutoFilterArgument* cur = desc.GetAutoFilterArguments(); *cur; cur++)
     v.push_back(cur->ti);
   ASSERT_EQ(2UL, v.size()) << "Extracted an insufficient number of types from a known filter function";
 
@@ -36,7 +36,7 @@ TEST_F(DecoratorTest, VerifyEmptyExtraction) {
   auto obj = std::make_shared<CoreObject>();
 
   // Should be possible to obtain this value and have it remain valid even after the descriptor is gone
-  const AutoFilterDescriptorInput* v = MakeAutoFilterDescriptor(obj).GetAutoFilterArguments();
+  const AutoFilterArgument* v = MakeAutoFilterDescriptor(obj).GetAutoFilterArguments();
   ASSERT_EQ(nullptr, v) << "Extracted arguments from an object known not to have a Filter method";
 }
 

--- a/src/autowiring/test/DecoratorTest.cpp
+++ b/src/autowiring/test/DecoratorTest.cpp
@@ -23,7 +23,7 @@ TEST_F(DecoratorTest, VerifyCorrectExtraction) {
   // Run our prop extractor based on a known decorator:
   AutoRequired<FilterA> filterA;
   AutoFilterDescriptor desc(static_cast<std::shared_ptr<FilterA>&>(filterA));
-  for(const AutoFilterDescriptorInput* cur = desc.GetAutoFilterInput(); *cur; cur++)
+  for(const AutoFilterDescriptorInput* cur = desc.GetAutoFilterArguments(); *cur; cur++)
     v.push_back(cur->ti);
   ASSERT_EQ(2UL, v.size()) << "Extracted an insufficient number of types from a known filter function";
 
@@ -36,7 +36,7 @@ TEST_F(DecoratorTest, VerifyEmptyExtraction) {
   auto obj = std::make_shared<CoreObject>();
 
   // Should be possible to obtain this value and have it remain valid even after the descriptor is gone
-  const AutoFilterDescriptorInput* v = MakeAutoFilterDescriptor(obj).GetAutoFilterInput();
+  const AutoFilterDescriptorInput* v = MakeAutoFilterDescriptor(obj).GetAutoFilterArguments();
   ASSERT_EQ(nullptr, v) << "Extracted arguments from an object known not to have a Filter method";
 }
 


### PR DESCRIPTION
Original name is misleading, this function actually returns all arguments to the underlying AutoFilter, not just its inputs