### PR TITLE
Make CoreContext::Create<T> return the most-specific type possible.

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -586,7 +586,7 @@ private:
   /// Creation helper routine
   /// </summary>
   template<class T>
-  static std::shared_ptr<CoreContext> UntypedCreate(
+  static std::shared_ptr<CoreContext> CreateUntyped(
     std::shared_ptr<CoreContext> pParent,
     t_childList::iterator backReference
   ) {
@@ -601,7 +601,7 @@ public:
   /// <param name="inj">An injectable type.</param>
   template<class T>
   std::shared_ptr<CoreContextT<T>> Create(AutoInjectable&& inj) {
-    return std::static_pointer_cast<CoreContextT<T>>(CreateInternal(&CoreContext::UntypedCreate<T>, std::move(inj)));
+    return std::static_pointer_cast<CoreContextT<T>>(CreateInternal(&CoreContext::CreateUntyped<T>, std::move(inj)));
   }
 
   /// <summary>
@@ -618,7 +618,7 @@ public:
   /// </remarks>
   template<class T>
   std::shared_ptr<CoreContextT<T>> Create(void) {
-    return std::static_pointer_cast<CoreContextT<T>>(CreateInternal(&CoreContext::UntypedCreate<T>));
+    return std::static_pointer_cast<CoreContextT<T>>(CreateInternal(&CoreContext::CreateUntyped<T>));
   }
 
   /// <summary>

--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -573,23 +573,35 @@ public:
   /// Creation helper routine
   /// </summary>
   template<class T>
-  static std::shared_ptr<CoreContext> Create(
+  static std::shared_ptr<CoreContextT<T>> Create(
     std::shared_ptr<CoreContext> pParent,
     t_childList::iterator backReference
   ) {
-    return std::static_pointer_cast<CoreContext>(
-      std::make_shared<CoreContextT<T>>(pParent, backReference)
-    );
+    return std::make_shared<CoreContextT<T>>(pParent, backReference);
   }
 
+private:
+  /// \internal
+  /// <summary>
+  /// Creation helper routine
+  /// </summary>
+  template<class T>
+  static std::shared_ptr<CoreContext> UntypedCreate(
+    std::shared_ptr<CoreContext> pParent,
+    t_childList::iterator backReference
+  ) {
+    return std::static_pointer_cast<CoreContext>(std::make_shared<CoreContextT<T>>(pParent, backReference));
+  }
+
+public:
   /// \internal
   /// <summary>
   /// Factory to create a new context
   /// </summary>
   /// <param name="inj">An injectable type.</param>
   template<class T>
-  std::shared_ptr<CoreContext> Create(AutoInjectable&& inj) {
-    return CreateInternal(&CoreContext::Create<T>, std::move(inj));
+  std::shared_ptr<CoreContextT<T>> Create(AutoInjectable&& inj) {
+    return std::static_pointer_cast<CoreContextT<T>>(CreateInternal(&CoreContext::UntypedCreate<T>, std::move(inj)));
   }
 
   /// <summary>
@@ -605,8 +617,8 @@ public:
   /// \endcode
   /// </remarks>
   template<class T>
-  std::shared_ptr<CoreContext> Create(void) {
-    return CreateInternal(&CoreContext::Create<T>);
+  std::shared_ptr<CoreContextT<T>> Create(void) {
+    return std::static_pointer_cast<CoreContextT<T>>(CreateInternal(&CoreContext::UntypedCreate<T>));
   }
 
   /// <summary>

--- a/src/autowiring/test/ContextCreatorTest.cpp
+++ b/src/autowiring/test/ContextCreatorTest.cpp
@@ -193,6 +193,30 @@ TEST_F(ContextCreatorTest, VoidKeyType) {
   ASSERT_EQ(2UL, vc->m_totalDestroyed) << "The void creator did not receive the expected number of NotifyContextDestroyed calls";
 }
 
+TEST_F(ContextCreatorTest, ExplicitCallTo_CoreContext_Create) {
+  struct FancySigil { };
+  struct DullSigil { };
+
+  std::shared_ptr<GlobalCoreContext> gc = GlobalCoreContext::Get();
+
+  std::shared_ptr<CoreContextT<FancySigil>> ctxt1 = gc->Create<FancySigil>();
+  std::shared_ptr<CoreContext> ctxt2 = gc->Create<FancySigil>();
+  std::shared_ptr<CoreContext> ctxt3 = gc->Create<DullSigil>();
+
+  size_t FancySigilCount = 0;
+  for (auto m : ContextEnumeratorT<FancySigil>(gc)) {
+    ++FancySigilCount;
+  }
+
+  size_t DullSigilCount = 0;
+  for (auto m : ContextEnumeratorT<DullSigil>(gc)) {
+    ++DullSigilCount;
+  }
+
+  ASSERT_EQ(2, FancySigilCount);
+  ASSERT_EQ(1, DullSigilCount);
+}
+
 struct mySigil {};
 
 class Runnable:


### PR DESCRIPTION
This makes CoreContext::Create<T> (and related functions) return std::shared_ptr\<CoreContextT\<T>> instead of just std::shared_ptr<CoreContext>.

- [ ] Wait of victor to give the go