### PR TITLE
Correct copyright string for Config.in

### DIFF
--- a/AutowiringConfig.h.in
+++ b/AutowiringConfig.h.in
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 //


### PR DESCRIPTION
Not sure how this didn't get caught by the copyright linter, but it's fixed now.