### PR TITLE
Add a CoreContext& overload to CurrentContextPusher

### DIFF
--- a/autowiring/CurrentContextPusher.h
+++ b/autowiring/CurrentContextPusher.h
@@ -20,6 +20,7 @@ public:
   /// </summary>
   CurrentContextPusher(void);
 
+  CurrentContextPusher(CoreContext& context);
   CurrentContextPusher(std::shared_ptr<CoreContext> pContext);
   CurrentContextPusher(std::shared_ptr<GlobalCoreContext> pContext);
   CurrentContextPusher(CoreContext* pContext);

--- a/src/autowiring/CurrentContextPusher.cpp
+++ b/src/autowiring/CurrentContextPusher.cpp
@@ -7,6 +7,10 @@ CurrentContextPusher::CurrentContextPusher(void):
   m_prior(CoreContext::CurrentContextOrNull())
 {}
 
+CurrentContextPusher::CurrentContextPusher(CoreContext& context):
+  m_prior(context.SetCurrent())
+{}
+
 CurrentContextPusher::CurrentContextPusher(std::shared_ptr<CoreContext> pContext):
   m_prior(pContext->SetCurrent())
 {}


### PR DESCRIPTION
If we expect people to plumb `CoreContext`, we should allow this type to be accepted anywhere that a shared pointer is accepted.