### PR TITLE
General unit test cleanup

### DIFF
--- a/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
+++ b/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
@@ -118,24 +118,14 @@ TEST_F(AutoFilterCollapseRulesTest, SharedPointerAliasingRules) {
   ASSERT_TRUE(gen2Called) << "AutoFilter accepting a decorated type was not called as expected";
 }
 
-class ProducesSharedPointer {
-public:
-  ProducesSharedPointer(void) :
-    m_called(0)
-  {}
-
-  int m_called;
-
-  void AutoFilter(std::shared_ptr<int>& output) {
-    ++m_called;
-    output = std::make_shared<int>(55);
-  }
-};
-
 TEST_F(AutoFilterCollapseRulesTest, AutoFilterSharedAliasingRules) {
-  AutoRequired<ProducesSharedPointer> produces;
   AutoRequired<FilterGen<int>> consumes;
   AutoRequired<AutoPacketFactory> factory;
+
+  *factory += [&](std::shared_ptr<int>& output) {
+    output = std::make_shared<int>(55);
+  };
+  *factory += [&](int) {};
 
   // Decorate the packet, verify attribute presence:
   auto packet = factory->NewPacket();

--- a/src/autowiring/test/AutoFilterSequencing.cpp
+++ b/src/autowiring/test/AutoFilterSequencing.cpp
@@ -16,13 +16,8 @@ public:
 
 class FilterFirst {
 public:
-  FilterFirst(void) :
-    m_magic(0xDEADBEEF),
-    m_called(0)
-  {}
-
-  const int m_magic;
-  int m_called;
+  const int m_magic = 0xDEADBEEF;
+  int m_called = 0;
 
   void AutoFilter(AutoPacket& pkt) {
     ASSERT_EQ(0xDEADBEEF, m_magic) << "Magic value was corrupted, pointer was not adjusted to the correct offset";
@@ -132,15 +127,9 @@ TEST_F(AutoFilterSequencing, ManySuccessors) {
 
 class PrevFilter {
 public:
-  PrevFilter(void):
-    m_prev_value(-1),
-    m_called(0),
-    m_num_empty_prev(0)
-  {}
-  
-  int m_prev_value;
-  int m_called;
-  int m_num_empty_prev;
+  int m_prev_value = -1;
+  int m_called = 0;
+  int m_num_empty_prev = 0;
   
   void AutoFilter(int current, auto_prev<int> prev) {
     ++m_called;
@@ -191,15 +180,11 @@ TEST_F(AutoFilterSequencing, UnsatisfiedPrev) {
 }
 
 struct OnlyPrev {
-  OnlyPrev():
-    m_called(0)
-  {}
-  
   void AutoFilter(auto_prev<int> p) {
     ++m_called;
   }
   
-  int m_called;
+  int m_called = 0;
 };
 
 TEST_F(AutoFilterSequencing, OnlyPrev) {
@@ -236,16 +221,12 @@ class DeferredPrev:
   public CoreThread
 {
 public:
-  DeferredPrev(void):
-    m_called(0)
-  {}
-  
   Deferred AutoFilter(auto_prev<int> prev) {
     ++m_called;
     return Deferred(this);
   }
   
-  int m_called;
+  int m_called = 0;
 };
 
 TEST_F(AutoFilterSequencing, DeferredPrev) {
@@ -264,17 +245,10 @@ TEST_F(AutoFilterSequencing, DeferredPrev) {
 
 class PrevPrevFilter {
 public:
-  PrevPrevFilter(void):
-    m_prev_prev_value(-1),
-    m_prev_value(-1),
-    m_called(0),
-    m_num_empty_prev(0)
-  {}
-
-  int m_prev_prev_value;
-  int m_prev_value;
-  int m_called;
-  int m_num_empty_prev;
+  int m_prev_prev_value = -1;
+  int m_prev_value = -1;
+  int m_called = 0;
+  int m_num_empty_prev = 0;
 
   void AutoFilter(int current, auto_prev<int, 2> prev) {
     ++m_called;

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -81,16 +81,12 @@ TEST_F(AutoFilterTest, VerifyTypeUsage) {
   ASSERT_EQ(2, filterA->m_one.i) << "AutoFilter was called using derived type instead of parent";
 }
 
-class FilterOut {
-public:
-  void AutoFilter(auto_out<Decoration<0>> out) {
-    out->i = 1;
-  }
-};
-
 TEST_F(AutoFilterTest, VerifyAutoOut) {
   AutoRequired<AutoPacketFactory> factory;
-  AutoRequired<FilterOut> out;
+
+  *factory += [](auto_out<Decoration<0>> out) {
+    out->i = 1;
+  };
 
   std::shared_ptr<AutoPacket> packet = factory->NewPacket();
   const Decoration<0>* result0 = nullptr;
@@ -98,18 +94,15 @@ TEST_F(AutoFilterTest, VerifyAutoOut) {
   ASSERT_EQ(result0->i, 1) << "Output incorrect";
 }
 
-class FilterOutPooled {
-  ObjectPool<Decoration<0>> m_pool;
-public:
-  void AutoFilter(auto_out<Decoration<0>> out) {
-    out = m_pool();
-    out-> i = 1;
-  }
-};
-
 TEST_F(AutoFilterTest, VerifyAutoOutPooled) {
   AutoRequired<AutoPacketFactory> factory;
-  AutoRequired<FilterOutPooled> out;
+  ObjectPool<Decoration<0>> pool;
+
+  *factory += [&](auto_out<Decoration<0>> out) {
+    out = pool();
+    out->i = 1;
+  };
+
   std::shared_ptr<AutoPacket> packet = factory->NewPacket();
   const Decoration<0>* result0 = nullptr;
   ASSERT_TRUE(packet->Get(result0)) << "Output missing";
@@ -320,73 +313,40 @@ TEST_F(AutoFilterTest, VerifyReferenceBasedInput) {
   }
 }
 
-class DeferredAutoFilter:
-  public CoreThread
-{
-public:
-  DeferredAutoFilter(void) :
-    nReceived(0)
-  {}
-
-  Deferred AutoFilter(AutoPacket&, const Decoration<0>&) {
-    // First packet is always delayed, this allows the dispatch queue to fill
-    // up with packets, and triggers typical rundown behavior
-    if(!nReceived)
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
-    nReceived++;
-    return Deferred(this);
-  }
-
-  size_t nReceived;
-};
-
-class HasAWeirdAutoFilterMethod {
-public:
-  HasAWeirdAutoFilterMethod(void):
-    m_baseValue(101),
-    m_called0(0),
-    m_called1(0)
-  {
-    *factory += [this] {
-      ASSERT_EQ(101, m_baseValue) << "AutoFilter entry base offset incorrectly computed";
-      ++m_called1;
-    };
-  }
-
-  void AutoFilter(Decoration<0>) {
-    ASSERT_EQ(101, m_baseValue) << "AutoFilter entry base offset incorrectly computed";
-    ++m_called0;
-  }
-
+TEST_F(AutoFilterTest, ZeroArgumentAutoFilter) {
   AutoRequired<AutoPacketFactory> factory;
-  const int m_baseValue;
-  int m_called0;
-  int m_called1;
-};
 
-TEST_F(AutoFilterTest, AnyAutoFilter) {
-  AutoRequired<HasAWeirdAutoFilterMethod> t;
+  int called1 = 0;
+  *factory += [&] { called1++; };
+  factory->NewPacket();
+
+  ASSERT_EQ(1, called1) << "Zero-argument AutoFilter method was not invoked as expected";
+}
+
+TEST_F(AutoFilterTest, ByValueDecoration) {
   AutoRequired<AutoPacketFactory> factory;
+
+  int called0 = 0;
+  int value = 101;
+  *factory += [&called0, value](Decoration<0>) {
+    // Check to ensure that the value was transferred in correctly
+    ASSERT_EQ(101, value) << "AutoFilter entry base offset incorrectly computed";
+    ++called0;
+  };
+
   auto packet = factory->NewPacket();
-
   packet->Decorate(Decoration<0>());
-  ASSERT_TRUE(t->m_called0 == 1) << "Root AutoFilter method was not invoked as expected";
-  ASSERT_TRUE(t->m_called1 == 1) << "Custom AutoFilter method was not invoked as expected";
+  ASSERT_EQ(1, called0) << "Root AutoFilter method was not invoked as expected";
 }
 
 class SimpleIntegerFilter
 {
 public:
-  SimpleIntegerFilter(void) :
-    hit(false)
-  {}
-
   void AutoFilter(int val) {
     hit = true;
   }
 
-  bool hit;
+  bool hit = false;
 };
 
 class DeferredIntegerFilter:
@@ -394,8 +354,7 @@ class DeferredIntegerFilter:
 {
 public:
   DeferredIntegerFilter(void) :
-    CoreThread("DeferredIntegerFilter"),
-    hit(false)
+    CoreThread("DeferredIntegerFilter")
   {}
 
   Deferred AutoFilter(int val) {
@@ -403,7 +362,7 @@ public:
     return Deferred(this);
   }
 
-  bool hit;
+  bool hit = false;
 };
 
 TEST_F(AutoFilterTest, SingleImmediate) {
@@ -450,11 +409,10 @@ class DoesNothingWithSharedPointer:
 {
 public:
   DoesNothingWithSharedPointer(void):
-    CoreThread("DoesNothingWithSharedPointer"),
-    callCount(0)
+    CoreThread("DoesNothingWithSharedPointer")
   {}
 
-  size_t callCount;
+  size_t callCount = 0;
 
   Deferred AutoFilter(std::shared_ptr<const int>) {
     callCount++;
@@ -752,16 +710,12 @@ TEST_F(AutoFilterTest, PacketTeardownNotificationCheck) {
 struct ContextChecker:
   ContextMember
 {
-  ContextChecker(void):
-    m_called(0)
-  {}
-
   void AutoFilter(int i) {
     ++m_called;
     ASSERT_EQ(AutoCurrentContext(), GetContext()) << "AutoFilter not called with the current context set to packet's context";
   }
 
-  int m_called;
+  int m_called = 0;
 };
 
 TEST_F(AutoFilterTest, CurrentContextCheck) {

--- a/src/autowiring/test/AutoPacketFactoryTest.cpp
+++ b/src/autowiring/test/AutoPacketFactoryTest.cpp
@@ -31,9 +31,7 @@ class IssuesPacketWaitsThenQuits:
   public CoreThread
 {
 public:
-  IssuesPacketWaitsThenQuits(void) :
-    m_hasQuit(false)
-  {
+  IssuesPacketWaitsThenQuits(void) {
     // Note:  Don't do this in practice.  This only works because we only inject this type
     // into a context that's already running; normally, creating a packet from our ctor can
     // cause an exception if we are being injected before Initiate is called.
@@ -41,7 +39,7 @@ public:
     m_packet = factory->NewPacket();
   }
 
-  bool m_hasQuit;
+  bool m_hasQuit = false;
   std::shared_ptr<AutoPacket> m_packet;
 
   void Run(void) override {
@@ -80,12 +78,8 @@ TEST_F(AutoPacketFactoryTest, WaitRunsDownAllPackets) {
 
 class HoldsAutoPacketFactoryReference {
 public:
-  HoldsAutoPacketFactoryReference(void):
-    m_value(0)
-  {}
-
   AutoRequired<AutoPacketFactory> m_factory;
-  int m_value;
+  int m_value = 0;
 
   // Just a dummy AutoFilter method so that this class is recognized as an AutoFilter
   void AutoFilter(int value) {
@@ -143,8 +137,6 @@ TEST_F(AutoPacketFactoryTest, AutoPacketFactoryCycle) {
 
 class DelaysAutoPacketsOneMS {
 public:
-  DelaysAutoPacketsOneMS(void) {}
-
   void AutoFilter(int value) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }

--- a/src/autowiring/test/AutoRestarterTest.cpp
+++ b/src/autowiring/test/AutoRestarterTest.cpp
@@ -13,18 +13,13 @@ class CreationDetectionBolt:
   public Bolt<RestartingSigil>
 {
 public:
-  CreationDetectionBolt(void):
-    nContextsCreated(0),
-    called(false)
-  {}
-
   void ContextCreated(void) override {
     called = true;
     nContextsCreated++;
   }
 
-  size_t nContextsCreated;
-  bool called;
+  size_t nContextsCreated = 0;
+  bool called = false;
 };
 
 class ThrowsAnExceptionFirstTime:

--- a/src/autowiring/test/AutoSignalTest.cpp
+++ b/src/autowiring/test/AutoSignalTest.cpp
@@ -76,9 +76,9 @@ TEST_F(AutoSignalTest, SignalWithAutowiring) {
   ASSERT_FALSE(handler_called) << "A handler was unexpectedly called after it should have been destroyed";
 }
 
-struct RaisesASignalDerived : public RaisesASignal {
-
-};
+struct RaisesASignalDerived:
+  public RaisesASignal
+{};
 
 TEST_F(AutoSignalTest, SignalWithAutowiringDerived) {
   bool handler_called = false;
@@ -118,7 +118,7 @@ TEST_F(AutoSignalTest, SignalWithAutowiringDerived) {
 }
 
 struct ContainsRaises {
-  ContainsRaises() : count(0) {
+  ContainsRaises(void) {
     ras(&RaisesASignal::signal) += [this](int v) {
       count++;
     };
@@ -129,7 +129,7 @@ struct ContainsRaises {
     i++;
   }
   Autowired<RaisesASignal> ras;
-  int count;
+  int count = 0;
 };
 
 TEST_F(AutoSignalTest, ConstructorAutowiredRegistration) {

--- a/src/autowiring/test/BasicThreadTest.cpp
+++ b/src/autowiring/test/BasicThreadTest.cpp
@@ -12,13 +12,12 @@ class SpinsAndThenQuits:
 public:
   SpinsAndThenQuits(size_t spinCount) :
     BasicThread("SpinsAndThenQuits"),
-    m_spinCount(spinCount),
-    m_continue(false)
+    m_spinCount(spinCount)
   {}
 
   volatile size_t m_spinCount;
 
-  bool m_continue;
+  bool m_continue = false;
   std::condition_variable m_signal;
 
   std::chrono::milliseconds m_kernelTime;

--- a/src/autowiring/test/BoltTest.cpp
+++ b/src/autowiring/test/BoltTest.cpp
@@ -18,11 +18,7 @@ class Listener:
   public Bolt<Pipeline>
 {
 public:
-  Listener(void):
-    hit(false)
-  {}
-
-  bool hit;
+  bool hit = false;
 
   std::shared_ptr<CoreContext> createdContext;
 
@@ -59,27 +55,19 @@ public:
 struct CountObject:
   ContextMember
 {
-  CountObject():
-    count(0)
-  {}
-
-  int count;
+  int count = 0;
 };
 
 class InjectsIntoEverything:
   public Bolt<>
 {
 public:
-  InjectsIntoEverything():
-    count(0)
-  {}
-
   void ContextCreated(void) override {
     AutoRequired<CountObject> derp;
     (derp->count)++;
   }
 
-  int count;
+  int count = 0;
 };
 
 TEST_F(BoltTest, VerifySimpleInjection) {

--- a/src/autowiring/test/ContextCleanupTest.cpp
+++ b/src/autowiring/test/ContextCleanupTest.cpp
@@ -129,15 +129,11 @@ class ReceivesTeardownNotice:
   public ContextMember
 {
 public:
-  ReceivesTeardownNotice(void) :
-    m_notified(false)
-  {}
-
   void NotifyContextTeardown(void) override {
     m_notified = true;
   }
 
-  bool m_notified;
+  bool m_notified = false;
 };
 
 TEST_F(ContextCleanupTest, VerifyGracefulThreadCleanup) {
@@ -200,11 +196,7 @@ class TakesALongTimeToExit:
   public CoreThread
 {
 public:
-  TakesALongTimeToExit(void) :
-    m_canContinue(false)
-  {}
-
-  bool m_canContinue;
+  bool m_canContinue = false;
 
   void Continue(void) {
     PerformStatusUpdate([this] {m_canContinue = true; });

--- a/src/autowiring/test/ContextCreatorTest.cpp
+++ b/src/autowiring/test/ContextCreatorTest.cpp
@@ -20,11 +20,7 @@ class VoidCreator:
   public ContextCreator<EvictionContext>
 {
 public:
-  VoidCreator(void):
-    m_totalDestroyed(0)
-  {}
-
-  size_t m_totalDestroyed;
+  size_t m_totalDestroyed = 0;
 
   void NotifyContextDestroyed(t_callbackHandle q, CoreContext* pContext) override {
     m_totalDestroyed++;
@@ -34,13 +30,9 @@ public:
 
 class GlobalSignal {
 public:
-  GlobalSignal(void):
-    m_shouldContinue(false)
-  {}
-
 private:
   std::mutex m_lock;
-  bool m_shouldContinue;
+  bool m_shouldContinue = false;
   std::condition_variable s_continueCond;
 
 public:

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -155,15 +155,11 @@ class BoltThatChecksForAThread:
   public Bolt<PreBoltInjectionSigil>
 {
 public:
-  BoltThatChecksForAThread(void):
-    m_threadPresent(false)
-  {}
-
   void ContextCreated(void) override {
     m_threadPresent = Autowired<CoreThread>().IsAutowired();
   }
 
-  bool m_threadPresent;
+  bool m_threadPresent = false;
 };
 
 TEST_F(CoreContextTest, PreBoltInjection) {
@@ -184,16 +180,12 @@ class BoltThatTakesALongTimeToReturn:
   public Bolt<NoEnumerateBeforeBoltReturn>
 {
 public:
-  BoltThatTakesALongTimeToReturn(void) :
-    m_bDoneRunning(false)
-  {}
-
   void ContextCreated(void) override {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     m_bDoneRunning = true;
   }
 
-  bool m_bDoneRunning;
+  bool m_bDoneRunning = false;
 };
 
 TEST_F(CoreContextTest, NoEnumerateBeforeBoltReturn) {

--- a/src/autowiring/test/CoreJobTest.cpp
+++ b/src/autowiring/test/CoreJobTest.cpp
@@ -88,13 +88,8 @@ TEST_F(CoreJobTest, VerifyTeardown) {
 }
 
 struct SimpleListen{
-  SimpleListen():
-    m_flag(false)
-  {}
-
-  void SetFlag(){m_flag=true;}
-
-  bool m_flag;
+  void SetFlag(){ m_flag = true; }
+  bool m_flag = false;
 };
 
 TEST_F(CoreJobTest, VerifyNoEventReceivers){

--- a/src/autowiring/test/CoreThreadTest.cpp
+++ b/src/autowiring/test/CoreThreadTest.cpp
@@ -30,14 +30,8 @@ class SpamguardTest:
   public CoreThread
 {
 public:
-  SpamguardTest(void):
-    m_hit(false),
-    m_multiHit(false)
-  {
-  }
-
-  bool m_hit;
-  bool m_multiHit;
+  bool m_hit = false;
+  bool m_multiHit = false;
 
   void Run(void) override {
     if(m_hit) {
@@ -314,11 +308,7 @@ class WaitsALongTimeThenQuits:
   public CoreThread
 {
 public:
-  WaitsALongTimeThenQuits(void):
-    m_runExiting(false)
-  {}
-
-  bool m_runExiting;
+  bool m_runExiting = false;
 
   void Run(void) override {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -444,8 +434,7 @@ class BTOverridesOnStopHandler:
   public BasicThread
 {
 public:
-  BTOverridesOnStopHandler(void) : got_stopped(false) {}
-  bool got_stopped;
+  bool got_stopped = false;
 
   void Run(void) override {}
 
@@ -456,8 +445,7 @@ class CTOverridesOnStopHandler:
   public CoreThread
 {
 public:
-  CTOverridesOnStopHandler(void) : got_stopped(false) {}
-  bool got_stopped;
+  bool got_stopped = false;
   void OnStop(void) override { got_stopped = true; }
 };
 

--- a/src/autowiring/test/DtorCorrectnessTest.cpp
+++ b/src/autowiring/test/DtorCorrectnessTest.cpp
@@ -40,11 +40,10 @@ class MyCtorDtorListener:
 {
 public:
   MyCtorDtorListener(void):
-    CoreThread("MyCtorDtorListener"),
-    m_hitDeferred(false)
+    CoreThread("MyCtorDtorListener")
   {}
 
-  bool m_hitDeferred;
+  bool m_hitDeferred = false;
 
   virtual void DoFired(CtorDtorCopyCounter ctr) {}
 

--- a/src/autowiring/test/EventReceiverTest.cpp
+++ b/src/autowiring/test/EventReceiverTest.cpp
@@ -488,11 +488,7 @@ TEST_F(EventReceiverTest, EventChain){
 
 class HasAWeirdReturnType {
 public:
-  HasAWeirdReturnType(void) :
-    bCalled(false)
-  {}
-
-  bool bCalled;
+  bool bCalled = false;
 
   int FiredMethod(void) {
     bCalled = true;

--- a/src/autowiring/test/ExceptionFilterTest.cpp
+++ b/src/autowiring/test/ExceptionFilterTest.cpp
@@ -45,18 +45,10 @@ class GenericFilter:
   public ExceptionFilter
 {
 public:
-  GenericFilter(void):
-    m_hit(false),
-    m_specific(false),
-    m_generic(false),
-    m_fireSpecific(false)
-  {
-  }
-
-  bool m_hit;
-  bool m_specific;
-  bool m_generic;
-  bool m_fireSpecific;
+  bool m_hit = false;
+  bool m_specific = false;
+  bool m_generic = false;
+  bool m_fireSpecific = false;
 
   virtual void Filter(void) override {
     m_hit = true;

--- a/src/autowiring/test/GuardObjectTest.cpp
+++ b/src/autowiring/test/GuardObjectTest.cpp
@@ -8,10 +8,10 @@ public testing::Test
 {};
 
 class copy_count {
-  mutable int m_copy;
+  mutable int m_copy = 0;
 
 public:
-  copy_count(): m_copy(0) {}
+  copy_count() {}
 
   copy_count(const copy_count& source): m_copy(source.m_copy + 1) {
     source.m_copy = m_copy;

--- a/src/autowiring/test/MultiInheritTest.cpp
+++ b/src/autowiring/test/MultiInheritTest.cpp
@@ -11,11 +11,7 @@ class MultiInheritTest:
 
 class Shared {
 public:
-  Shared(void) {
-    m_i = 100;
-  }
-
-  int m_i;
+  int m_i = 100;
 };
 
 class Base {

--- a/src/autowiring/test/PostConstructTest.cpp
+++ b/src/autowiring/test/PostConstructTest.cpp
@@ -29,11 +29,7 @@ class A:
   public ContextMember
 {
 public:
-  A(void):
-    m_value(2)
-  {}
-
-  int m_value;
+  int m_value = 2;
 
   int GetValue(void) const {return m_value;}
 };
@@ -69,30 +65,28 @@ class Smarter:
   public ContextMember
 {
 public:
-  Smarter(void):
-    value(1)
+  Smarter(void)
   {
     m_a.NotifyWhenAutowired([this] () {
       this->value = m_a->GetValue();
     });
   }
 
-  int value;
+  int value = 1;
   Autowired<A> m_a;
 };
 
 class SmarterInterface
 {
 public:
-  SmarterInterface(void):
-    value(1)
+  SmarterInterface(void)
   {
     m_interface.NotifyWhenAutowired([this] () {
       this->value = m_interface->GetValue();
     });
   }
 
-  int value;
+  int value = 1;
   Autowired<Interface> m_interface;
 };
 
@@ -359,11 +353,6 @@ TEST_F(PostConstructTest, RecursiveNotificationPostConstruction) {
 struct ClassWithAutoInit:
   std::enable_shared_from_this<ClassWithAutoInit>
 {
-  ClassWithAutoInit(void) :
-    m_constructed(true),
-    m_postConstructed(false)
-  {}
-
   void AutoInit(void) {
     ASSERT_TRUE(m_constructed) << "A postconstruct routine was called BEFORE the corresponding constructor";
     m_postConstructed = true;
@@ -372,8 +361,8 @@ struct ClassWithAutoInit:
     ASSERT_EQ(this, myself.get()) << "Reflexive shared_from_this did not return a shared pointer to this as expected";
   }
 
-  bool m_constructed;
-  bool m_postConstructed;
+  bool m_constructed = true;
+  bool m_postConstructed = false;
 };
 
 static_assert(has_autoinit<ClassWithAutoInit>::value, "AutoInit-bearing class did not pass a static type check");

--- a/src/autowiring/test/SelfSelectingFixtureTest.cpp
+++ b/src/autowiring/test/SelfSelectingFixtureTest.cpp
@@ -20,15 +20,11 @@ class HitCountingBolt:
   public Bolt<SimpleLocalClass>
 {
 public:
-  HitCountingBolt(void):
-    m_hitCount(0)
-  {}
-
   void ContextCreated(void) override {
     m_hitCount++;
   }
 
-  size_t m_hitCount;
+  size_t m_hitCount = 0;
 };
 
 TEST_F(SelfSelectingFixtureTest, LocalFixtureTest) {

--- a/src/autowiring/test/SnoopTest.cpp
+++ b/src/autowiring/test/SnoopTest.cpp
@@ -17,13 +17,8 @@ class SnoopTestBase:
   public ContextMember
 {
 public:
-  SnoopTestBase(void):
-    m_simpleCall(false),
-    m_callCount(0)
-  {}
-
-  bool m_simpleCall;
-  int m_callCount;
+  bool m_simpleCall = false;
+  int m_callCount = 0;
 
   void SimpleCall(void) override {
     m_simpleCall = true;
@@ -62,10 +57,7 @@ class RemovesSelf:
     ctxt->RemoveSnooper(GetSelf<RemovesSelf>());
   }
 public:
-  RemovesSelf():
-    counter(0)
-  {};
-  int counter;
+  int counter = 0;
 };
 
 TEST_F(SnoopTest, VerifySimpleSnoop) {


### PR DESCRIPTION
Simplify some classes to lambda AutoFilters and use in-class initializers

This test construction is easier to follow as the whole element of the test is contained in one function and in-class initialization is used.  Refactor such cases where they appear.