### PR TITLE
Add the ability to have the context itself be an input argument

### DIFF
--- a/autowiring/auto_arg.h
+++ b/autowiring/auto_arg.h
@@ -4,6 +4,7 @@
 #include "auto_in.h"
 #include "auto_out.h"
 #include "auto_prev.h"
+#include "SharedPointerSlot.h"
 
 class AutoPacket;
 class CoreContext;

--- a/autowiring/auto_arg.h
+++ b/autowiring/auto_arg.h
@@ -1,10 +1,12 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include "auto_id.h"
 #include "auto_in.h"
 #include "auto_out.h"
 #include "auto_prev.h"
 
 class AutoPacket;
+class CoreContext;
 
 /*
  The auto_arg<T> classes are used to generate of auto_in and auto_out types
@@ -260,7 +262,7 @@ public:
 /// AutoPacket specialization
 /// </summary>
 /// <remarks>
-/// This type is treated as an input type because it supports concurrent modification
+/// Because this type is immediately satisfied, it is neither an input nor an output
 /// </remarks>
 template<>
 class auto_arg<AutoPacket&>
@@ -269,7 +271,7 @@ public:
   typedef AutoPacket& type;
   typedef auto_in<AutoPacket> arg_type;
   typedef AutoPacket id_type;
-  static const bool is_input = true;
+  static const bool is_input = false;
   static const bool is_output = false;
   static const bool is_shared = false;
   static const bool is_multi = false;
@@ -278,6 +280,44 @@ public:
   static AutoPacket& arg(AutoPacket& packet) {
     return packet;
   }
+};
+
+/// <summary>
+/// CoreContext specialization
+/// </summary>
+template<>
+class auto_arg<CoreContext&>
+{
+public:
+  typedef CoreContext& type;
+  typedef CoreContext& arg_type;
+  typedef CoreContext id_type;
+  static const bool is_input = false;
+  static const bool is_output = false;
+  static const bool is_shared = false;
+  static const bool is_multi = false;
+  static const int tshift = 0;
+
+  static CoreContext& arg(AutoPacket&);
+};
+
+/// <summary>
+/// shared_ptr CoreContext specialization
+/// </summary>
+template<>
+class auto_arg<std::shared_ptr<CoreContext>>
+{
+public:
+  typedef std::shared_ptr<CoreContext> type;
+  typedef std::shared_ptr<CoreContext> arg_type;
+  typedef CoreContext id_type;
+  static const bool is_input = false;
+  static const bool is_output = false;
+  static const bool is_shared = false;
+  static const bool is_multi = false;
+  static const int tshift = 0;
+
+  static std::shared_ptr<CoreContext> arg(AutoPacket&);
 };
 
 /// <summary>
@@ -326,7 +366,6 @@ class auto_arg<T const *const*>:
 /// <summary>
 /// Shared pointer multi-in specialization
 /// </summary>
-/// </remarks>
 template<class T>
 class auto_arg<std::shared_ptr<const T>*>
 {

--- a/src/autowiring/AutoPacketInternal.cpp
+++ b/src/autowiring/AutoPacketInternal.cpp
@@ -45,28 +45,6 @@ void AutoPacketInternal::Initialize(bool isFirstPacket) {
   // NOTE: This may result in decorations that cause other subscribers to be called.
   for (SatCounter* call : callCounters)
     call->GetCall()(call->GetAutoFilter(), *this);
-
-  std::vector<SatCounter*> callQueue;
-  {
-    // First-call indicated by argumument type AutoPacket&:
-    std::lock_guard<std::mutex> lk(m_lock);
-
-    // Manual handling of the AutoPacket input type:
-    auto q = m_decorations.find(DecorationKey(typeid(auto_arg<AutoPacket&>::id_type), 0));
-    if (q == m_decorations.end())
-      return;
-
-    q->second.m_state = DispositionState::Complete;
-    for (auto subscriber : q->second.m_subscribers) {
-      auto* satCounter = subscriber.satCounter;
-      if (satCounter->Decrement())
-        callQueue.push_back(satCounter);
-    }
-  }
-
-  // Generate all calls
-  for (SatCounter* call : callQueue)
-    call->GetCall()(call->GetAutoFilter(), *this);
 }
 
 std::shared_ptr<AutoPacketInternal> AutoPacketInternal::SuccessorInternal(void) {

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -15,10 +15,16 @@ set(Autowiring_SRCS
   atomic_object.h
   at_exit.h
   altitude.h
+  auto_arg.h
+  auto_arg.cpp
   auto_id.h
+  auto_in.h
   auto_future.h
+  auto_out.h
+  auto_prev.h
   auto_signal.h
   auto_signal.cpp
+  auto_tuple.h
   AutoConfig.h
   AutoConfigBase.cpp
   AutoConfigBase.h
@@ -59,11 +65,6 @@ set(Autowiring_SRCS
   AutowiringEvents.h
   autowiring_error.cpp
   autowiring_error.h
-  auto_arg.h
-  auto_in.h
-  auto_out.h
-  auto_prev.h
-  auto_tuple.h
   BasicThread.cpp
   BasicThread.h
   BasicThreadStateBlock.cpp

--- a/src/autowiring/auto_arg.cpp
+++ b/src/autowiring/auto_arg.cpp
@@ -1,0 +1,12 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "auto_arg.h"
+#include "CoreContext.h"
+
+CoreContext& auto_arg<CoreContext&>::arg(AutoPacket&) {
+  return *CoreContext::CurrentContext();
+}
+
+std::shared_ptr<CoreContext> auto_arg<std::shared_ptr<CoreContext>>::arg(AutoPacket&) {
+  return CoreContext::CurrentContext();
+}

--- a/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
+++ b/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
@@ -198,3 +198,22 @@ TEST_F(AutoFilterCollapseRulesTest, AutoPrevInheritance) {
     packet->Decorate(baseVec);
   }
 }
+
+TEST_F(AutoFilterCollapseRulesTest, CoreContextArg) {
+  AutoCurrentContext ctxt;
+  AutoRequired<AutoPacketFactory> factory;
+
+  bool match1 = false;
+  bool match2 = false;
+
+  *factory += [ctxt, &match1](CoreContext& ctxtArg) {
+    match1 = ctxt.get() == &ctxtArg;
+  };
+  *factory += [ctxt, &match2](std::shared_ptr<CoreContext> ctxtArg) {
+    match2 = ctxt.get() == ctxtArg.get();
+  };
+
+  auto packet = factory->NewPacket();
+  ASSERT_TRUE(match1) << "Reference input argument did not match expected";
+  ASSERT_TRUE(match2) << "Shared pointer input argument did not match expectation";
+}


### PR DESCRIPTION
While this is equivalent to referencing `AutoCurrentContext` inside the `AutoFilter` method, some users prefer the more explicit form of having `CoreContext` named expressly.

Also simplify the `AutoPacketInternal::Ininitialize` routine by avoiding any kind of special case handling.