### PR TITLE
Do not include Autowired.h wherever it can be avoided

### DIFF
--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "AutoPacket.h"
-#include "Autowired.h"
 #include "AutoPacketFactory.h"
 #include "AutoPacketInternal.hpp"
 #include "AutoPacketProfiler.h"

--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -1,10 +1,13 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "BasicThread.h"
-#include "Autowired.h"
 #include "autowiring_error.h"
 #include "BasicThreadStateBlock.h"
 #include "ContextEnumerator.h"
+#include "CoreContext.h"
+#include "CurrentContextPusher.h"
+#include "dispatch_aborted_exception.h"
+#include "GlobalCoreContext.h"
 #include "fast_pointer_cast.h"
 #include ATOMIC_HEADER
 
@@ -173,7 +176,7 @@ bool BasicThread::IsCompleted(void) const {
 }
 
 void BasicThread::ForceCoreThreadReidentify(void) {
-  for(const auto& ctxt : ContextEnumerator(AutoGlobalContext())) {
+  for(const auto& ctxt : ContextEnumerator(GlobalCoreContext::Get())) {
     for(const auto& thread : ctxt->CopyBasicThreadList())
       thread->SetCurrentThreadName();
   }

--- a/src/autowiring/ContextMember.cpp
+++ b/src/autowiring/ContextMember.cpp
@@ -1,9 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ContextMember.h"
-#include "Autowired.h"
 #include "CoreContext.h"
-#include "SlotInformation.h"
 
 ContextMember::ContextMember(const char* name):
   m_context(CoreContext::CurrentContext()),

--- a/src/autowiring/CoreThread.cpp
+++ b/src/autowiring/CoreThread.cpp
@@ -1,8 +1,8 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "CoreThread.h"
-#include "Autowired.h"
 #include "BasicThreadStateBlock.h"
+#include "CurrentContextPusher.h"
 
 CoreThread::CoreThread(const char* pName):
   BasicThread(pName)

--- a/src/autowiring/SlotInformation.cpp
+++ b/src/autowiring/SlotInformation.cpp
@@ -1,8 +1,8 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "SlotInformation.h"
+#include "AutowirableSlot.h"
 #include "InterlockedExchange.h"
-#include "Autowired.h"
 #include "thread_specific_ptr.h"
 #include MEMORY_HEADER
 

--- a/src/autowiring/auto_signal.cpp
+++ b/src/autowiring/auto_signal.cpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "auto_signal.h"
-#include "Autowired.h"
 #include "SlotInformation.h"
 
 using namespace autowiring;


### PR DESCRIPTION
This header is a customer-facing header; dependencies on this header can create cyclic dependencies that are difficult to troubleshoot, and because this header includes so much, referencing it tends to cause full project rebuilds.  Don't reference it unless it's absolutely necessary that it be referenced.