### PR TITLE
Do not generate refs to GlobalCoreContext from the CurrentContextPusher

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -930,9 +930,14 @@ public:
   bool DelayUntilInitiated(void);
 
   /// <summary>
+  /// Static version of SetCurrent, may be invoked with nullptr
+  /// </summary>
+  static std::shared_ptr<CoreContext> SetCurrent(const std::shared_ptr<CoreContext>& ctxt);
+
+  /// <summary>
   /// Makes this context the current context.
   /// </summary>
-  /// <returns>The previously current context.</returns>
+  /// <returns>The previously current context, or else nullptr if no context was current.</returns>
   std::shared_ptr<CoreContext> SetCurrent(void);
 
   /// <summary>
@@ -941,6 +946,8 @@ public:
   /// <remarks>
   /// Generally speaking, if you just want to release a reference to the current context, simply
   /// make the global context current instead.
+  ///
+  /// This method is identical to CoreContext::SetCurrent(nullptr)
   /// </remarks>
   static void EvictCurrent(void);
 
@@ -948,14 +955,19 @@ public:
   /// The shared pointer to the current context.
   /// </summary>
   /// <returns>
-  /// A shared pointer to the current CoreContext instance of the current thread,
-  /// or else an empty pointer, if no context is current.
+  /// A shared pointer to the current CoreContext instance of the current thread, or else nullptr,
+  /// if no context is current.
   /// </returns>
   /// <remarks>
   /// This works by using thread-local store, and so is safe in multithreaded systems.  The current
   /// context is assigned before invoking a CoreRunnable instance's Run method, and it's also assigned
   /// when a context is first constructed by a thread.
   /// </remarks>
+  static std::shared_ptr<CoreContext> CurrentContextOrNull(void);
+
+  /// <summary>
+  /// Identical to CurrentContextNoCheck, except returns the global context instead of a null pointer
+  /// </summary>
   static std::shared_ptr<CoreContext> CurrentContext(void);
 
   /// <summary>

--- a/autowiring/CurrentContextPusher.h
+++ b/autowiring/CurrentContextPusher.h
@@ -36,6 +36,10 @@ public:
   std::shared_ptr<CoreContext> Pop(void);
 
 private:
+  // True if Pop has already been invoked
+  bool pop_invoked = false;
+
+  // Pointer to the prior context--may potentially be nullptr
   std::shared_ptr<CoreContext> m_prior;
 };
 

--- a/src/autowiring/CurrentContextPusher.cpp
+++ b/src/autowiring/CurrentContextPusher.cpp
@@ -4,7 +4,7 @@
 #include "GlobalCoreContext.h"
 
 CurrentContextPusher::CurrentContextPusher(void):
-  m_prior(CoreContext::CurrentContext())
+  m_prior(CoreContext::CurrentContextOrNull())
 {}
 
 CurrentContextPusher::CurrentContextPusher(std::shared_ptr<CoreContext> pContext):
@@ -28,10 +28,12 @@ CurrentContextPusher::~CurrentContextPusher(void) {
 }
 
 std::shared_ptr<CoreContext> CurrentContextPusher::Pop(void) {
-  std::shared_ptr<CoreContext> retVal;
-  if(m_prior) {
-    retVal = m_prior->SetCurrent();
-    m_prior.reset();
-  }
+  if (pop_invoked)
+    // Nothing to do
+    return nullptr;
+
+  pop_invoked = true;
+  auto retVal = CoreContext::SetCurrent(m_prior);
+  m_prior.reset();
   return retVal;
 }


### PR DESCRIPTION
`CurrentContextPusher` should restore the current context to `nullptr` if no context was explicitly assigned when the type was instantiated.  For this to work, it must use `CoreContext::CurrentContextOrNull` intead of `CoreContext::CurrentContext`.

Also add `CoreContext::CurrentContextOrNull` and fix documentation in the vicinity of `CoreContext::CurrentContext`.