### PR TITLE
Add Autowiring diagnostic routines

### DIFF
--- a/autowiring/AutoFilterDescriptor.h
+++ b/autowiring/AutoFilterDescriptor.h
@@ -76,6 +76,16 @@ public:
   bool IsDeferred(void) const { return m_deferred; }
   const std::type_info* GetAutoFilterTypeInfo(void) const { return m_pType; }
 
+  /// <returns>
+  /// True if the specified type is present as an output argument on this filter
+  /// </returns>
+  bool Provides(const std::type_info& ti) const;
+
+  /// <returns>
+  /// True if the specified type is present as an input argument on this filter
+  /// </returns>
+  bool Consumes(const std::type_info& ti) const;
+
   /// <summary>
   /// Orientation (input/output, required/optional) of the argument type.
   /// </summary>

--- a/autowiring/AutoPacketFactory.h
+++ b/autowiring/AutoPacketFactory.h
@@ -68,6 +68,11 @@ public:
     container.insert(container.end(), m_autoFilters.begin(), m_autoFilters.end());
   }
 
+  /// <returns>
+  /// A copy of all AutoFilter instances on this class
+  /// </returns>
+  std::vector<AutoFilterDescriptor> GetAutoFilters(void) const;
+
   /// <summary>
   /// Creates a linked list of saturation counters
   /// </summary>

--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -1,8 +1,8 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "auto_signal.h"
+#include "AutowiringDebug.h"
 #include "AutowirableSlot.h"
-#include "Decompose.h"
 #include "GlobalCoreContext.h"
 #include MEMORY_HEADER
 #include ATOMIC_HEADER

--- a/autowiring/AutowiringDebug.h
+++ b/autowiring/AutowiringDebug.h
@@ -1,0 +1,50 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include <string>
+#include <vector>
+
+struct AutoFilterDescriptor;
+class AutoPacket;
+
+namespace autowiring {
+namespace dbg {
+
+/// <returns>
+/// True if the specified typename looks like it might be the type of a lambda function
+/// </returns>
+bool IsLambda(const std::type_info& ti);
+
+/// <returns>
+/// A string corresponding to the current context name
+/// </returns>
+std::string ContextName(void);
+
+/// <returns>
+/// The current packet under processing
+/// </returns>
+AutoPacket* CurrentPacket(void);
+
+/// <returns>
+/// An AutoFilterDescriptor corresponding to the filter with the specified name
+/// </returns>
+/// <param name="name">The name of the filter</param>
+const AutoFilterDescriptor* DescriptorByName(const char* name);
+
+/// <summary>
+/// Attempts to determine why the specified AutoFilter type might not be called
+/// </summary>
+/// <param name="name">The name of the filter</param>
+std::string AutoFilterInfo(const char* name);
+
+/// <summary>
+/// Shows decorations that are considered "root decorations" in the current context
+/// </summary>
+/// <param name="name">The name of the filter</param>
+std::vector<std::string> ListRootDecorations(void);
+
+/// <summary>
+/// Initializes the Autowiring debug library
+/// </summary>
+void DebugInit(void);
+}
+}

--- a/src/autowiring/AutoFilterDescriptor.cpp
+++ b/src/autowiring/AutoFilterDescriptor.cpp
@@ -18,6 +18,20 @@ AutoFilterDescriptorStub::AutoFilterDescriptorStub(const std::type_info* pType, 
   }
 }
 
+bool AutoFilterDescriptorStub::Provides(const std::type_info& ti) const {
+  for (size_t i = GetArity(); i--;)
+    if (*m_pArgs[i].ti == ti)
+      return m_pArgs[i].is_output;
+  return false;
+}
+
+bool AutoFilterDescriptorStub::Consumes(const std::type_info& ti) const {
+  for (size_t i = GetArity(); i--;)
+    if (*m_pArgs[i].ti == ti)
+      return m_pArgs[i].is_output;
+  return false;
+}
+
 const AutoFilterArgument* AutoFilterDescriptorStub::GetArgumentType(const std::type_info* argType) const {
   for (auto pArg = m_pArgs; *pArg; pArg++)
     if (pArg->ti == argType)

--- a/src/autowiring/AutoPacketFactory.cpp
+++ b/src/autowiring/AutoPacketFactory.cpp
@@ -74,6 +74,13 @@ std::shared_ptr<void> AutoPacketFactory::GetInternalOutstanding(void) {
   return retVal;
 }
 
+std::vector<AutoFilterDescriptor> AutoPacketFactory::GetAutoFilters(void) const {
+  std::lock_guard<std::mutex> lk(m_lock);
+  std::vector<AutoFilterDescriptor> retVal;
+  retVal.assign(m_autoFilters.begin(), m_autoFilters.end());
+  return retVal;
+}
+
 SatCounter* AutoPacketFactory::CreateSatCounterList(void) const {
   std::lock_guard<std::mutex> lk(m_lock);
 

--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -22,7 +22,13 @@ bool autowiring::dbg::IsLambda(const std::type_info& ti) {
     if (
       !('a' <= cur && cur <= 'z') &&
       !('A' <= cur && cur <= 'Z') &&
-      !('0' <= cur && cur <= '9')
+      !('0' <= cur && cur <= '9') &&
+      cur != '_' &&
+      cur != ':' &&
+      cur != '<' &&
+      cur != '>' &&
+      cur != ',' &&
+      cur != ' '
     )
       return true;
   return false;

--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -51,7 +51,12 @@ static std::string DemangleWithAutoID(const std::type_info& ti) {
   auto retVal = demangle(ti);
 
   // prefix is at the beginning of the string, skip over it
+#ifdef _MSC_VER
   static const char prefix [] = "struct auto_id<";
+#else
+  static const char prefix [] = "auto_id<";
+#endif
+
   if (retVal.compare(0, sizeof(prefix) - 1, prefix) == 0) {
     size_t off = sizeof(prefix) - 1;
     retVal = retVal.substr(off, retVal.length() - off - 2);

--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -36,11 +36,14 @@ bool autowiring::dbg::IsLambda(const std::type_info& ti) {
 #endif
 
 static std::string TrimPrefix(std::string name) {
+#ifdef _MSC_VER
   // "class" or "struct" prefixes should be eliminated
   if (name.compare(0, 6, "class "))
     name = name.substr(5);
   if (name.compare(0, 7, "struct "))
     name = name.substr(6);
+#endif
+
   return name;
 }
 

--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -1,0 +1,162 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "AutowiringDebug.h"
+#include "Autowired.h"
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+using namespace autowiring;
+using namespace autowiring::dbg;
+
+#ifdef _MSC_VER
+// On Windows, lambda functions start with the key string "class <"
+bool autowiring::dbg::IsLambda(const std::type_info& ti) {
+  return demangle(ti).compare(0, 7, "class <") == 0;
+}
+#else
+// On other platforms, try to find lambda functions by the presence of forbidden characters
+bool autowiring::dbg::IsLambda(const std::type_info& ti) {
+  auto name = demangle(ti);
+  for (auto cur : name)
+    if (
+      !('a' <= cur && cur <= 'z') &&
+      !('A' <= cur && cur <= 'Z') &&
+      !('0' <= cur && cur <= '9')
+    )
+      return true;
+  return false;
+}
+#endif
+
+static std::string TrimPrefix(std::string name) {
+  // "class" or "struct" prefixes should be eliminated
+  if (name.compare(0, 6, "class "))
+    name = name.substr(5);
+  if (name.compare(0, 7, "struct "))
+    name = name.substr(6);
+  return name;
+}
+
+static std::string DemangleWithAutoID(const std::type_info& ti) {
+  auto retVal = demangle(ti);
+
+  // prefix is at the beginning of the string, skip over it
+  static const char prefix [] = "struct auto_id<";
+  if (retVal.compare(0, sizeof(prefix) - 1, prefix) == 0) {
+    size_t off = sizeof(prefix) - 1;
+    retVal = retVal.substr(off, retVal.length() - off - 2);
+  }
+  return TrimPrefix(retVal);
+}
+
+std::string autowiring::dbg::ContextName(void) {
+  AutoCurrentContext ctxt;
+  return autowiring::demangle(ctxt->GetSigilType());
+}
+
+AutoPacket* autowiring::dbg::CurrentPacket(void) {
+  Autowired<AutoPacketFactory> factory;
+  if (!factory)
+    return nullptr;
+  return factory->CurrentPacket().get();
+}
+
+static const AutoFilterDescriptor* DescriptorByName(const char* name, const std::vector<AutoFilterDescriptor>& filters) {
+  for (const auto& filter : filters) {
+    auto type = filter.GetType();
+    if (!type)
+      continue;
+
+    auto curName = TrimPrefix(demangle(type));
+    if (!curName.compare(name))
+      return &filter;
+  }
+  return nullptr;
+}
+
+const AutoFilterDescriptor* autowiring::dbg::DescriptorByName(const char* name) {
+  Autowired<AutoPacketFactory> factory;
+  if (!factory)
+    return nullptr;
+
+  return DescriptorByName(name, factory->GetAutoFilters());
+}
+
+std::string autowiring::dbg::AutoFilterInfo(const char* name) {
+  Autowired<AutoPacketFactory> factory;
+  if (!factory)
+    return "No factory detected in this context";
+
+  // Obtain all descriptors:
+  const std::vector<AutoFilterDescriptor> descs = factory->GetAutoFilters();
+
+  // Need the root descriptor first
+  const AutoFilterDescriptor* desc = DescriptorByName(name, descs);
+  if (!desc)
+    return "Filter not found";
+
+  std::ostringstream os;
+  std::function<void(const AutoFilterDescriptor&, int)> fnCall = [&](const AutoFilterDescriptor& desc, size_t nLevels) {
+    auto args = desc.GetAutoFilterArguments();
+
+    for (size_t i = 0; i < desc.GetArity(); i++) {
+      // Argument must be an input to the filter we want to know more about
+      if (!args[i].is_input)
+        continue;
+
+      // Who provides this input?
+      for (const auto& providerDesc : descs) {
+        auto providerArg = providerDesc.GetArgumentType(args[i].ti);
+        if (providerArg && providerArg->is_output) {
+          // Need to print information about this provider:
+          os << demangle(*args[i].ti) << ' ' << std::string(' ', nLevels) << demangle(*providerDesc.GetType()) << std::endl;
+
+          // The current descriptor provides an input to the parent, recurse
+          fnCall(providerDesc, nLevels + 1);
+        }
+      }
+    }
+  };
+
+  // Root typename print first:
+  os << demangle(desc->GetType()) << std::endl;
+  fnCall(*desc, 1);
+
+  auto retVal = os.str();
+  return retVal;
+}
+
+std::vector<std::string> autowiring::dbg::ListRootDecorations(void) {
+  Autowired<AutoPacketFactory> factory;
+  if (!factory)
+    return std::vector<std::string>{};
+
+  // Obtain all descriptors:
+  const std::vector<AutoFilterDescriptor> descs = factory->GetAutoFilters();
+
+  // Get all baseline descriptor types, figure out what isn't satisfied:
+  std::unordered_map<std::type_index, const std::type_info*> outputs;
+  std::unordered_map<std::type_index, const std::type_info*> inputs;
+
+  for (const auto& desc : descs) {
+    auto args = desc.GetAutoFilterArguments();
+    for (size_t i = 0; i < desc.GetArity(); i++)
+      (args[i].is_output ? outputs : inputs)[*args[i].ti] = args[i].ti;
+  }
+
+  // Remove all inputs that exist in the outputs set:
+  for (auto& output : outputs)
+    inputs.erase(*output.second);
+
+  // Any remaining inputs are unsatisfied
+  std::vector<std::string> retVal;
+  for (auto& input : inputs)
+    if (input.second)
+      retVal.push_back(DemangleWithAutoID(*input.second));
+  return retVal;
+}
+
+void autowiring::dbg::DebugInit(void) {
+
+}

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -53,6 +53,8 @@ set(Autowiring_SRCS
   Autowired.h
   autowiring.h
   AutowiringConfig.h
+  AutowiringDebug.h
+  AutowiringDebug.cpp
   AutowiringEvents.cpp
   AutowiringEvents.h
   autowiring_error.cpp

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -81,6 +81,10 @@ TEST_F(AutoFilterTest, VerifyTypeUsage) {
   ASSERT_EQ(2, filterA->m_one.i) << "AutoFilter was called using derived type instead of parent";
 }
 
+int DoTheThingAndStuff(void) {
+  return 999;
+}
+
 TEST_F(AutoFilterTest, VerifyAutoOut) {
   AutoRequired<AutoPacketFactory> factory;
 

--- a/src/autowiring/test/AutowiringDebugTest.cpp
+++ b/src/autowiring/test/AutowiringDebugTest.cpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include <autowiring/autowiring.h>
+#include "TestFixtures/Decoration.hpp"
+
+class AutowiringDebugTest:
+  public testing::Test
+{};
+
+TEST_F(AutowiringDebugTest, IsLambdaTest) {
+  auto fn = [] {};
+  ASSERT_TRUE(autowiring::dbg::IsLambda(typeid(fn))) << "Lambda function not correctly detected";
+  ASSERT_FALSE(autowiring::dbg::IsLambda(typeid(CoreThread))) << "Simple class incorrectly identified as a lambda function";
+  ASSERT_FALSE(autowiring::dbg::IsLambda(typeid(std::vector<int>))) << "Template class incorrectly identified as a lambda function";
+}
+
+class HasDebugInformation {
+public:
+  void AutoFilter(const Decoration<0>& dec, Decoration<1>&) {}
+};
+
+TEST_F(AutowiringDebugTest, FilterInfoTest) {
+  AutoRequired<HasDebugInformation> hdi;
+
+  auto text = autowiring::dbg::AutoFilterInfo("HasDebugInformation");
+  ASSERT_NE(std::string{"Filter not found"}, text) << "Debug helper routine did not find a named filter in the current context as expected";
+}
+
+TEST_F(AutowiringDebugTest, IdentifyRootType) {
+  AutoRequired<AutoPacketFactory> factory;
+
+  *factory += [](const Decoration<0>&, Decoration<1>&) {};
+  *factory += [](const Decoration<1>&, Decoration<2>&) {};
+
+  auto entries = autowiring::dbg::ListRootDecorations();
+  ASSERT_EQ(1UL, entries.size()) << "An incorrect number of unsatisfied decorations was detected";
+  ASSERT_EQ("Decoration<0>", entries[0]) << "The wrong decoration was detected as being unsatisfiable";
+}
+
+TEST_F(AutowiringDebugTest, CanGetCurrentPacket) {
+  AutoCurrentContext()->Initiate();
+  AutoRequired<AutoPacketFactory> factory;
+  *factory += [](AutoPacket& packet) {
+    ASSERT_EQ(&packet, autowiring::dbg::CurrentPacket()) << "CurrentPacket did not correctly report the current packet";
+  };
+
+  auto packet = factory->NewPacket();
+}

--- a/src/autowiring/test/AutowiringTest.cpp
+++ b/src/autowiring/test/AutowiringTest.cpp
@@ -7,6 +7,7 @@
 #include <autowiring/CoreThread.h>
 
 int main(int argc, const char* argv []) {
+  autowiring::dbg::DebugInit();
   return autotesting_main(argc, argv);
 }
 

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -18,6 +18,7 @@ set(AutowiringTest_SRCS
   AutoPacketFactoryTest.cpp
   AutoRestarterTest.cpp
   AutoSignalTest.cpp
+  AutowiringDebugTest.cpp
   AutowiringTest.cpp
   AutowiringUtilitiesTest.cpp
   BasicThreadTest.cpp


### PR DESCRIPTION
These routines are intended to be used to diagnose Autowiring issues from a debugger that is capable of evaluating function calls.  None of these routines make stateful changes to the system.  These methods assume that the debugger will run these functions from the thread context current in the debugger.