### PR TITLE
Make demangle behavior more consistent

### DIFF
--- a/src/autowiring/AutoConfigParser.cpp
+++ b/src/autowiring/AutoConfigParser.cpp
@@ -5,13 +5,12 @@
 #include <stdexcept>
 
 std::string autowiring::ExtractKey(const std::string& demangled) {
-  //Extract Namespace and value from typename
-  //struct ConfigTypeExtractor<struct Namespace, class ..., struct Value>
-  //Or on unix: ConfigTypeExtractor<Namespace, ..., Value>
+  // Extract Namespace and value from typename
+  // ConfigTypeExtractor<Namespace, ..., Value>
 
   const auto identifiersStart = demangled.find('<');
   const auto identifiersEnd = demangled.rfind('>');
-  if (identifiersStart == (std::string::npos) || identifiersEnd == std::string::npos)
+  if (identifiersStart == std::string::npos || identifiersEnd == std::string::npos)
     return std::string();
 
   std::string key;

--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -12,7 +12,7 @@ using namespace autowiring::dbg;
 #ifdef _MSC_VER
 // On Windows, lambda functions start with the key string "class <"
 bool autowiring::dbg::IsLambda(const std::type_info& ti) {
-  return demangle(ti).compare(0, 7, "class <") == 0;
+  return demangle(ti)[0] == '<';
 }
 #else
 // On other platforms, try to find lambda functions by the presence of forbidden characters
@@ -35,33 +35,17 @@ bool autowiring::dbg::IsLambda(const std::type_info& ti) {
 }
 #endif
 
-static std::string TrimPrefix(std::string name) {
-#ifdef _MSC_VER
-  // "class" or "struct" prefixes should be eliminated
-  if (name.compare(0, 6, "class "))
-    name = name.substr(5);
-  if (name.compare(0, 7, "struct "))
-    name = name.substr(6);
-#endif
-
-  return name;
-}
-
 static std::string DemangleWithAutoID(const std::type_info& ti) {
   auto retVal = demangle(ti);
 
   // prefix is at the beginning of the string, skip over it
-#ifdef _MSC_VER
-  static const char prefix [] = "struct auto_id<";
-#else
   static const char prefix [] = "auto_id<";
-#endif
 
   if (retVal.compare(0, sizeof(prefix) - 1, prefix) == 0) {
     size_t off = sizeof(prefix) - 1;
     retVal = retVal.substr(off, retVal.length() - off - 2);
   }
-  return TrimPrefix(retVal);
+  return retVal;
 }
 
 std::string autowiring::dbg::ContextName(void) {
@@ -120,7 +104,7 @@ static const AutoFilterDescriptor* DescriptorByName(const char* name, const std:
     if (!type)
       continue;
 
-    auto curName = TrimPrefix(demangle(type));
+    auto curName = demangle(type);
     if (!curName.compare(name))
       return &filter;
   }

--- a/src/autowiring/demangle.cpp
+++ b/src/autowiring/demangle.cpp
@@ -23,12 +23,33 @@ static std::string demangle_name(const char* name) {
 #else // Windows
 
 static std::string demangle_name(const char* name) {
-  std::string demangled(name);
-  
-  if (demangled.find("`") != std::string::npos)
-    return std::string();
-  
-  return demangled;
+  if (strchr(name, '`'))
+    return std::string{};
+
+  // Number of left <'s we have seen
+  int nLeft = 0;
+
+  // "class" or "struct" prefixes should be eliminated
+  std::ostringstream os;
+  while(*name) {
+    if (strncmp(name, "class ", 6) == 0) {
+      name += 6;
+      continue;
+    }
+    
+    if (strncmp(name, "struct ", 7) == 0) {
+      name += 7;
+      continue;
+    }
+
+    os << *name;
+    if(*name == ',')
+      // Put a space after all commas, required for proper template parsing
+      os << ' ';
+
+    name++;
+  }
+  return os.str();
 }
 
 #endif

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -34,6 +34,7 @@ set(AutowiringTest_SRCS
   CoreThreadTest.cpp
   CurrentContextPusherTest.cpp
   DecoratorTest.cpp
+  DemangleTest.cpp
   DispatchQueueTest.cpp
   DtorCorrectnessTest.hpp
   DtorCorrectnessTest.cpp

--- a/src/autowiring/test/DemangleTest.cpp
+++ b/src/autowiring/test/DemangleTest.cpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include <autowiring/autowiring.h>
+
+class DemangleTest:
+  public testing::Test
+{};
+
+class DemangleTestType {};
+
+TEST_F(DemangleTest, DemanglePreciseResultSimple) {
+  ASSERT_STREQ(
+    "DemangleTestType",
+    autowiring::demangle(typeid(DemangleTestType)).c_str()
+  ) << "Mismatch on a simple non-template type";
+}
+
+template<typename T>
+class TemplatedDemangleTestType {};
+
+TEST_F(DemangleTest, DemangleSingleTemplate) {
+  ASSERT_STREQ(
+    "TemplatedDemangleTestType<DemangleTestType>",
+    autowiring::demangle(typeid(TemplatedDemangleTestType<DemangleTestType>)).c_str()
+  ) << "Single templated type was not demangled correctly";
+}
+
+template<typename T, typename U>
+class TwoArgTemplatedDemangleTestType {};
+
+TEST_F(DemangleTest, DemangleDoubleTemplate) {
+  ASSERT_STREQ(
+    "TwoArgTemplatedDemangleTestType<DemangleTestType, DemangleTestType>",
+    autowiring::demangle(
+      typeid(TwoArgTemplatedDemangleTestType<DemangleTestType, DemangleTestType>)
+    ).c_str()
+  ) << "Single templated type was not demangled correctly";
+}


### PR DESCRIPTION
The return value of `autowiring::demangle` should be deterministic on all platforms.  Its nondeterminism is placing a lot of compensation requirements downstream that should not be necessary in a well-designed abstraction.  Also add unit test to guarantee this reliability on all platforms.