### PR TITLE
Do not use isspace on non-ASCII strings

### DIFF
--- a/src/autowiring/test/AutowiringDebugTest.cpp
+++ b/src/autowiring/test/AutowiringDebugTest.cpp
@@ -76,13 +76,13 @@ TEST_F(AutowiringDebugTest, ContextPrintout) {
                      "        └── Derp\n";
 
   // Remove whitespace so test is more robust
-  tree.erase(std::remove_if(tree.begin(), tree.end(), isspace), tree.end());
+  tree.erase(std::remove_if(tree.begin(), tree.end(), [](char ch) { return ch == ' '; }), tree.end());
 
   // Write output to stringstream an remove whitespace
   std::stringstream ss;
   autowiring::dbg::PrintContextTree(ss);
   auto output = ss.str();
-  output.erase(std::remove_if(output.begin(), output.end(), isspace), output.end());
+  output.erase(std::remove_if(output.begin(), output.end(), [](char ch) { return ch == ' '; }), output.end());
 
   ASSERT_EQ(tree, output) << "Didn't print correct tree";
 }


### PR DESCRIPTION
Characters like ├ are not actually ASCII characters, and it is an error to pass them to routines like `isspace`.  On Windows, this actually causes an assertion failure.  Furthermore, this test should probably care about the specific placement of newlines.

Use a handrolled lambda to eliminate spaces in particular while preserving newlines to get around this issue.