### PR TITLE
Fix another conversion warning

### DIFF
--- a/src/autowiring/test/AutoFilterConstructRulesTest.cpp
+++ b/src/autowiring/test/AutoFilterConstructRulesTest.cpp
@@ -15,7 +15,7 @@ public:
 
     uint8_t* pRetVal = ::new uint8_t[ncb];
     for (size_t i = 0; i < ncb; i++)
-      pRetVal[i] = (i + 1) * 101;
+      pRetVal[i] = static_cast<uint8_t>((i + 1) * 101);
     return pRetVal;
   }
 


### PR DESCRIPTION
An explicit cast here is appropriate, we really do want to drop data.