### PR TITLE
Fix size conversion warnings in LeapBench

### DIFF
--- a/src/autowiring/benchmark/Benchmark.h
+++ b/src/autowiring/benchmark/Benchmark.h
@@ -12,7 +12,7 @@ struct Stopwatch {
   void Stop(size_t n) {
     auto stop = std::chrono::profiling_clock::now();
     std::chrono::duration<double> delta = stop - start;
-    duration += delta / n;
+    duration += delta / static_cast<double>(n);
   }
 
 private:

--- a/src/autowiring/benchmark/DispatchQueueBm.cpp
+++ b/src/autowiring/benchmark/DispatchQueueBm.cpp
@@ -38,7 +38,7 @@ Benchmark DispatchQueueBm::Dispatch(void) {
           }
         );
 
-        int x = 0;
+        size_t x = 0;
         std::string s = "Hello world";
         auto l = [&x, s] { x += s.length(); };
 
@@ -62,7 +62,7 @@ Benchmark DispatchQueueBm::Dispatch(void) {
         AutoRequired<CoreThread> ct;
         ctxt->Initiate();
 
-        int x = 0;
+        size_t x = 0;
         std::string s = "Hello world";
         auto l = [&x, s] { x += s.length(); };
 


### PR DESCRIPTION
This is making 64 bit build annoying.  Simple enough to resolve.