### PR TITLE
Implement BasicThread::IsMainThread

### DIFF
--- a/autowiring/BasicThread.h
+++ b/autowiring/BasicThread.h
@@ -308,6 +308,11 @@ public:
   /// \include snippets/BasicThread_GetRunningTime.txt
   /// </remarks>
   void GetThreadTimes(std::chrono::milliseconds& kernelTime, std::chrono::milliseconds& userTime);
+
+  /// <returns>
+  /// True if the calling thread is the main thread
+  /// </returns>
+  static bool IsMainThread(void);
 };
 
 /// <summary>

--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -11,6 +11,8 @@
 #include "fast_pointer_cast.h"
 #include ATOMIC_HEADER
 
+static auto mainTID = std::this_thread::get_id();
+
 BasicThread::BasicThread(const char* pName):
   ContextMember(pName),
   m_state(std::make_shared<BasicThreadStateBlock>())
@@ -184,4 +186,8 @@ void BasicThread::ForceCoreThreadReidentify(void) {
 
 void ForceCoreThreadReidentify(void) {
   BasicThread::ForceCoreThreadReidentify();
+}
+
+bool BasicThread::IsMainThread(void) {
+  return mainTID == std::this_thread::get_id();
 }

--- a/src/autowiring/test/BasicThreadTest.cpp
+++ b/src/autowiring/test/BasicThreadTest.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/BasicThread.h>
+#include FUTURE_HEADER
 
 class BasicThreadTest:
   public testing::Test
@@ -63,4 +64,15 @@ TEST_F(BasicThreadTest, ValidateThreadTimes) {
   // Thread should not have been able to complete in less time than we completed, by a factor of ten or so at least
   ASSERT_LE(benchmark, spinsThenQuits->m_userTime * 10) <<
     "Reported execution time could not possibly be correct, spin operation took less time to execute than should have been possible with the CPU";
+}
+
+TEST_F(BasicThreadTest, IsMainThread) {
+  ASSERT_TRUE(BasicThread::IsMainThread()) << "Main thread not correctly identified as the main thread";
+  std::future<bool> secondaryIsMain = std::async(
+    std::launch::async,
+    [] {
+      return BasicThread::IsMainThread();
+    }
+  );
+  ASSERT_FALSE(secondaryIsMain.get()) << "Secondary thread incorrectly identified as the main thread";
 }


### PR DESCRIPTION
Add support to discriminate between the main thread and other threads on the system.  Some systems have special handling for the main thread--IE, certain APIs can only be called safely from it--thus it's important that we have a way to inform such systems as to whether a particular thread is the main thread.