### PR TITLE
Add a CurrentPacket method to AutoPacketFactory

### DIFF
--- a/autowiring/AutoPacketFactory.h
+++ b/autowiring/AutoPacketFactory.h
@@ -37,6 +37,9 @@ private:
   // Internal outstanding reference for issued packet:
   std::weak_ptr<void> m_outstandingInternal;
   
+  // The most recently issued packet:
+  std::weak_ptr<AutoPacketInternal> m_curPacket;
+
   // The next packet to be issued from this factory
   std::shared_ptr<AutoPacketInternal> m_nextPacket;
 
@@ -166,6 +169,11 @@ protected:
   static bool IsAutoPacketType(const std::type_info& dataType);
 
 public:
+  /// <returns>
+  /// The most recently issued packet, or possibly nullptr if that packet has already been destroyed
+  /// </returns>
+  std::shared_ptr<AutoPacket> CurrentPacket(void);
+
   /// <summary>
   /// Obtains a new packet from the object pool and configures it with the current
   /// satisfaction graph

--- a/src/autowiring/AutoPacketFactory.cpp
+++ b/src/autowiring/AutoPacketFactory.cpp
@@ -12,6 +12,11 @@ AutoPacketFactory::AutoPacketFactory(void):
 
 AutoPacketFactory::~AutoPacketFactory() {}
 
+std::shared_ptr<AutoPacket> AutoPacketFactory::CurrentPacket(void) {
+  std::lock_guard<std::mutex> lk(m_lock);
+  return m_curPacket.lock();
+}
+
 std::shared_ptr<AutoPacket> AutoPacketFactory::NewPacket(void) {
   if(ShouldStop())
     throw autowiring_error("Attempted to create a packet on an AutoPacketFactory that was already terminated");
@@ -30,6 +35,7 @@ std::shared_ptr<AutoPacket> AutoPacketFactory::NewPacket(void) {
     // Create a new next packet
     retVal = m_nextPacket;
     m_nextPacket = retVal->SuccessorInternal();
+    m_curPacket = retVal;
   }
   
   retVal->Initialize(isFirstPacket);

--- a/src/autowiring/test/AutoPacketFactoryTest.cpp
+++ b/src/autowiring/test/AutoPacketFactoryTest.cpp
@@ -251,3 +251,13 @@ TEST_F(AutoPacketFactoryTest, CanRemoveAddedLambda) {
   ASSERT_TRUE(packet1->Has<int>()) << "First packet did not posess expected decoration";
   ASSERT_FALSE(packet2->Has<int>()) << "Decoration present even after all filters were removed from a factory";
 }
+
+TEST_F(AutoPacketFactoryTest, CurrentPacket) {
+  AutoCurrentContext()->Initiate();
+  AutoRequired<AutoPacketFactory> factory;
+  ASSERT_EQ(nullptr, factory->CurrentPacket()) << "Current packet returned before any packets were issued";
+  auto packet = factory->NewPacket();
+  ASSERT_EQ(packet, factory->CurrentPacket()) << "Current packet was not reported correctly as being issued to the known current packet";
+  packet.reset();
+  ASSERT_EQ(nullptr, factory->CurrentPacket()) << "A current packet was reported after the current packet has expired";
+}


### PR DESCRIPTION
This will allow certain kinds of APIs that rely on global state to be ported to using AutoPacket, and will also make debug methods easier to implement.