### PR TITLE
Prevent pointer types from being decorated onto an AutoPacket.

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -390,6 +390,7 @@ public:
   /// </remarks>
   template<class T>
   const T& Decorate(T t) {
+    static_assert(!std::is_pointer<T>::value, "Can't decorate using a pointer type.");
     // Create a copy of the input, put the copy in a shared pointer
     auto ptr = std::make_shared<T>(std::forward<T&&>(t));
     Decorate(


### PR DESCRIPTION
Added a static_assert which prohibits types T satisfying std::is_pointer<T>::value from being decorated onto an AutoWiring packet, because the ownership/lifetime issue of said pointer is not a concern that we want to deal with.