### PR TITLE
Construct subscriber on the real type

### DIFF
--- a/autowiring/AutoFilterDescriptor.h
+++ b/autowiring/AutoFilterDescriptor.h
@@ -277,22 +277,13 @@ public:
   bool operator!=(const AutoFilterDescriptor& rhs) const { return !(*this == rhs); }
 };
 
-/// <summary>
-/// Utility routine to support the creation of an AutoFilterDescriptor from T::AutoFilter
-/// </summary>
-/// <remarks>
-/// This method will return an empty descriptor in the case that T::AutoFilter is not defined
-/// </remarks>
-template<class T>
-AutoFilterDescriptor MakeAutoFilterDescriptor(const std::shared_ptr<T>& ptr) {
-  return MakeAutoFilterDescriptor(ptr, std::integral_constant<bool, has_autofilter<T>::value>());
-}
-
+namespace autowiring {
+namespace internal {
 /// <summary>
 /// Alias for AutoFilterDescriptor(ptr)
 /// </summary>
 template<class T>
-AutoFilterDescriptor MakeAutoFilterDescriptor(const std::shared_ptr<T>& ptr, std::true_type) {
+AutoFilterDescriptor MakeAFDescriptor(const std::shared_ptr<T>& ptr, std::true_type) {
   return AutoFilterDescriptor(ptr);
 }
 
@@ -303,8 +294,21 @@ AutoFilterDescriptor MakeAutoFilterDescriptor(const std::shared_ptr<T>& ptr, std
 /// This method will return an empty descriptor in the case that T::AutoFilter is not defined
 /// </remarks>
 template<class T>
-AutoFilterDescriptor MakeAutoFilterDescriptor(const std::shared_ptr<T>&, std::false_type) {
+AutoFilterDescriptor MakeAFDescriptor(const std::shared_ptr<T>&, std::false_type) {
   return AutoFilterDescriptor();
+}
+}
+}
+
+/// <summary>
+/// Utility routine to support the creation of an AutoFilterDescriptor from T::AutoFilter
+/// </summary>
+/// <remarks>
+/// This method will return an empty descriptor in the case that T::AutoFilter is not defined
+/// </remarks>
+template<class T>
+AutoFilterDescriptor MakeAutoFilterDescriptor(const std::shared_ptr<T>& ptr) {
+  return autowiring::internal::MakeAFDescriptor(ptr, std::integral_constant<bool, has_autofilter<T>::value>());
 }
 
 namespace std {

--- a/autowiring/CoreObjectDescriptor.h
+++ b/autowiring/CoreObjectDescriptor.h
@@ -29,7 +29,7 @@ struct CoreObjectDescriptor {
     actual_type(&typeid(auto_id<TActual>)),
     stump(&SlotInformationStump<T>::s_stump),
     value(value),
-    subscriber(MakeAutoFilterDescriptor(value)),
+    subscriber(MakeAutoFilterDescriptor<T>(value)),
     pCoreObject(autowiring::fast_pointer_cast<CoreObject>(value)),
     pContextMember(autowiring::fast_pointer_cast<ContextMember>(value)),
     pCoreRunnable(autowiring::fast_pointer_cast<CoreRunnable>(value)),


### PR DESCRIPTION
AutoFilters added to `AutoPacketFactory` during `CoreContext::Inject` should have their atual types registered, not the synthetic type used to ensure `CoreObject` inheritance.  This makes things easier to debug.