### PR TITLE
Split AutoFilterDescriptor implementation into a separate source file

### DIFF
--- a/autowiring/AutoFilterDescriptor.h
+++ b/autowiring/AutoFilterDescriptor.h
@@ -33,23 +33,7 @@ struct AutoFilterDescriptorStub {
   /// is required to carry information about the type of the proper member function to be called; t_extractedCall is
   /// required to be instantiated by the caller and point to the AutoFilter proxy routine.
   /// </summary>
-  AutoFilterDescriptorStub(const std::type_info* pType, autowiring::altitude altitude, const AutoFilterArgument* pArgs, bool deferred, t_extractedCall pCall) :
-    m_pType(pType),
-    m_altitude(altitude),
-    m_pArgs(pArgs),
-    m_deferred(deferred),
-    m_arity(0),
-    m_requiredCount(0),
-    m_pCall(pCall)
-  {
-    for(auto pArg = m_pArgs; *pArg; pArg++) {
-      m_arity++;
-      
-      // time shifted arguments arn't required
-      if (pArg->is_input)
-        ++m_requiredCount;
-    }
-  }
+  AutoFilterDescriptorStub(const std::type_info* pType, autowiring::altitude altitude, const AutoFilterArgument* pArgs, bool deferred, t_extractedCall pCall);
 
 protected:
   // Type of the subscriber itself
@@ -98,14 +82,7 @@ public:
   /// <remarks>
   /// Returns nullptr when no argument is of the requested type.
   /// </remarks>
-  const AutoFilterArgument* GetArgumentType(const std::type_info* argType) {
-    for(auto pArg = m_pArgs; *pArg; pArg++) {
-      if (pArg->ti == argType) {
-        return pArg;
-      }
-    }
-    return nullptr;
-  }
+  const AutoFilterArgument* GetArgumentType(const std::type_info* argType) const;
 
   /// <returns>A call lambda wrapping the associated subscriber</returns>
   /// <remarks>

--- a/src/autowiring/AutoFilterDescriptor.cpp
+++ b/src/autowiring/AutoFilterDescriptor.cpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "AutoFilterDescriptor.h"
+
+AutoFilterDescriptorStub::AutoFilterDescriptorStub(const std::type_info* pType, autowiring::altitude altitude, const AutoFilterArgument* pArgs, bool deferred, t_extractedCall pCall) :
+  m_pType(pType),
+  m_altitude(altitude),
+  m_pArgs(pArgs),
+  m_deferred(deferred),
+  m_pCall(pCall)
+{
+  for(auto pArg = m_pArgs; *pArg; pArg++) {
+    m_arity++;
+      
+    // time shifted arguments arn't required
+    if (pArg->is_input)
+      ++m_requiredCount;
+  }
+}
+
+const AutoFilterArgument* AutoFilterDescriptorStub::GetArgumentType(const std::type_info* argType) const {
+  for (auto pArg = m_pArgs; *pArg; pArg++)
+    if (pArg->ti == argType)
+      return pArg;
+  return nullptr;
+}

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -27,6 +27,7 @@ set(Autowiring_SRCS
   AutoConfigParser.cpp
   AutoConfigParser.hpp
   AutoFilterDescriptor.h
+  AutoFilterDescriptor.cpp
   AutoFilterArgument.h
   AutoFuture.cpp
   AutoFuture.h


### PR DESCRIPTION
General policy to speed compile times by reducing the number of symbols that wind up in object files