### PR TITLE
Convert a whole bunch of std::shared_ptr

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -369,7 +369,7 @@ public:
   /// Furthermore, types that are unsatisfied in this context will not be marked as
   /// unsatisfied in the recipient - only present data will be provided.
   /// </remarks>
-  void ForwardAll(std::shared_ptr<AutoPacket> recipient) const;
+  void ForwardAll(const std::shared_ptr<AutoPacket>& recipient) const;
 
   /// <summary>
   /// Marks the named decoration as unsatisfiable
@@ -413,7 +413,7 @@ public:
   /// If the passed value is null, the corresponding value will be marked unsatisfiable.
   /// </remarks>
   template<class T>
-  void Decorate(std::shared_ptr<T> ptr) {
+  void Decorate(const std::shared_ptr<T>& ptr) {
     DecorationKey key(auto_id<T>::key(), 0);
     
     // We don't want to see this overload used on a const T
@@ -437,7 +437,7 @@ public:
   /// shared pointer.
   /// </remarks>
   template<class T>
-  void Decorate(std::shared_ptr<const T> ptr) {
+  void Decorate(const std::shared_ptr<const T>& ptr) {
     Decorate(std::const_pointer_cast<T>(ptr));
   }
 

--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -65,11 +65,11 @@ public:
     std::shared_ptr<CoreContext>(CoreContext::CurrentContext()->Create<T>(std::move(inj)))
   {}
 
-  AutoCreateContextT(std::shared_ptr<CoreContext>& ctxt) :
+  AutoCreateContextT(const std::shared_ptr<CoreContext>& ctxt) :
     std::shared_ptr<CoreContext>(ctxt->Create<T>())
   {}
 
-  AutoCreateContextT(std::shared_ptr<CoreContext>& ctxt, AutoInjectable&& inj) :
+  AutoCreateContextT(const std::shared_ptr<CoreContext>& ctxt, AutoInjectable&& inj) :
     std::shared_ptr<CoreContext>(ctxt->Create<T>(std::move(inj)))
   {}
 };

--- a/autowiring/AutowiringDebug.h
+++ b/autowiring/AutowiringDebug.h
@@ -59,7 +59,7 @@ std::vector<std::string> ListRootDecorations(void);
 /// <returns> string representation of DOT file, or outputs to 'os' </returns>
 std::string WriteAutoFilterGraph(void);
 void WriteAutoFilterGraph(std::ostream& os);
-void WriteAutoFilterGraph(std::ostream& os, std::shared_ptr<CoreContext> ctxt);
+void WriteAutoFilterGraph(std::ostream& os, const std::shared_ptr<CoreContext>& ctxt);
 
 /// <summary>
 /// Initializes the Autowiring debug library

--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -149,7 +149,7 @@ class CoreContext:
 {
 protected:
   typedef std::list<std::weak_ptr<CoreContext>> t_childList;
-  CoreContext(std::shared_ptr<CoreContext> pParent, t_childList::iterator backReference);
+  CoreContext(const std::shared_ptr<CoreContext>& pParent, t_childList::iterator backReference);
 
 public:
   virtual ~CoreContext(void);
@@ -1174,7 +1174,7 @@ public:
   ///
   /// It is an error to pass nullptr to this method.
   /// </remarks>
-  void SetThreadPool(std::shared_ptr<autowiring::ThreadPool> threadPool);
+  void SetThreadPool(const std::shared_ptr<autowiring::ThreadPool>& threadPool);
 
   /// <summary>
   /// Returns the current thread pool
@@ -1280,7 +1280,7 @@ class CoreContextT:
 public:
   static const std::type_info& sc_type;
 
-  CoreContextT(std::shared_ptr<CoreContext> pParent, t_childList::iterator backReference) :
+  CoreContextT(const std::shared_ptr<CoreContext>& pParent, t_childList::iterator backReference) :
     CoreContext(pParent, backReference)
   {}
 

--- a/autowiring/CurrentContextPusher.h
+++ b/autowiring/CurrentContextPusher.h
@@ -21,8 +21,8 @@ public:
   CurrentContextPusher(void);
 
   CurrentContextPusher(CoreContext& context);
-  CurrentContextPusher(std::shared_ptr<CoreContext> pContext);
-  CurrentContextPusher(std::shared_ptr<GlobalCoreContext> pContext);
+  CurrentContextPusher(const std::shared_ptr<CoreContext>& pContext);
+  CurrentContextPusher(const std::shared_ptr<GlobalCoreContext>& pContext);
   CurrentContextPusher(CoreContext* pContext);
   CurrentContextPusher(CurrentContextPusher&& rhs);
   ~CurrentContextPusher(void);

--- a/autowiring/InvokeRelay.h
+++ b/autowiring/InvokeRelay.h
@@ -16,7 +16,7 @@ class InvokeRelay<RetType (T::*)(Args...)> {
 public:
   InvokeRelay(void) = default;
 
-  InvokeRelay(std::shared_ptr<JunctionBox<T>> erp, RetType (T::*fnPtr)(Args...)) :
+  InvokeRelay(const std::shared_ptr<JunctionBox<T>>& erp, RetType (T::*fnPtr)(Args...)) :
     erp(erp),
     fnPtr(fnPtr)
   {}
@@ -56,6 +56,6 @@ public:
 /// Makes an invocation relay for a particular junction box and function pointer
 /// </summary>
 template<typename T, typename FnPtr>
-InvokeRelay<FnPtr> MakeInvokeRelay(std::shared_ptr<JunctionBox<T>> pJunctionBox, FnPtr fnPtr) {
+InvokeRelay<FnPtr> MakeInvokeRelay(const std::shared_ptr<JunctionBox<T>>& pJunctionBox, FnPtr fnPtr) {
   return InvokeRelay<FnPtr>(pJunctionBox, fnPtr);
 }

--- a/autowiring/JunctionBoxEntry.h
+++ b/autowiring/JunctionBoxEntry.h
@@ -26,7 +26,7 @@ struct JunctionBoxEntry:
 {
   JunctionBoxEntry(void) {}
 
-  JunctionBoxEntry(CoreContext* owner, std::shared_ptr<T> ptr) :
+  JunctionBoxEntry(CoreContext* owner, const std::shared_ptr<T>& ptr) :
     JunctionBoxEntryBase(owner),
     m_ptr(ptr)
   {}

--- a/autowiring/ManualThreadPool.h
+++ b/autowiring/ManualThreadPool.h
@@ -8,7 +8,7 @@ namespace autowiring {
 class ManualThreadPool;
 
 struct ThreadPoolToken {
-  ThreadPoolToken(std::shared_ptr<ManualThreadPool> manualPool) :
+  ThreadPoolToken(const std::shared_ptr<ManualThreadPool>& manualPool) :
     manualPool(manualPool)
   {}
 

--- a/autowiring/NullPool.h
+++ b/autowiring/NullPool.h
@@ -32,7 +32,7 @@ public:
   /// <summary>
   /// Sets the pool that will be used by the owning context when the owning context initiates
   /// </summary>
-  void SetSuccessor(std::shared_ptr<ThreadPool> successor);
+  void SetSuccessor(const std::shared_ptr<ThreadPool>& successor);
 
   /// <summary>
   /// Causes all internally held dispatchers to be moved to the successor pool, then clears this pool

--- a/autowiring/SystemThreadPoolWin.h
+++ b/autowiring/SystemThreadPoolWin.h
@@ -34,7 +34,7 @@ private:
 
 public:
   // ThreadPool overrides:
-  void Consume(std::shared_ptr<DispatchQueue> dq) override;
+  void Consume(const std::shared_ptr<DispatchQueue>& dq) override;
   bool Submit(std::unique_ptr<DispatchThunkBase>&& thunk) override;
 };
 

--- a/autowiring/ThreadPool.h
+++ b/autowiring/ThreadPool.h
@@ -70,7 +70,7 @@ public:
   /// This method is guaranteed not to block.  The default implementation captures the passed
   /// queue in a lambda and invokes Submit with this constructed lambda.
   /// </remarks>
-  virtual void Consume(std::shared_ptr<DispatchQueue> dq);
+  virtual void Consume(const std::shared_ptr<DispatchQueue>& dq);
 
   /// <summary>
   /// Adds the specified thunk to be executed by the thread pool at some later time

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -419,7 +419,7 @@ AutoPacket::t_decorationMap AutoPacket::GetDecorations(void) const
   return m_decorations;
 }
 
-void AutoPacket::ForwardAll(std::shared_ptr<AutoPacket> recipient) const {
+void AutoPacket::ForwardAll(const std::shared_ptr<AutoPacket>& recipient) const {
   // Copy decorations into an internal decorations maintenance collection.  The values
   // in this collection are guaranteed to be stable in memory, and there are stable states
   // that can be relied upon without synchronization.

--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -209,7 +209,7 @@ std::string WriteAutoFilterGraph(void) {
   return ss.str();
 }
 
-void autowiring::dbg::WriteAutoFilterGraph(std::ostream& os, std::shared_ptr<CoreContext> ctxt) {
+void autowiring::dbg::WriteAutoFilterGraph(std::ostream& os, const std::shared_ptr<CoreContext>& ctxt) {
   CurrentContextPusher pshr(ctxt);
   Autowired<AutoPacketFactory> factory;
 

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -53,7 +53,7 @@ public:
 static thread_specific_ptr<std::shared_ptr<CoreContext>> autoCurrentContext;
 
 // Peer Context Constructor. Called interally by CreatePeer
-CoreContext::CoreContext(std::shared_ptr<CoreContext> pParent, t_childList::iterator backReference) :
+CoreContext::CoreContext(const std::shared_ptr<CoreContext>& pParent, t_childList::iterator backReference) :
   m_pParent(pParent),
   m_backReference(backReference),
   m_stateBlock(new CoreContextStateBlock),
@@ -698,7 +698,7 @@ void CoreContext::BuildCurrentState(void) {
   }
 }
 
-void CoreContext::SetThreadPool(std::shared_ptr<ThreadPool> threadPool) {
+void CoreContext::SetThreadPool(const std::shared_ptr<ThreadPool>& threadPool) {
   if (!threadPool)
     throw std::invalid_argument("A context cannot be given a null thread pool");
 

--- a/src/autowiring/CurrentContextPusher.cpp
+++ b/src/autowiring/CurrentContextPusher.cpp
@@ -11,11 +11,11 @@ CurrentContextPusher::CurrentContextPusher(CoreContext& context):
   m_prior(context.SetCurrent())
 {}
 
-CurrentContextPusher::CurrentContextPusher(std::shared_ptr<CoreContext> pContext):
+CurrentContextPusher::CurrentContextPusher(const std::shared_ptr<CoreContext>& pContext) :
   m_prior(pContext->SetCurrent())
 {}
 
-CurrentContextPusher::CurrentContextPusher(std::shared_ptr<GlobalCoreContext> pContext) :
+CurrentContextPusher::CurrentContextPusher(const std::shared_ptr<GlobalCoreContext>& pContext) :
   m_prior(pContext->SetCurrent())
 {}
 

--- a/src/autowiring/NullPool.cpp
+++ b/src/autowiring/NullPool.cpp
@@ -10,7 +10,7 @@ NullPool::NullPool(void)
 NullPool::~NullPool(void)
 {}
 
-void NullPool::SetSuccessor(std::shared_ptr<ThreadPool> successor) {
+void NullPool::SetSuccessor(const std::shared_ptr<ThreadPool>& successor) {
   std::lock_guard<std::mutex> lk(m_lock);
   m_successor = successor;
 }

--- a/src/autowiring/SystemThreadPoolWin.cpp
+++ b/src/autowiring/SystemThreadPoolWin.cpp
@@ -60,7 +60,7 @@ void SystemThreadPoolWin::OnStop(void) {
   m_pwkDispatchRundown = nullptr;
 }
 
-void SystemThreadPoolWin::Consume(std::shared_ptr<DispatchQueue> dq)
+void SystemThreadPoolWin::Consume(const std::shared_ptr<DispatchQueue>& dq)
 {
   // Append the entry and then signal the rundown queue that there is work to be done
   std::lock_guard<std::mutex> lk(m_lock);

--- a/src/autowiring/ThreadPool.cpp
+++ b/src/autowiring/ThreadPool.cpp
@@ -24,7 +24,7 @@ std::shared_ptr<void> ThreadPool::Start(void) {
 }
 
 
-void ThreadPool::Consume(std::shared_ptr<DispatchQueue> dq) {
+void ThreadPool::Consume(const std::shared_ptr<DispatchQueue>& dq) {
   Submit(
     MakeDispatchThunk(
       [dq] { dq->DispatchAllEvents(); }


### PR DESCRIPTION
`std::shared_ptr`, when passed by value, is actually quite inefficient because of the acquire and release semantics required by the underlying implementation for cache coherency reasons.  Wherever possible, pass this type by const reference rather than by value.