### PR TITLE
Deny T* as an AutoFilter argument.

### DIFF
--- a/autowiring/auto_arg.h
+++ b/autowiring/auto_arg.h
@@ -84,6 +84,29 @@ public:
 };
 
 /// <summary>
+/// Specialization for "T*" ~ auto_in<T*>.  T must be const-qualified in order to be an input parameter.
+/// </summary>
+template<class T>
+class auto_arg<T*>
+{
+public:
+  static_assert(std::is_const<T>::value, "Pointer-typed input parameters must point to a const-qualified type (T must be const-qualified)");
+  typedef T* type;
+  typedef T* arg_type;
+  typedef auto_id<T*> id_type;
+  static const bool is_input = true;
+  static const bool is_output = false;
+  static const bool is_shared = false;
+  static const bool is_multi = false;
+  static const int tshift = 0;
+
+  template<class C>
+  static const T* arg(C& packet) {
+    return packet.template Get<const T*>();
+  }
+};
+
+/// <summary>
 /// Specialization for equivalent T auto_in<T>
 /// </summary>
 template<class T>


### PR DESCRIPTION
Added a specialization for `T*` in `auto_arg` which requires (via `static_assert`) that `T` is const-qualified.  This is required for input semantics.  `T*` is not allowed as an output parameter.