### PR TITLE
Allow ThreadPool classes to be documented by doxygen

### DIFF
--- a/publicDoxyfile.conf
+++ b/publicDoxyfile.conf
@@ -811,6 +811,8 @@ FILE_PATTERNS          = "at_exit.h" \
                          "GlobalCoreContext.h" \
                          "MicroBolt.h" \
                          "Object.h" \
+                         "ThreadPool.h" \
+                         "SystemThreadPool.h" \
                          "overview.md" \
                          "AutoFilters.md" \
                          "Contexts.md" \


### PR DESCRIPTION
Fix this oversight; without it, docs for ThreadPool and SystemThreadPool don't get generated