### PR TITLE
Do not set upper bounds for thread pool dispatchers

### DIFF
--- a/autowiring/DispatchQueue.h
+++ b/autowiring/DispatchQueue.h
@@ -20,6 +20,7 @@ class DispatchQueue;
 class DispatchQueue {
 public:
   DispatchQueue(void);
+  DispatchQueue(size_t dispatchCap);
   DispatchQueue(DispatchQueue&&) = delete;
   DispatchQueue(const DispatchQueue&) = delete;
 

--- a/src/autowiring/DispatchQueue.cpp
+++ b/src/autowiring/DispatchQueue.cpp
@@ -6,6 +6,10 @@
 
 DispatchQueue::DispatchQueue(void) {}
 
+DispatchQueue::DispatchQueue(size_t dispatchCap):
+  m_dispatchCap(dispatchCap)
+{}
+
 DispatchQueue::~DispatchQueue(void) {
   // Wipe out each entry in the queue, we can't call any of them because we're in teardown
   for (auto cur = m_pHead; cur;) {

--- a/src/autowiring/SystemThreadPoolStl.cpp
+++ b/src/autowiring/SystemThreadPoolStl.cpp
@@ -5,7 +5,8 @@
 
 using namespace autowiring;
 
-SystemThreadPoolStl::SystemThreadPoolStl(void)
+SystemThreadPoolStl::SystemThreadPoolStl(void):
+  m_toBeDone(~0)
 {}
 
 SystemThreadPoolStl::~SystemThreadPoolStl(void)

--- a/src/autowiring/SystemThreadPoolWin.cpp
+++ b/src/autowiring/SystemThreadPoolWin.cpp
@@ -5,9 +5,9 @@
 
 using namespace autowiring;
 
-SystemThreadPoolWin::SystemThreadPoolWin(void) 
-{
-}
+SystemThreadPoolWin::SystemThreadPoolWin(void) :
+  m_toBeDone(~0)
+{}
 
 SystemThreadPoolWin::~SystemThreadPoolWin(void)
 {


### PR DESCRIPTION
Such limits make thread pools inheritly non-scalable.  Limits to thread pool dispatcher counts should be enforced by the client.