### PR TITLE
Eliminate is_shared from DecorationKey

### DIFF
--- a/src/autowiring/AutoPacketGraph.cpp
+++ b/src/autowiring/AutoPacketGraph.cpp
@@ -84,22 +84,18 @@ void AutoPacketGraph::AutoFilter(AutoPacket& packet) {
       auto& decoration = cur.second;
       auto type = cur.first.ti;
 
-      for (auto& publisher : decoration.m_publishers) {
-        if (!publisher->remaining) {
+      for (auto& publisher : decoration.m_publishers)
+        if (!publisher->remaining)
           RecordDelivery(type, *publisher, false);
-        }
-      }
 
       for (auto& subscriber : decoration.m_subscribers) {
         // Skip the AutoPacketGraph
-        const std::type_info& descType = m_factory->GetContext()->GetAutoTypeId(subscriber->GetAutoFilter());
-        if (descType == typeid(AutoPacketGraph)) {
+        const std::type_info& descType = m_factory->GetContext()->GetAutoTypeId(subscriber.satCounter->GetAutoFilter());
+        if (descType == typeid(AutoPacketGraph))
           continue;
-        }
         
-        if (subscriber->remaining) {
-          RecordDelivery(type, *subscriber, true);
-        }
+        if (subscriber.satCounter->remaining)
+          RecordDelivery(type, *subscriber.satCounter, true);
       }
     }
   });

--- a/src/autowiring/AutoPacketInternal.cpp
+++ b/src/autowiring/AutoPacketInternal.cpp
@@ -47,17 +47,15 @@ void AutoPacketInternal::Initialize(bool isFirstPacket) {
     call->GetCall()(call->GetAutoFilter(), *this);
 
   // First-call indicated by argumument type AutoPacket&:
-  for (bool is_shared : {false, true}) {
-    std::unique_lock<std::mutex> lk(m_lock);
+  std::unique_lock<std::mutex> lk(m_lock);
 
-    // Don't modify the decorations set if nobody expects an AutoPacket input
-    auto q = m_decorations.find(DecorationKey(typeid(auto_arg<AutoPacket&>::id_type), is_shared, 0));
-    if (q == m_decorations.end())
-      continue;
+  // Don't modify the decorations set if nobody expects an AutoPacket input
+  auto q = m_decorations.find(DecorationKey(typeid(auto_arg<AutoPacket&>::id_type), 0));
+  if (q == m_decorations.end())
+    return;
 
-    q->second.m_state = DispositionState::Satisfied;
-    UpdateSatisfactionUnsafe(std::move(lk), q->second);
-  }
+  q->second.m_state = DispositionState::Satisfied;
+  UpdateSatisfactionUnsafe(std::move(lk), q->second);
 }
 
 std::shared_ptr<AutoPacketInternal> AutoPacketInternal::SuccessorInternal(void) {

--- a/src/autowiring/test/ArgumentTypeTest.cpp
+++ b/src/autowiring/test/ArgumentTypeTest.cpp
@@ -87,7 +87,7 @@ TEST_F(ArgumentTypeTest, TestAutoIn) {
 
   // Deduced Type
   const auto& arg = t_argShared::arg(*packet);
-  ASSERT_EQ(2UL, arg.use_count()) << "AutoPacket should store exactly two shared pointer references";
+  ASSERT_EQ(1UL, arg.use_count()) << "AutoPacket should store exactly one shared pointer reference to a decorated entry";
 }
 
 TEST_F(ArgumentTypeTest, TestAutoOut) {

--- a/src/autowiring/test/AutoFilterDiagnosticsTest.cpp
+++ b/src/autowiring/test/AutoFilterDiagnosticsTest.cpp
@@ -28,7 +28,7 @@ TEST_F(AutoFilterDiagnosticsTest, CanGetExpectedTrueType) {
   auto& disposition = decorations.begin()->second;
   ASSERT_EQ(1UL, disposition.m_subscribers.size()) << "Expected exactly one subscriber for the sole present type";
 
-  const SatCounter* descriptor = disposition.m_subscribers.front();
+  const SatCounter* descriptor = disposition.m_subscribers.front().satCounter;
   AnySharedPointer asp(descriptor->GetAutoFilter());
 
   // Get more information about this object from the enclosing context:


### PR DESCRIPTION
This variable being present here prevents proper accumulation of multidecorate values and makes it harder to understand what's going on.  Centralize the behavior and make use of trait properties when deciding whether a filter should be called.