### PR TITLE
Fix multidecorate filter unsatisfiability case

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -283,7 +283,7 @@ public:
   bool Get(std::shared_ptr<const T>& out, int tshift = 0) const {
     std::lock_guard<std::mutex> lk(m_lock);
     auto deco = m_decorations.find(DecorationKey(auto_id<T>::key(), true, tshift));
-    if(deco != m_decorations.end() && deco->second.m_state == DispositionState::Satisfied) {
+    if(deco != m_decorations.end() && deco->second.m_state == DispositionState::Complete) {
       auto& disposition = deco->second;
       if(disposition.m_decorations.size() == 1) {
         out = disposition.m_decorations[0]->as_unsafe<T>();

--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -105,7 +105,7 @@ protected:
   /// This method results in a call to the AutoFilter method on any subscribers which are
   /// satisfied by this decoration.  This method must be called with m_lock held.
   /// </remarks>
-  void UpdateSatisfactionUnsafe(std::unique_lock<std::mutex>&& lk, const DecorationDisposition& disposition);
+  void UpdateSatisfactionUnsafe(std::unique_lock<std::mutex> lk, const DecorationDisposition& disposition);
 
   /// <summary>
   /// Performs a "satisfaction pulse", which will avoid notifying any deferred filters
@@ -177,7 +177,7 @@ public:
   t_decorationMap GetDecorations(void) const;
 
   /// <returns>
-  /// True if this packet posesses a decoration of the specified type
+  /// True if this packet posesses one or more instances of a decoration of the specified type
   /// </returns>
   /// <remarks>
   /// Although "AutoPacket &" and "const AutoPacket&" argument types will be
@@ -444,7 +444,7 @@ public:
       // IMPORTANT: isCheckedOut = true prevents subsequent decorations of this type
       for(DecorationDisposition*  pEntry : pTypeSubs) {
         pEntry->m_pImmediate = nullptr;
-        pEntry->m_state = DispositionState::Unsatisfiable;
+        pEntry->m_state = DispositionState::Complete;
       }
 
       // Now trigger a rescan to hit any deferred, unsatisfiable entries:

--- a/src/autowiring/test/AutoFilterMultiDecorateTest.cpp
+++ b/src/autowiring/test/AutoFilterMultiDecorateTest.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/CoreThread.h>
+#include "TestFixtures/Decoration.hpp"
 #include CHRONO_HEADER
 #include THREAD_HEADER
 
@@ -63,4 +64,37 @@ TEST_F(AutoFilterMultiDecorateTest, MultiPostHocIntroductionTest) {
   };
 
   ASSERT_EQ(3, called) << "Not all lambda functions were called as expected";
+}
+
+TEST_F(AutoFilterMultiDecorateTest, UnsatDecTest) {
+  AutoRequired<AutoPacketFactory> f;
+  *f += [] (const Decoration<0>&, std::string& out) {
+    out = "Hello";
+  };
+  *f += [](const Decoration<1>&, std::string& out) {
+    out = "World";
+  };
+  *f += [](const Decoration<2>&, std::string& out) {
+    out = "Crickets";
+  };
+  *f += [](const std::string* args[], int& val) {
+    for (val = 0; *args; args++, val++);
+  };
+
+  auto packet = f->NewPacket();
+  packet->Decorate(Decoration<0>{});
+  packet->Unsatisfiable<Decoration<1>>();
+  packet->Decorate(Decoration<2>{});
+
+  auto strs = packet->GetAll<std::string>();
+  ASSERT_NE(nullptr, strs) << "String datatype not found on multidecorate packet";
+  ASSERT_NE(nullptr, strs.get()[0]) << "No strings attached to a multidecorate packet as expected";
+  ASSERT_NE(nullptr, strs.get()[1]) << "Expected two strings back, got one";
+  ASSERT_EQ(nullptr, strs.get()[2]) << "Expected two strings back, got three";
+  ASSERT_EQ("Hello", *strs.get()[0]) << "Entry in multidecorate set was not the expected value";
+  ASSERT_EQ("Crickets", *strs.get()[1]) << "Entry in multidecorate set was not the expected value";
+
+  int nEntries;
+  ASSERT_NO_THROW(nEntries = packet->Get<int>()) << "Multidecorate filter was not run as expected";
+  ASSERT_EQ(2, nEntries) << "Mismatch of number of multi-decorate entries on the packet";
 }

--- a/src/autowiring/test/AutoFilterMultiDecorateTest.cpp
+++ b/src/autowiring/test/AutoFilterMultiDecorateTest.cpp
@@ -88,11 +88,11 @@ TEST_F(AutoFilterMultiDecorateTest, UnsatDecTest) {
 
   auto strs = packet->GetAll<std::string>();
   ASSERT_NE(nullptr, strs) << "String datatype not found on multidecorate packet";
-  ASSERT_NE(nullptr, strs.get()[0]) << "No strings attached to a multidecorate packet as expected";
-  ASSERT_NE(nullptr, strs.get()[1]) << "Expected two strings back, got one";
-  ASSERT_EQ(nullptr, strs.get()[2]) << "Expected two strings back, got three";
-  ASSERT_EQ("Hello", *strs.get()[0]) << "Entry in multidecorate set was not the expected value";
-  ASSERT_EQ("Crickets", *strs.get()[1]) << "Entry in multidecorate set was not the expected value";
+  ASSERT_NE(nullptr, strs[0]) << "No strings attached to a multidecorate packet as expected";
+  ASSERT_NE(nullptr, strs[1]) << "Expected two strings back, got one";
+  ASSERT_EQ(nullptr, strs[2]) << "Expected two strings back, got three";
+  ASSERT_EQ("Hello", *strs[0]) << "Entry in multidecorate set was not the expected value";
+  ASSERT_EQ("Crickets", *strs[1]) << "Entry in multidecorate set was not the expected value";
 
   int nEntries;
   ASSERT_NO_THROW(nEntries = packet->Get<int>()) << "Multidecorate filter was not run as expected";

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -230,14 +230,14 @@ TEST_F(AutoFilterTest, VerifyAntiDecorate) {
     // Obtain a new packet and mark an unsatisfiable decoration:
     auto packet = factory->NewPacket();
     packet->Unsatisfiable<Decoration<0>>();
-    ASSERT_ANY_THROW(packet->Decorate(Decoration<0>())) << "Decoration succeeded on a decoration marked unsatisfiable";
+    ASSERT_ANY_THROW(packet->Decorate(Decoration<0>())) << "Incorrectly allowed a decoration to be added to a packet when that decoration was unsatisfiable";
   }
 
   {
     // Obtain a new packet and try to make a satisfied decoration unsatisfiable.
     auto packet = factory->NewPacket();
     packet->Decorate(Decoration<0>());
-    ASSERT_ANY_THROW(packet->Unsatisfiable<Decoration<0>>()) << "Succeeded in marking an already-existing decoration as unsatisfiable";
+    ASSERT_NO_THROW(packet->Unsatisfiable<Decoration<0>>()) << "Failed to expunge a decoration from a packet";
   }
 }
 


### PR DESCRIPTION
Correct an issue where an unsatisfiable AutoFilter prevents multidecorate from running.  Issue corrected by tracking the number of producers run on a per-decoration basis separately from the number of decorations on the packet.