### PR TITLE
Correct potential memory smasher in GetAll

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -315,20 +315,24 @@ public:
   std::unique_ptr<const T*[]> GetAll(int tshift = 0) const {
     std::lock_guard<std::mutex> lk(m_lock);
     auto q = m_decorations.find(DecorationKey(auto_id<T>::key(), tshift));
+    std::unique_ptr<const T*[]> retVal;
 
     // If decoration doesn't exist, return empty null-terminated buffer
     if (q == m_decorations.end()) {
-      const T** retVal = new const T*[1];
+      retVal.reset(new const T*[1]);
       retVal[0] = nullptr;
-      return std::unique_ptr<const T*[]>{retVal};
+      return retVal;
     }
 
     const auto& decorations = q->second.m_decorations;
-    const T** retVal = new const T*[decorations.size() + 1];
+    retVal.reset(new const T*[decorations.size() + 1]);
+
     for (size_t i = 0; i < decorations.size(); i++)
       retVal[i] = static_cast<const T*>(decorations[i]->ptr());
+
     retVal[decorations.size()] = nullptr;
-    return std::unique_ptr<const T*[]>{retVal};
+
+    return retVal;
   }
 
   /// <summary>Shares all broadcast data from this packet with the recipient packet</summary>

--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -311,27 +311,24 @@ public:
   /// Returns a null-terminated temporary buffer containing all decorations
   /// </summary>
   /// <returns>The null-terminated temporary buffer</returns>
-  /// <remarks>
-  /// The returned buffer must be freed with std::return_temporary_buffer
-  /// </remarks>
   template<class T>
-  const T** GetAll(int tshift = 0) const {
+  std::unique_ptr<const T*> GetAll(int tshift = 0) const {
     std::lock_guard<std::mutex> lk(m_lock);
     auto q = m_decorations.find(DecorationKey(auto_id<T>::key(), tshift));
 
     // If decoration doesn't exist, return empty null-terminated buffer
     if (q == m_decorations.end()) {
-      const T** retVal = std::get_temporary_buffer<const T*>(1).first;
+      const T** retVal = new const T*[1];
       retVal[0] = nullptr;
-      return retVal;
+      return std::unique_ptr<const T*>{retVal};
     }
 
     const auto& decorations = q->second.m_decorations;
-    const T** retVal = std::get_temporary_buffer<const T*>(decorations.size() + 1).first;
+    const T** retVal = new const T*[decorations.size() + 1];
     for (size_t i = 0; i < decorations.size(); i++)
       retVal[i] = static_cast<const T*>(decorations[i]->ptr());
     retVal[decorations.size()] = nullptr;
-    return retVal;
+    return std::unique_ptr<const T*>{retVal};
   }
 
   /// <summary>Shares all broadcast data from this packet with the recipient packet</summary>

--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -312,7 +312,7 @@ public:
   /// </summary>
   /// <returns>The null-terminated temporary buffer</returns>
   template<class T>
-  std::unique_ptr<const T*> GetAll(int tshift = 0) const {
+  std::unique_ptr<const T*[]> GetAll(int tshift = 0) const {
     std::lock_guard<std::mutex> lk(m_lock);
     auto q = m_decorations.find(DecorationKey(auto_id<T>::key(), tshift));
 
@@ -320,7 +320,7 @@ public:
     if (q == m_decorations.end()) {
       const T** retVal = new const T*[1];
       retVal[0] = nullptr;
-      return std::unique_ptr<const T*>{retVal};
+      return std::unique_ptr<const T*[]>{retVal};
     }
 
     const auto& decorations = q->second.m_decorations;
@@ -328,7 +328,7 @@ public:
     for (size_t i = 0; i < decorations.size(); i++)
       retVal[i] = static_cast<const T*>(decorations[i]->ptr());
     retVal[decorations.size()] = nullptr;
-    return std::unique_ptr<const T*>{retVal};
+    return std::unique_ptr<const T*[]>{retVal};
   }
 
   /// <summary>Shares all broadcast data from this packet with the recipient packet</summary>

--- a/autowiring/auto_arg.h
+++ b/autowiring/auto_arg.h
@@ -163,7 +163,7 @@ class auto_arg<T&>
 {
 public:
   typedef std::shared_ptr<T> type;
-  
+
   // Utility type, required to dereference the std::shared_ptr
   struct arg_type {
     arg_type(std::shared_ptr<T>& arg) :
@@ -292,7 +292,7 @@ class auto_arg<T const **>
 public:
   typedef const T** arg_type;
   struct type {
-    explicit type(type&& rhs) :
+    type(type&& rhs) :
       ptr(std::move(rhs.ptr))
     {}
 

--- a/autowiring/auto_arg.h
+++ b/autowiring/auto_arg.h
@@ -296,11 +296,11 @@ public:
       ptr(std::move(rhs.ptr))
     {}
 
-    explicit type(std::unique_ptr<const T*>&& ptr) :
+    explicit type(std::unique_ptr<const T*[]>&& ptr) :
       ptr{std::move(ptr)}
     {}
 
-    std::unique_ptr<const T*> ptr;
+    std::unique_ptr<const T*[]> ptr;
 
     operator const T**(void) const { return ptr.get(); }
   };

--- a/autowiring/auto_arg.h
+++ b/autowiring/auto_arg.h
@@ -296,7 +296,7 @@ public:
       ptr(std::move(rhs.ptr))
     {}
 
-    explicit type(std::unique_ptr<const T*[]>&& ptr) :
+    explicit type(std::unique_ptr<const T*[]> ptr) :
       ptr{std::move(ptr)}
     {}
 

--- a/autowiring/auto_arg.h
+++ b/autowiring/auto_arg.h
@@ -290,21 +290,19 @@ template<class T>
 class auto_arg<T const **>
 {
 public:
-  typedef const T** type;
-
-  // Another compositional structure, used to coerce a vector to a data item
-  struct arg_type {
-    arg_type(const T** value) :
-      value(value)
+  typedef const T** arg_type;
+  struct type {
+    explicit type(type&& rhs) :
+      ptr(std::move(rhs.ptr))
     {}
 
-    ~arg_type(void) {
-      std::return_temporary_buffer(value);
-    }
+    explicit type(std::unique_ptr<const T*>&& ptr) :
+      ptr{std::move(ptr)}
+    {}
 
-    const T** value;
+    std::unique_ptr<const T*> ptr;
 
-    operator const T**(void) const { return value; }
+    operator const T**(void) const { return ptr.get(); }
   };
 
   typedef auto_id<T> id_type;
@@ -315,8 +313,8 @@ public:
   static const int tshift = 0;
 
   template<class C>
-  static const T** arg(C& packet) {
-    return packet.template GetAll<T>();
+  static type arg(C& packet) {
+    return type{packet.template GetAll<T>()};
   }
 };
 


### PR DESCRIPTION
`std::get_temporary_buffer` does not guarantee sufficient space for allocations in the same way that `new` does.  Use `new` here instead in order to ensure we do not smash memory during `GetAll`.