### PR TITLE
Eliminate anciliary subscribers concept

### DIFF
--- a/autowiring/SlotInformation.h
+++ b/autowiring/SlotInformation.h
@@ -4,18 +4,7 @@
 #include <typeinfo>
 #include MEMORY_HEADER
 
-struct AutoFilterDescriptorStub;
 class DeferrableAutowiring;
-
-struct AutoFilterDescriptorStubLink {
-  AutoFilterDescriptorStubLink(const AutoFilterDescriptorStub& stub, const AutoFilterDescriptorStubLink* pFlink) :
-    stub(stub),
-    pFlink(pFlink)
-  {}
-
-  const AutoFilterDescriptorStub& stub;
-  const AutoFilterDescriptorStubLink* const pFlink;
-};
 
 /// <summary>
 /// Represents information about a single slot detected as having been declared in a context member
@@ -57,11 +46,6 @@ struct SlotInformationStumpBase {
 
   // Current slot information:
   const SlotInformation* pHead = nullptr;
-
-  // If there are any custom AutoFilter fields defined, this is the first of them
-  // Note that these custom fields -only- include fields registered via the AutoFilter
-  // registration type
-  const AutoFilterDescriptorStubLink* pFirstAutoFilter = nullptr;
 };
 
 /// <summary>
@@ -128,9 +112,6 @@ private:
   // Current slot information:
   SlotInformation* m_pCur = nullptr;
 
-  // Most recent AutoFilter descriptor link:
-  AutoFilterDescriptorStubLink* m_pLastLink = nullptr;
-
 public:
   /// <returns>
   /// True if the passed pointer is inside of the object currently under construction at this stack location
@@ -161,9 +142,4 @@ public:
   /// Registers the named slot with the current stack location
   /// </summary>
   static void RegisterSlot(DeferrableAutowiring* pAutowiring);
-
-  /// <summary>
-  /// Registers a NewAutoFilter with this SlotInformation
-  /// </summary>
-  static void RegisterSlot(const AutoFilterDescriptorStub& stub);
 };

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -300,7 +300,6 @@ void CoreContext::AddInternal(const CoreObjectDescriptor& traits) {
   }
 
   // Subscribers, if applicable:
-  const auto& stump = *traits.stump;
   if(!traits.subscriber.empty())
     AddPacketSubscriber(traits.subscriber);
 

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -301,17 +301,8 @@ void CoreContext::AddInternal(const CoreObjectDescriptor& traits) {
 
   // Subscribers, if applicable:
   const auto& stump = *traits.stump;
-  if(!traits.subscriber.empty()) {
+  if(!traits.subscriber.empty())
     AddPacketSubscriber(traits.subscriber);
-
-    // Ancilliary subscribers, if present:
-    for(const auto* pCur = stump.pFirstAutoFilter; pCur; pCur = pCur->pFlink) {
-      AutoFilterDescriptor subscriber(traits.subscriber.GetAutoFilter(), pCur->stub);
-      AddPacketSubscriber(subscriber);
-    }
-  }
-  else if(stump.pFirstAutoFilter)
-    throw autowiring_error("It is an error to make use of NewAutoFilter in a type which does not have an AutoFilter member; please provide an AutoFilter method on this type");
 
   // Signal listeners that a new object has been created
   GetGlobal()->Invoke(&AutowiringEvents::NewObject)(*this, traits);

--- a/src/autowiring/SlotInformation.cpp
+++ b/src/autowiring/SlotInformation.cpp
@@ -35,7 +35,6 @@ SlotInformationStackLocation::~SlotInformationStackLocation(void) {
   tss.reset(&prior);
 
   UpdateOrCascadeDelete(m_pCur, stump.pHead);
-  UpdateOrCascadeDelete(m_pLastLink, stump.pFirstAutoFilter);
 
   // Unconditionally update to true, no CAS needed
   stump.bInitialized = true;
@@ -65,11 +64,4 @@ void SlotInformationStackLocation::RegisterSlot(DeferrableAutowiring* pDeferrabl
     reinterpret_cast<const unsigned char*>(tss->pObj),
     false
   );
-}
-
-void SlotInformationStackLocation::RegisterSlot(const AutoFilterDescriptorStub& stub) {
-  if(!tss.get() || tss->stump.bInitialized)
-    return;
-
-  tss->m_pLastLink = new AutoFilterDescriptorStubLink(stub, tss->m_pLastLink);
 }


### PR DESCRIPTION
This concept has been superceded by `AutoPacketFactory::operator+=`