### PR TITLE
Fix an exception thrown when DecorateImmediate is used more than once

### DIFF
--- a/src/autowiring/test/AutoFilterSequencing.cpp
+++ b/src/autowiring/test/AutoFilterSequencing.cpp
@@ -337,3 +337,30 @@ TEST_F(AutoFilterSequencing, PathologicalAsync) {
 
   ASSERT_TRUE(filter->success) << "AutoFilter inconsistency detected";
 }
+
+TEST_F(AutoFilterSequencing, UnsatisfiableImmediate) {
+  AutoCurrentContext ctxt;
+  ctxt->Initiate();
+  AutoRequired<AutoPacketFactory> factory;
+
+  size_t oneInRunCt = 0;
+  size_t twoInRunCt = 0;
+
+  *factory += [&oneInRunCt](const Decoration<0>&, Decoration<4>&) {
+    oneInRunCt++;
+  };
+  *factory += [&twoInRunCt](const Decoration<0>&, const Decoration<1>&, const Decoration<4>&, Decoration<40>&) {
+    twoInRunCt++;
+  };
+
+  auto packet = factory->NewPacket();
+
+  // This should cause the first filter to be run:
+  packet->DecorateImmediate(Decoration<0>{});
+  ASSERT_NO_THROW(packet->Get<Decoration<4>>()) << "Single argument immediate filter was not run as expected";
+  ASSERT_EQ(1UL, oneInRunCt) << "Single argument filter not run the expected number of times";
+
+  // If we didn't use DecorateImmediate before, then this would normally cause the second filter to be run
+  ASSERT_EQ(0UL, twoInRunCt) << "A zero-argument immediate filter was incorrectly run";
+  ASSERT_NO_THROW(packet->DecorateImmediate(Decoration<1>{}));
+}


### PR DESCRIPTION
The exception is thrown when the second call to `AutoPacket::DecorateImmediate` would have satisfied the AutoFilter if the first call were made with `AutoPacket::Decorate` instead.  `AutoPacket` is not correctly detecting that the first call was transient, and is incorrectly attempting to make the AutoFilter call at the point of the second `Decorate` call.