### PR TITLE
GlobalCoreContext::Release should return the last shared pointer

### DIFF
--- a/autowiring/GlobalCoreContext.h
+++ b/autowiring/GlobalCoreContext.h
@@ -35,6 +35,11 @@ public:
   /// <summary>
   /// Releases the global context, allowing reinitialization
   /// </summary>
+  /// <returns>
+  /// A reference to the global context.  The caller may test `std::shared_ptr::unique`
+  /// to determine whether the pointer is the last outstanding reference to the global
+  /// context.
+  /// </returns>
   /// <remarks>
   /// In addition to releasing the global core context, all initializer operations
   /// are dumped.  Note that releasing the context is not synonymous with destroying
@@ -49,7 +54,7 @@ public:
   /// thread holds a reference to the current global context via SetCurrent, it is
   /// the caller's responsibility to manually release that reference via EvictCurrent.
   /// </remarks>
-  static void Release(void);
+  static std::shared_ptr<GlobalCoreContext> Release(void);
 
 private:
   // Global context shared pointer and lock:

--- a/src/autowiring/GlobalCoreContext.cpp
+++ b/src/autowiring/GlobalCoreContext.cpp
@@ -43,10 +43,12 @@ std::shared_ptr<GlobalCoreContext> GlobalCoreContext::Get() {
   return ptr;
 }
 
-void GlobalCoreContext::Release(void) {
+std::shared_ptr<GlobalCoreContext> GlobalCoreContext::Release(void) {
   // Release local:
   std::lock_guard<std::mutex> lk(getInitLock());
+  auto retVal = getGlobalContextSharedPtr();
   getGlobalContextSharedPtr().reset();
+  return retVal;
 }
 
 std::mutex& GlobalCoreContext::getInitLock() {

--- a/src/autowiring/test/GlobalInitTest.cpp
+++ b/src/autowiring/test/GlobalInitTest.cpp
@@ -14,16 +14,18 @@ void GlobalInitTest::SetUp(void) {
 }
 
 void GlobalInitTest::TearDown(void) {
-  std::weak_ptr<GlobalCoreContext> glbl = AutoGlobalContext();
+  std::shared_ptr<GlobalCoreContext> glbl = AutoGlobalContext();
 
-  // Always drop the global context when tests are done
-  GlobalCoreContext::Release();
+  {
+    // Always drop the global context when tests are done
+    ASSERT_EQ(glbl, GlobalCoreContext::Release()) << "Release did not correctly return the previously current global context";
+  }
 
   // Also release the current context, whatever it is.
   CoreContext::EvictCurrent();
 
   // Be absolutely sure the global context went away
-  ASSERT_TRUE(glbl.expired()) << "Global context did not tear down as expected";
+  ASSERT_TRUE(glbl.unique()) << "An unexpected additional reference to the global context was detected";
 }
 
 TEST_F(GlobalInitTest, VerifyGlobalExists) {


### PR DESCRIPTION
This allows callers to infer what will happen/has happened to the global context on return of this method.  Without this, there is no easy way to ensure in one single call that the global context was evicted and then destroyed.