### PR TITLE
Fix deprecation hole

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -249,9 +249,12 @@ public:
   /// This method will throw an exception if the requested decoration is multiply present on the packet
   /// </remarks>
   template<class T>
-  bool Get(const std::shared_ptr<const T>*& out, int tshift=0) const {
+  bool Get(const std::shared_ptr<T>*& out, int tshift=0) const {
+    static_assert(std::is_const<T>::value, "Cannot get a non-const shared pointer from AutoPacket, declare as `const std::shared_ptr<const T>*`");
+    typedef typename std::remove_const<T>::type TActual;
+
     // Decoration must be present and the shared pointer itself must also be present
-    DecorationKey key(auto_id<T>::key(), tshift);
+    DecorationKey key(auto_id<TActual>::key(), tshift);
     const DecorationDisposition* pDisposition = GetDisposition(key);
     if (!pDisposition) {
       out = nullptr;
@@ -264,7 +267,7 @@ public:
       return false;
     case 1:
       // Single decoration available, we can return here
-      out = &pDisposition->m_decorations[0]->as_unsafe<const T>();
+      out = &pDisposition->m_decorations[0]->as_unsafe<T>();
       return true;
     default:
       ThrowMultiplyDecoratedException(key);

--- a/src/autowiring/test/AutoPacketTest.cpp
+++ b/src/autowiring/test/AutoPacketTest.cpp
@@ -62,3 +62,11 @@ TEST_F(AutoPacketTest, MultipleDecorateGetFailures) {
     ASSERT_ANY_THROW(packet->Get(out));
   }
 }
+
+TEST_F(AutoPacketTest, AliasGet) {
+  auto packet = factory->NewPacket();
+  packet->Decorate(Decoration<0>{});
+
+  const std::shared_ptr<const Decoration<0>>* ptr;
+  ASSERT_TRUE(packet->Get(ptr)) << "Failed to find the shared pointer version of a trivial decoration on the packet";
+}


### PR DESCRIPTION
The non-const `std::shared_ptr` use pattern for `AutoPacket::Get` was deprecated in #543, creating a support hole.  Fix this lapse by adding a static assert to prevent the old use pattern from working.