### PR TITLE
Fix valgrind error in AutoFilterConstructRulesTest.CorrectlyCallsCustomAllocator

### DIFF
--- a/src/autowiring/test/AutoFilterConstructRulesTest.cpp
+++ b/src/autowiring/test/AutoFilterConstructRulesTest.cpp
@@ -19,6 +19,10 @@ public:
     return pRetVal;
   }
 
+  static void operator delete(void* ptr) {
+    ::delete[] static_cast<uint8_t*>(ptr);
+  }
+
   uint8_t data[128];
 };
 bool HasCustomNewFunction::s_invoked = false;


### PR DESCRIPTION
valgrind was reporting the following error for the CorrectlyCallsCustomAllocator unit test :

    ==8925== Mismatched free() / delete / delete []

Since this class has a custom allocator, it should have a corresponding custom deallocator. A mere test issue, but keeping things valgrind-clean clears the way for spotting memory errors in other tests.