### PR TITLE
Auto out

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -68,7 +68,7 @@ protected:
   // Decorations are indexed first by type and second by pipe terminating type, if any.
   // NOTE: This is a disambiguation of function reference assignment, and avoids use of constexp.
   typedef std::unordered_map<DecorationKey, DecorationDisposition> t_decorationMap;
-  t_decorationMap m_decorations;
+  t_decorationMap m_decoration_map;
 
   mutable std::mutex m_lock;
 
@@ -285,8 +285,8 @@ public:
   template<class T>
   bool Get(std::shared_ptr<const T>& out, int tshift = 0) const {
     std::lock_guard<std::mutex> lk(m_lock);
-    auto deco = m_decorations.find(DecorationKey(auto_id<T>::key(), tshift));
-    if(deco != m_decorations.end() && deco->second.m_state == DispositionState::Complete) {
+    auto deco = m_decoration_map.find(DecorationKey(auto_id<T>::key(), tshift));
+    if(deco != m_decoration_map.end() && deco->second.m_state == DispositionState::Complete) {
       auto& disposition = deco->second;
       if(disposition.m_decorations.size() == 1) {
         out = disposition.m_decorations[0]->as_unsafe<T>();
@@ -316,8 +316,8 @@ public:
     std::lock_guard<std::mutex> lk(m_lock);
 
     // If decoration doesn't exist, return empty null-terminated buffer
-    auto q = m_decorations.find(DecorationKey(auto_id<T>::key(), tshift));
-    if (q == m_decorations.end())
+    auto q = m_decoration_map.find(DecorationKey(auto_id<T>::key(), tshift));
+    if (q == m_decoration_map.end())
       return std::unique_ptr<const T*[]>{
         new const T*[1] {nullptr}
       };
@@ -341,8 +341,8 @@ public:
     typedef typename std::remove_const<T>::type TActual;
 
     // If decoration doesn't exist, return empty null-terminated buffer
-    auto q = m_decorations.find(DecorationKey(auto_id<TActual>::key(), tshift));
-    if (q == m_decorations.end())
+    auto q = m_decoration_map.find(DecorationKey(auto_id<TActual>::key(), tshift));
+    if (q == m_decoration_map.end())
       return std::unique_ptr<std::shared_ptr<const T>[]>{
         new std::shared_ptr<const T>[1] {nullptr}
       };

--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -48,6 +48,11 @@ public:
   AutoPacket(AutoPacketFactory& factory, std::shared_ptr<void>&& outstanding);
   ~AutoPacket();
 
+  // The set of decorations currently attached to this object, and the associated lock:
+  // Decorations are indexed first by type and second by pipe terminating type, if any.
+  // NOTE: This is a disambiguation of function reference assignment, and avoids use of constexp.
+  typedef std::unordered_map<DecorationKey, DecorationDisposition> t_decorationMap;
+
 protected:
   // A pointer back to the factory that created us. Used for recording lifetime statistics.
   const std::shared_ptr<AutoPacketFactory> m_parentFactory;
@@ -64,10 +69,6 @@ protected:
   // Pointer to a forward linked list of saturation counters, constructed when the packet is created
   SatCounter* m_firstCounter = nullptr;
 
-  // The set of decorations currently attached to this object, and the associated lock:
-  // Decorations are indexed first by type and second by pipe terminating type, if any.
-  // NOTE: This is a disambiguation of function reference assignment, and avoids use of constexp.
-  typedef std::unordered_map<DecorationKey, DecorationDisposition> t_decorationMap;
   t_decorationMap m_decoration_map;
 
   mutable std::mutex m_lock;

--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -165,12 +165,14 @@ protected:
 
 public:
   /// <returns>
-  /// The number of distinct decoration types on this packet
+  /// The number of distinct decoration types on this packet (this is really an implementation-detail-based count
+  /// of the parameters of all relevant filters, including lambdas appended to this packet).
   /// </returns>
   size_t GetDecorationTypeCount(void) const;
 
   /// <returns>
-  /// A copy of the decoration dispositions collection
+  /// A copy of the decoration dispositions collection (this is really an implementation-detail-based description
+  /// of the parameters of all relevant filters, including lambdas appended to this packet).
   /// </returns>
   /// <remarks>
   /// This is a diagnostic method, users are recommended to avoid the use of this routine where possible
@@ -377,7 +379,17 @@ public:
   /// form std::shared_ptr<const T> to be called, if the remainder of their inputs are available.
   /// </remarks>
   template<class T>
-  void Unsatisfiable(void) {
+  void DEPRECATED(Unsatisfiable(void), "Unsatisfiable is deprecated; use MarkUnsatisfiable instead.");
+
+  /// <summary>
+  /// Marks the named decoration as unsatisfiable
+  /// </summary>
+  /// <remarks>
+  /// Marking a decoration as unsatisfiable immediately causes any filters with an input of the
+  /// form std::shared_ptr<const T> to be called, if the remainder of their inputs are available.
+  /// </remarks>
+  template<class T>
+  void MarkUnsatisfiable(void) {
     MarkUnsatisfiable(DecorationKey(auto_id<T>::key(), 0));
   }
 
@@ -640,3 +652,8 @@ public:
   /// Get the context of this packet (The context of the AutoPacketFactory that created this context)
   std::shared_ptr<CoreContext> GetContext(void) const;
 };
+
+template<class T>
+void AutoPacket::Unsatisfiable(void) {
+  MarkUnsatisfiable(DecorationKey(auto_id<T>::key(), 0));
+}

--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -389,10 +389,31 @@ public:
   /// value regardless of whether any subscribers exist.
   /// </remarks>
   template<class T>
-  const T& Decorate(T t) {
+  const T& Decorate(T&& t) {
+    typedef typename std::remove_reference<T>::type BaseType;
+    static_assert(!std::is_pointer<BaseType>::value, "Can't decorate using a pointer type.");
+    // Create a copy of the input, put the copy in a shared pointer
+    auto ptr = std::make_shared<BaseType>(std::forward<T>(t));
+    Decorate(
+      AnySharedPointer(ptr),
+      DecorationKey(auto_id<BaseType>::key(), 0)
+    );
+    return *ptr;
+  }
+
+  /// <summary>
+  /// Decorates this packet with a particular type T, forwarding the arguments to the constructor of T.
+  /// </summary>
+  /// <returns>A reference to the internally persisted object</returns>
+  /// <remarks>
+  /// The Decorate method is unconditional and will install the passed
+  /// value regardless of whether any subscribers exist.
+  /// </remarks>
+  template<class T, typename... Args>
+  const T& Decorate(Args&&... args) {
     static_assert(!std::is_pointer<T>::value, "Can't decorate using a pointer type.");
     // Create a copy of the input, put the copy in a shared pointer
-    auto ptr = std::make_shared<T>(std::forward<T&&>(t));
+    auto ptr = std::make_shared<T>(std::forward<Args>(args)...);
     Decorate(
       AnySharedPointer(ptr),
       DecorationKey(auto_id<T>::key(), 0)

--- a/autowiring/CallExtractor.h
+++ b/autowiring/CallExtractor.h
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "auto_arg.h"
+#include "auto_in.h"
 #include "auto_tuple.h"
 #include "AutoPacket.h"
 #include "CurrentContextPusher.h"

--- a/autowiring/CallExtractor.h
+++ b/autowiring/CallExtractor.h
@@ -40,7 +40,7 @@ struct CallExtractorSetup
     auto_arg<typename autowiring::nth_type<N, Args...>::type>::is_output,
     bool
   >::type Commit(bool) {
-    packet.Decorate(autowiring::get<N>(args));
+    auto_arg<typename autowiring::nth_type<N, Args...>::type>::Commit(packet, autowiring::get<N>(args));
     return true;
   }
 

--- a/autowiring/auto_arg.h
+++ b/autowiring/auto_arg.h
@@ -117,6 +117,8 @@ class auto_arg<auto_in<T>>:
   public auto_arg<T>
 {};
 
+namespace Internal {
+
 /// <summary>
 /// Construction helper for output-by-reference decoration types
 /// </summary>
@@ -158,6 +160,8 @@ struct auto_arg_ctor_helper<T, has_default, false> {
   }
 };
 
+} // end of namespace Internal
+
 /// <summary>
 /// Specialization for "T&" ~ auto_out<T>
 /// </summary>
@@ -185,7 +189,8 @@ public:
   static const int tshift = 0;
 
   static std::shared_ptr<T> arg(AutoPacket& packet) {
-    return auto_arg_ctor_helper<T>::arg(packet);
+    return Internal::auto_arg_ctor_helper<T>::arg(packet);
+  }
 
   template<class C>
   static void Commit (C& packet, type val) {

--- a/autowiring/auto_arg.h
+++ b/autowiring/auto_arg.h
@@ -186,6 +186,10 @@ public:
 
   static std::shared_ptr<T> arg(AutoPacket& packet) {
     return auto_arg_ctor_helper<T>::arg(packet);
+
+  template<class C>
+  static void Commit (C& packet, type val) {
+    packet.template Decorate<T>(val);
   }
 };
 

--- a/autowiring/auto_arg.h
+++ b/autowiring/auto_arg.h
@@ -1,12 +1,12 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "auto_id.h"
-#include "auto_in.h"
-#include "auto_out.h"
 #include "auto_prev.h"
 #include "SharedPointerSlot.h"
 
 class AutoPacket;
+template <class T> class auto_in;
+template <class T> class auto_out;
 class CoreContext;
 
 /*
@@ -235,15 +235,28 @@ class auto_arg<std::shared_ptr<T>> {
   );
 };
 
-/// <summary>
-/// Specialization for equivalent T auto_out<T>
-/// </summary>
 template<class T>
-class auto_arg<auto_out<T>>:
-  public auto_arg<T&>
+class auto_arg<auto_out<T>>
 {
 public:
+
+  typedef auto_out<T> type;
   typedef auto_out<T> arg_type;
+  typedef auto_id<T> id_type;
+  static const bool is_input = false;
+  static const bool is_output = true;
+  static const bool is_shared = false;
+  static const bool is_multi = false;
+  static const int tshift = 0;
+
+  static auto_out<T> arg(AutoPacket& packet) {
+    return auto_out<T>(packet);
+  }
+
+  template<class C>
+  static void Commit (C& packet, type val) {
+    // Do nothing -- auto_out does its own deferred decoration.
+  }
 };
 
 template<class T, int N>

--- a/autowiring/auto_id.h
+++ b/autowiring/auto_id.h
@@ -13,7 +13,7 @@
 template<class T>
 struct auto_id {
   
-  // Return this type_info for this type with 'const' and 'volitile' removed
+  // Return this type_info for this type with 'const' and 'volatile' removed
   static const std::type_info& key(void) {
     return typeid(auto_id<typename std::remove_cv<T>::type>);
   }

--- a/autowiring/auto_out.h
+++ b/autowiring/auto_out.h
@@ -44,7 +44,7 @@ private:
     auto_out_impl (auto_out_impl &&aoi) : m_packet(std::move(aoi.m_packet)), m_decoration(std::move(aoi.m_decoration)) { }
     ~auto_out_impl () {
       if (!m_decoration)
-        m_packet->Unsatisfiable<T>();
+        m_packet->MarkUnsatisfiable<T>();
     }
     const T &operator * () const {
       AssertValidity();

--- a/autowiring/auto_out.h
+++ b/autowiring/auto_out.h
@@ -15,20 +15,26 @@ class auto_out
 {
 public:
 
-  auto_out () = delete; // This allows us to guarantee that m_auto_out_impl is always a valid shared_ptr.
+  auto_out () { }
   auto_out (AutoPacket &packet) : m_auto_out_impl(std::make_shared<auto_out_impl>(packet)) { }
   auto_out (const auto_out &ao) : m_auto_out_impl(ao.m_auto_out_impl) { }
   auto_out (auto_out &&ao) : m_auto_out_impl(std::move(ao.m_auto_out_impl)) { }
 
-  const T &operator * () const { AssertValidityGuarantee(); return m_auto_out_impl->operator*(); }
-  const T *operator -> () const { AssertValidityGuarantee(); return m_auto_out_impl->operator->(); }
-  auto_out &operator= (const T &t) { AssertValidityGuarantee(); m_auto_out_impl->operator=(t); }
-  auto_out &operator= (T &&t) { AssertValidityGuarantee(); m_auto_out_impl->operator=(std::forward<T>(t)); }
-  auto_out &operator= (const std::shared_ptr<T> &t) { AssertValidityGuarantee(); m_auto_out_impl->operator=(t); }
+  operator bool () const { return bool(m_auto_out_impl); }
+  const T &operator * () const { ThrowIfInvalid(); return m_auto_out_impl->operator*(); }
+  const T *operator -> () const { ThrowIfInvalid(); return m_auto_out_impl->operator->(); }
+  auto_out &operator= (const auto_out &ao) { m_auto_out_impl = ao.m_auto_out_impl; }
+  auto_out &operator= (auto_out &&ao) { m_auto_out_impl = std::move(ao.m_auto_out_impl); }
+  auto_out &operator= (const T &t) { ThrowIfInvalid(); m_auto_out_impl->operator=(t); }
+  auto_out &operator= (T &&t) { ThrowIfInvalid(); m_auto_out_impl->operator=(std::forward<T>(t)); }
+  auto_out &operator= (const std::shared_ptr<T> &t) { ThrowIfInvalid(); m_auto_out_impl->operator=(t); }
   
 private:
   
-  void AssertValidityGuarantee () { assert(m_auto_out_impl && "m_auto_out_impl should never be null."); }
+  void ThrowIfInvalid () const {
+    if (!m_auto_out_impl)
+      throw autowiring_error("Can't dereference or assign to an invalid auto_out<T>.");
+  }
   
   struct auto_out_impl {
   public:
@@ -41,39 +47,40 @@ private:
         m_packet->Unsatisfiable<T>();
     }
     const T &operator * () const {
-      assert(bool(m_packet) && "m_packet should never be null.");
+      AssertValidity();
       if (!m_decoration)
         throw autowiring_error("Can't get a reference to an instance of T before it has been Decorated to the packet (in this case by assigning to the auto_out<T> via operator=.");
       return *m_decoration;
     }
     const T *operator -> () const {
-      assert(bool(m_packet) && "m_packet should never be null.");
+      AssertValidity();
       if (!m_decoration)
         throw autowiring_error("Can't get a reference to an instance of T before it has been Decorated to the packet (in this case by assigning to the auto_out<T> via operator=.");
       return m_decoration.get();
     }
     void operator= (const T &t) {
-      assert(bool(m_packet) && "m_packet should never be null.");
+      AssertValidity();
       if (!m_decoration) {
         m_packet->Decorate<T>(t);
         m_packet->Get<T>(m_decoration);
       }
     }
     void operator= (T &&t) {
-      assert(bool(m_packet) && "m_packet should never be null.");
+      AssertValidity();
       if (!m_decoration) {
         m_packet->Decorate<T>(std::forward<T>(t));
         m_packet->Get<T>(m_decoration);
       }
     }
     void operator= (const std::shared_ptr<T> &t) {
-      assert(bool(m_packet) && "m_packet should never be null.");
+      AssertValidity();
       if (!m_decoration) {
         m_packet->Decorate<T>(t);
         m_packet->Get<T>(m_decoration);
       }
     }
   private:
+    void AssertValidity () { assert(bool(m_packet) && "m_packet should never be null."); }
     std::shared_ptr<AutoPacket> m_packet;
     std::shared_ptr<const T> m_decoration;
   };

--- a/autowiring/auto_out.h
+++ b/autowiring/auto_out.h
@@ -24,6 +24,7 @@ public:
   const T *operator -> () const { AssertValidityGuarantee(); return m_auto_out_impl->operator->(); }
   auto_out &operator= (const T &t) { AssertValidityGuarantee(); m_auto_out_impl->operator=(t); }
   auto_out &operator= (T &&t) { AssertValidityGuarantee(); m_auto_out_impl->operator=(std::forward<T>(t)); }
+  auto_out &operator= (const std::shared_ptr<T> &t) { AssertValidityGuarantee(); m_auto_out_impl->operator=(t); }
   
 private:
   
@@ -62,6 +63,13 @@ private:
       assert(bool(m_packet) && "m_packet should never be null.");
       if (!m_decoration) {
         m_packet->Decorate<T>(std::forward<T>(t));
+        m_packet->Get<T>(m_decoration);
+      }
+    }
+    void operator= (const std::shared_ptr<T> &t) {
+      assert(bool(m_packet) && "m_packet should never be null.");
+      if (!m_decoration) {
+        m_packet->Decorate<T>(t);
         m_packet->Get<T>(m_decoration);
       }
     }

--- a/autowiring/auto_out.h
+++ b/autowiring/auto_out.h
@@ -2,70 +2,73 @@
 #pragma once
 #include MEMORY_HEADER
 
+#include "AutoPacket.h"
+#include "autowiring_error.h"
+
 /// <summary>
-/// Declares an output of an AutoFilter method via an argument.
+/// TODO write these comments
 /// </summary>
 /// <remarks>
-/// Lazy allocation is implemented, and is triggered on destruction.
-/// Any attempt to access the referenced data will trigger
-/// instantiation and a commitment to output the data.
-/// Moved construction and assignment removes the option to output
-/// from the r-value operand, but does *not* force an output.
 /// </remarks>
-template<class T>
+template <class T>
 class auto_out
 {
 public:
-  typedef T id_type;
 
-  auto_out(const auto_out<T>& rhs):
-    m_value(rhs.m_value)
-  {}
+  auto_out () = delete; // This allows us to guarantee that m_auto_out_impl is always a valid shared_ptr.
+  auto_out (AutoPacket &packet) : m_auto_out_impl(std::make_shared<auto_out_impl>(packet)) { }
+  auto_out (const auto_out &ao) : m_auto_out_impl(ao.m_auto_out_impl) { }
+  auto_out (auto_out &&ao) : m_auto_out_impl(std::move(ao.m_auto_out_impl)) { }
 
-  auto_out(std::shared_ptr<T>& value) :
-    m_value(value)
-  {}
-
-protected:
-  std::shared_ptr<T>& m_value;
-
-public:
-  /// <summary>
-  /// Returns the dumb pointer to the underlying output value
-  /// </summary>
-  T* get(void) const { return m_value.get(); }
-
-  /// <summary>
-  /// Releases the internal shared pointer, preventing it from being decorated on the packet
-  /// </summary>
-  void reset(void) {
-    m_value.reset();
-  }
-
-  // Convenience operator overloads
-  T& operator* () { return *m_value; }
-  T* operator-> () { return m_value.get(); }
-  explicit operator bool() const { return m_value; }
-  operator T&(void) { return *m_value; }
-  operator std::shared_ptr<T>&(void) { return m_value; }
-
-  /// <summary>Output will be shared data provided by rhs</summary>
-  /// <remarks>
-  /// This method faciliates output of shared ObjectPool data, with
-  /// destructors defined accordingly.
-  /// </remarks>
-  auto_out& operator=(std::shared_ptr<T> rhs) {
-    std::swap(m_value, rhs);
-    return *this;
-  }
-
-  auto_out& operator=(T&& rhs) {
-    m_value = std::make_shared<T>(std::forward<T&&>(rhs));
-    return *this;
-  }
-
-  auto_out& operator=(const T& rhs) {
-    m_value = std::make_shared<T>(rhs);
-    return *this;
-  }
+  const T &operator * () const { AssertValidityGuarantee(); return m_auto_out_impl->operator*(); }
+  const T *operator -> () const { AssertValidityGuarantee(); return m_auto_out_impl->operator->(); }
+  auto_out &operator= (const T &t) { AssertValidityGuarantee(); m_auto_out_impl->operator=(t); }
+  auto_out &operator= (T &&t) { AssertValidityGuarantee(); m_auto_out_impl->operator=(std::forward<T>(t)); }
+  
+private:
+  
+  void AssertValidityGuarantee () { assert(m_auto_out_impl && "m_auto_out_impl should never be null."); }
+  
+  struct auto_out_impl {
+  public:
+    auto_out_impl () = delete; // This allows us to guarantee that m_packet is always a valid shared_ptr.
+    auto_out_impl (AutoPacket &packet) : m_packet(packet.shared_from_this()) { }
+    auto_out_impl (const auto_out_impl &aoi) : m_packet(aoi.m_packet), m_decoration(aoi.m_decoration) { }
+    auto_out_impl (auto_out_impl &&aoi) : m_packet(std::move(aoi.m_packet)), m_decoration(std::move(aoi.m_decoration)) { }
+    ~auto_out_impl () {
+      if (!m_decoration)
+        m_packet->Unsatisfiable<T>();
+    }
+    const T &operator * () const {
+      assert(bool(m_packet) && "m_packet should never be null.");
+      if (!m_decoration)
+        throw autowiring_error("Can't get a reference to an instance of T before it has been Decorated to the packet (in this case by assigning to the auto_out<T> via operator=.");
+      return *m_decoration;
+    }
+    const T *operator -> () const {
+      assert(bool(m_packet) && "m_packet should never be null.");
+      if (!m_decoration)
+        throw autowiring_error("Can't get a reference to an instance of T before it has been Decorated to the packet (in this case by assigning to the auto_out<T> via operator=.");
+      return m_decoration.get();
+    }
+    void operator= (const T &t) {
+      assert(bool(m_packet) && "m_packet should never be null.");
+      if (!m_decoration) {
+        m_packet->Decorate<T>(t);
+        m_packet->Get<T>(m_decoration);
+      }
+    }
+    void operator= (T &&t) {
+      assert(bool(m_packet) && "m_packet should never be null.");
+      if (!m_decoration) {
+        m_packet->Decorate<T>(std::forward<T>(t));
+        m_packet->Get<T>(m_decoration);
+      }
+    }
+  private:
+    std::shared_ptr<AutoPacket> m_packet;
+    std::shared_ptr<const T> m_decoration;
+  };
+  
+  std::shared_ptr<auto_out_impl> m_auto_out_impl;
 };

--- a/autowiring/auto_out.h
+++ b/autowiring/auto_out.h
@@ -6,27 +6,50 @@
 #include "autowiring_error.h"
 
 /// <summary>
-/// TODO write these comments
+/// The auto_out<T> class provides a way to implement deferred-output autofilters.
 /// </summary>
 /// <remarks>
+/// An `auto_out<T>` parameter in an autofilter is an output parameter equivalent to type T.  It stores a
+/// std::shared_ptr to the AutoPacket from which the autofilter call was generated, and essentially just
+/// waits to be assigned to, at which point it decorates the packet with the assigned value.  If the auto_out<T>
+/// instance (and all copies of it) is destroyed without being assigned to, then it marks T as unsatisfiable,
+/// which has particular consequences (see AutoPacket::MarkUnsatisfiable).
+///
+/// In particular, auto_out<T> allows one to define asynchronously processed autofilters by deferring output
+/// decoration until much later than the filter itself was called.  For example, one could store the auto_out<T>,
+/// begin an asynchronous process on a different thread, and assign to the auto_out<T> once that process completes.
+///
+/// The auto_out<T> class has shared_ptr style semantics (pointer dereferencing), and additionally can be assigned
+/// to from various types, primary including T and its relatives (e.g. `const T&` and `T&&` and `std::shared_ptr<T>`.
+/// When assigned to from a T-like typed value, the packet is decorated with that value.  Assignment can only happen
+/// once.
 /// </remarks>
 template <class T>
 class auto_out
 {
 public:
 
+  // Constructs an empty auto_out object.
   auto_out () { }
+  // This should only be called by Autowiring internals.
   auto_out (AutoPacket &packet) : m_auto_out_impl(std::make_shared<auto_out_impl>(packet)) { }
+  
   auto_out (const auto_out &ao) : m_auto_out_impl(ao.m_auto_out_impl) { }
   auto_out (auto_out &&ao) : m_auto_out_impl(std::move(ao.m_auto_out_impl)) { }
-
-  operator bool () const { return bool(m_auto_out_impl); }
-  const T &operator * () const { ThrowIfInvalid(); return m_auto_out_impl->operator*(); }
-  const T *operator -> () const { ThrowIfInvalid(); return m_auto_out_impl->operator->(); }
   auto_out &operator= (const auto_out &ao) { m_auto_out_impl = ao.m_auto_out_impl; }
   auto_out &operator= (auto_out &&ao) { m_auto_out_impl = std::move(ao.m_auto_out_impl); }
+
+  // Returns true iff this auto_out object is nonempty (i.e. refers to a packet).
+  operator bool () const { return bool(m_auto_out_impl); }
+  // Returns a const reference to the decorated value, if this auto_out object has been assigned to, otherwise throws.
+  const T &operator* () const { ThrowIfInvalid(); return m_auto_out_impl->operator*(); }
+  // Returns a const pointer to the decorated value, if this auto_out object has been assigned to, otherwise throws.
+  const T *operator-> () const { ThrowIfInvalid(); return m_auto_out_impl->operator->(); }
+  // Assign to this auto_out object from a T value (via const reference).
   auto_out &operator= (const T &t) { ThrowIfInvalid(); m_auto_out_impl->operator=(t); }
+  // Assign to this auto_out object from a T value (via r-value reference)
   auto_out &operator= (T &&t) { ThrowIfInvalid(); m_auto_out_impl->operator=(std::forward<T>(t)); }
+  // Assign to this auto_out object from a T value (via shared_ptr).
   auto_out &operator= (const std::shared_ptr<T> &t) { ThrowIfInvalid(); m_auto_out_impl->operator=(t); }
   
 private:
@@ -46,13 +69,13 @@ private:
       if (!m_decoration)
         m_packet->MarkUnsatisfiable<T>();
     }
-    const T &operator * () const {
+    const T &operator* () const {
       AssertValidity();
       if (!m_decoration)
         throw autowiring_error("Can't get a reference to an instance of T before it has been Decorated to the packet (in this case by assigning to the auto_out<T> via operator=.");
       return *m_decoration;
     }
-    const T *operator -> () const {
+    const T *operator-> () const {
       AssertValidity();
       if (!m_decoration)
         throw autowiring_error("Can't get a reference to an instance of T before it has been Decorated to the packet (in this case by assigning to the auto_out<T> via operator=.");

--- a/autowiring/auto_out.h
+++ b/autowiring/auto_out.h
@@ -23,6 +23,12 @@
 /// to from various types, primary including T and its relatives (e.g. `const T&` and `T&&` and `std::shared_ptr<T>`.
 /// When assigned to from a T-like typed value, the packet is decorated with that value.  Assignment can only happen
 /// once.
+///
+/// Note that `auto_out<T>` as an output parameter of an autofilter is conceptually less strict than `T&`.  The former
+/// does not guarantee that T will be decorated onto the packet by the time the autofilter method returns, and the
+/// determination of which may require reasoning about the run-time state of the program.  The latter guarantees that
+/// T will be decorated onto the packet by the time the autofilter method returns.  Use `T&` if possible, and only
+/// use auto_out<T> when the deferred output behavior is required.
 /// </remarks>
 template <class T>
 class auto_out

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -98,7 +98,10 @@ void AutoPacket::AddSatCounterUnsafe(SatCounter& satCounter) {
       });
       switch (entry.m_state) {
       case DispositionState::Complete:
-        satCounter.Decrement();
+        // Either decorations must be present, or the decoration type must be a shared_ptr.
+        if (!entry.m_decorations.empty() || pCur->is_shared) {
+          satCounter.Decrement();
+        }
         break;
       default:
         break;

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -27,7 +27,7 @@ AutoPacket::~AutoPacket(void) {
   
   // Mark decorations of successor packets that use decorations
   // originating from this packet as unsatisfiable
-  for (auto& pair : m_decorations)
+  for (auto& pair : m_decoration_map)
     if (!pair.first.tshift && pair.second.m_state != DispositionState::Complete)
       MarkSuccessorsUnsatisfiable(DecorationKey(*pair.first.ti, 0));
 
@@ -59,7 +59,7 @@ AutoPacket::~AutoPacket(void) {
 DecorationDisposition& AutoPacket::DecorateImmediateUnsafe(const DecorationKey& key, const void* pvImmed)
 {
   // Obtain the decoration disposition of the entry we will be returning
-  DecorationDisposition& dec = m_decorations[key];
+  DecorationDisposition& dec = m_decoration_map[key];
 
   if (dec.m_state != DispositionState::Unsatisfied) {
     std::stringstream ss;
@@ -77,7 +77,7 @@ DecorationDisposition& AutoPacket::DecorateImmediateUnsafe(const DecorationKey& 
 void AutoPacket::AddSatCounterUnsafe(SatCounter& satCounter) {
   for(auto pCur = satCounter.GetAutoFilterArguments(); *pCur; pCur++) {
     DecorationKey key(*pCur->ti, pCur->tshift);
-    DecorationDisposition& entry = m_decorations[key];
+    DecorationDisposition& entry = m_decoration_map[key];
 
     // Decide what to do with this entry:
     if (pCur->is_input) {
@@ -120,14 +120,14 @@ void AutoPacket::AddSatCounterUnsafe(SatCounter& satCounter) {
 
     // Make sure decorations exist for timeshifts less that key's timeshift
     for (int tshift = 0; tshift < key.tshift; ++tshift)
-      m_decorations[DecorationKey(*key.ti, tshift)];
+      m_decoration_map[DecorationKey(*key.ti, tshift)];
   }
 }
 
 void AutoPacket::MarkUnsatisfiable(const DecorationKey& key) {
   // Ensure correct type if instantiated here
   std::unique_lock<std::mutex> lk(m_lock);
-  auto& entry = m_decorations[key];
+  auto& entry = m_decoration_map[key];
 
   // Clear all decorations and pointers attached here
   entry.m_state = DispositionState::Complete;
@@ -145,7 +145,7 @@ void AutoPacket::MarkSuccessorsUnsatisfiable(DecorationKey key) {
   key.tshift++;
   auto successor = SuccessorUnsafe();
   
-  while (m_decorations.count(key)) {
+  while (m_decoration_map.count(key)) {
     successor->MarkUnsatisfiable(key);
     
     // Update key and successor
@@ -226,7 +226,7 @@ void AutoPacket::UpdateSatisfactionUnsafe(std::unique_lock<std::mutex> lk, const
   // Mark all unsatisfiable output types
   for (auto unsatOutputArg : unsatOutputArgs) {
     // One more producer run, even though we couldn't attach any new decorations
-    auto& entry = m_decorations[DecorationKey{*unsatOutputArg->ti, 0}];
+    auto& entry = m_decoration_map[DecorationKey{*unsatOutputArg->ti, 0}];
     entry.m_nProducersRun++;
 
     // Now recurse on this entry
@@ -288,8 +288,8 @@ void AutoPacket::PulseSatisfactionUnsafe(std::unique_lock<std::mutex> lk, Decora
 }
 
 bool AutoPacket::HasUnsafe(const DecorationKey& key) const {
-  auto q = m_decorations.find(key);
-  if(q == m_decorations.end())
+  auto q = m_decoration_map.find(key);
+  if(q == m_decoration_map.end())
     return false;
   return !q->second.m_decorations.empty();
 }
@@ -299,7 +299,7 @@ void AutoPacket::DecorateNoPriors(const AnySharedPointer& ptr, DecorationKey key
   {
     std::lock_guard<std::mutex> lk(m_lock);
 
-    disposition = &m_decorations[key];
+    disposition = &m_decoration_map[key];
     switch (disposition->m_state) {
     case DispositionState::Complete:
       {
@@ -355,15 +355,15 @@ void AutoPacket::Decorate(const AnySharedPointer& ptr, DecorationKey key) {
     // If there are any filters on _this_ packet that desire to know the prior packet, then
     // we must proactively preserve the value of this decoration for our successor.
     (std::lock_guard<std::mutex>)m_lock,
-    m_decorations.count(key)
+    m_decoration_map.count(key)
   );
 }
 
 const DecorationDisposition* AutoPacket::GetDisposition(const DecorationKey& key) const {
   std::lock_guard<std::mutex> lk(m_lock);
 
-  auto q = m_decorations.find(key);
-  if (q != m_decorations.end() && q->second.m_state == DispositionState::Complete)
+  auto q = m_decoration_map.find(key);
+  if (q != m_decoration_map.end() && q->second.m_state == DispositionState::Complete)
     return &q->second;
 
   return nullptr;
@@ -371,7 +371,7 @@ const DecorationDisposition* AutoPacket::GetDisposition(const DecorationKey& key
 
 bool AutoPacket::HasSubscribers(const DecorationKey& key) const {
   std::lock_guard<std::mutex> lk(m_lock);
-  return m_decorations.count(key) != 0;
+  return m_decoration_map.count(key) != 0;
 }
 
 const SatCounter& AutoPacket::GetSatisfaction(const std::type_info& subscriber) const {
@@ -397,13 +397,13 @@ void AutoPacket::ThrowMultiplyDecoratedException(const DecorationKey& key) {
 size_t AutoPacket::GetDecorationTypeCount(void) const
 {
   std::lock_guard<std::mutex> lk(m_lock);
-  return m_decorations.size();
+  return m_decoration_map.size();
 }
 
 AutoPacket::t_decorationMap AutoPacket::GetDecorations(void) const
 {
   std::lock_guard<std::mutex> lk(m_lock);
-  return m_decorations;
+  return m_decoration_map;
 }
 
 void AutoPacket::ForwardAll(std::shared_ptr<AutoPacket> recipient) const {
@@ -413,7 +413,7 @@ void AutoPacket::ForwardAll(std::shared_ptr<AutoPacket> recipient) const {
   std::vector<std::pair<DecorationKey, DecorationDisposition>> dd;
   {
     std::lock_guard<std::mutex> lk(m_lock);
-    for (const auto& decoration : m_decorations)
+    for (const auto& decoration : m_decoration_map)
       // Only fully complete decorations are considered for propagation
       if (decoration.second.m_state == DispositionState::Complete)
         dd.push_back(decoration);

--- a/src/autowiring/AutoPacketInternal.cpp
+++ b/src/autowiring/AutoPacketInternal.cpp
@@ -33,7 +33,7 @@ void AutoPacketInternal::Initialize(bool isFirstPacket) {
 
   // Mark timeshifted decorations as unsatisfiable on the first packet
   if (isFirstPacket)
-    for (auto& dec : m_decorations) {
+    for (auto& dec : m_decoration_map) {
       auto& key = dec.first;
       if (key.tshift) {
         MarkUnsatisfiable(key);

--- a/src/autowiring/test/ArgumentTypeTest.cpp
+++ b/src/autowiring/test/ArgumentTypeTest.cpp
@@ -2,6 +2,7 @@
 #include "stdafx.h"
 #include "var_logic.h"
 #include <autowiring/auto_arg.h>
+#include <autowiring/auto_out.h>
 #include <autowiring/has_autofilter.h>
 
 class ArgumentTypeTest:
@@ -31,10 +32,6 @@ public:
   int i;
   Argument(int j = N) : i(j) {}
 };
-
-void FilterFunction(const Argument<0>& typeIn, auto_out<Argument<1>> typeOut) {
-  typeOut->i += 1 + typeIn.i;
-}
 
 typedef Argument<0> copied_in;
 typedef const Argument<0> copied_in_const;

--- a/src/autowiring/test/AutoFilterFunctionTest.cpp
+++ b/src/autowiring/test/AutoFilterFunctionTest.cpp
@@ -13,8 +13,12 @@ public:
 };
 
 void FilterFunction(const Decoration<0>& typeIn, auto_out<Decoration<1>> typeOut) {
-  typeOut->i += 1 + typeIn.i;
+  typeOut = Decoration<1>(1 + 1 + typeIn.i);
 }
+
+// void FilterFunction(const Decoration<0>& typeIn, Decoration<1> &typeOut) {
+//   typeOut = Decoration<1>(1 + 1 + typeIn.i);
+// }
 
 TEST_F(AutoFilterFunctionalTest, FunctionDecorationTest) {
   // AddRecipient that is an instance of std::function f : a -> b
@@ -27,9 +31,11 @@ TEST_F(AutoFilterFunctionalTest, FunctionDecorationTest) {
   {
     auto packet = factory->NewPacket();
     packet->Decorate(Decoration<0>());
+    ASSERT_EQ(1, packet->GetDecorationTypeCount()) << "Unexpected number of decorations";
     packet->AddRecipient(AutoFilterDescriptor(&FilterFunction));
     const Decoration<1>* getdec;
     ASSERT_TRUE(packet->Get(getdec)) << "Decoration function was not called";
+    ASSERT_EQ(2, packet->GetDecorationTypeCount()) << "Unexpected number of decorations";
   }
 
   //Decoration with function first
@@ -40,6 +46,7 @@ TEST_F(AutoFilterFunctionalTest, FunctionDecorationTest) {
     packet->Decorate(Decoration<0>());
     const Decoration<1>* getdec;
     ASSERT_TRUE(packet->Get(getdec)) << "Decoration function was not called";
+    ASSERT_EQ(2, packet->GetDecorationTypeCount()) << "Unexpected number of decorations";
   }
 }
 
@@ -53,7 +60,7 @@ TEST_F(AutoFilterFunctionalTest, FunctionDecorationLambdaTest) {
     auto sentry = std::make_shared<bool>(true);
     *packet +=
       [addType, sentry](const Decoration<0>& typeIn, auto_out<Decoration<1>> typeOut) {
-        typeOut->i += 1 + typeIn.i;
+        typeOut = Decoration<1>(1 + 1 + typeIn.i);
       };
 
     // Sentry's use count should be precisely two at this point
@@ -72,7 +79,7 @@ TEST_F(AutoFilterFunctionalTest, FunctionInjectorTest) {
   auto packet = factory->NewPacket();
   int addType = 1;
   packet->AddRecipient([addType](auto_out<Decoration<0>> typeOut) {
-    typeOut->i += addType;
+    typeOut = Decoration<0>(addType);
   });
   const Decoration<0>* getdec;
   ASSERT_TRUE(packet->Get(getdec)) << "Decoration function was not called";

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -89,7 +89,7 @@ TEST_F(AutoFilterTest, VerifyAutoOut) {
   AutoRequired<AutoPacketFactory> factory;
 
   *factory += [](auto_out<Decoration<0>> out) {
-    out->i = 1;
+    out = Decoration<0>(1);
   };
 
   std::shared_ptr<AutoPacket> packet = factory->NewPacket();
@@ -98,20 +98,20 @@ TEST_F(AutoFilterTest, VerifyAutoOut) {
   ASSERT_EQ(result0->i, 1) << "Output incorrect";
 }
 
-TEST_F(AutoFilterTest, VerifyAutoOutPooled) {
-  AutoRequired<AutoPacketFactory> factory;
-  ObjectPool<Decoration<0>> pool;
-
-  *factory += [&](auto_out<Decoration<0>> out) {
-    out = pool();
-    out->i = 1;
-  };
-
-  std::shared_ptr<AutoPacket> packet = factory->NewPacket();
-  const Decoration<0>* result0 = nullptr;
-  ASSERT_TRUE(packet->Get(result0)) << "Output missing";
-  ASSERT_EQ(result0->i, 1) << "Output incorrect";
-}
+// TEST_F(AutoFilterTest, VerifyAutoOutPooled) {
+//   AutoRequired<AutoPacketFactory> factory;
+//   ObjectPool<Decoration<0>> pool;
+// 
+//   *factory += [&](auto_out<Decoration<0>> out) {
+//     Decoration<0> &val = out = pool();
+//     val.i = 1;
+//   };
+// 
+//   std::shared_ptr<AutoPacket> packet = factory->NewPacket();
+//   const Decoration<0>* result0 = nullptr;
+//   ASSERT_TRUE(packet->Get(result0)) << "Output missing";
+//   ASSERT_EQ(result0->i, 1) << "Output incorrect";
+// }
 
 TEST_F(AutoFilterTest, VerifyNoMultiDecorate) {
   AutoRequired<FilterA> filterA;

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -735,3 +735,33 @@ TEST_F(AutoFilterTest, CurrentContextCheck) {
 
   ASSERT_EQ(1, filter->m_called) << "AutoFilter called incorrect number of times";
 }
+
+TEST_F(AutoFilterTest, AutoOut0) {
+  AutoRequired<AutoPacketFactory> factory;
+  {
+    auto packet = factory->NewPacket();
+    packet->Decorate(123.45);
+    ASSERT_EQ(1, packet->GetDecorationTypeCount()) << "Did not get the expected number of decorations.";
+    ASSERT_EQ(123.45, packet->Get<double>());
+    *packet += [](const double &x, auto_out<int> y) {
+      y = static_cast<int>(x);
+    };
+    ASSERT_EQ(2, packet->GetDecorationTypeCount()) << "Did not get the expected number of decorations.";
+    ASSERT_EQ(123, packet->Get<int>());
+  }
+}
+
+TEST_F(AutoFilterTest, AutoOut1) {
+  AutoRequired<AutoPacketFactory> factory;
+  {
+    auto packet = factory->NewPacket();
+    // Same as AutoOut0 but add the filter first.
+    *packet += [](const double &x, auto_out<int> y) {
+      y = static_cast<int>(x);
+    };
+    packet->Decorate(123.45);
+    ASSERT_EQ(2, packet->GetDecorationTypeCount()) << "Did not get the expected number of decorations.";
+    ASSERT_EQ(123.45, packet->Get<double>());
+    ASSERT_EQ(123, packet->Get<int>());
+  }
+}

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -765,3 +765,184 @@ TEST_F(AutoFilterTest, AutoOut1) {
     ASSERT_EQ(123, packet->Get<int>());
   }
 }
+
+#include <iostream>
+
+std::string decoration_status_string (DispositionState s) {
+  switch (s) {
+    case DispositionState::Unsatisfied:     return "Unsatisfied";
+    case DispositionState::PartlySatisfied: return "PartlySatisfied";
+    case DispositionState::Complete:        return "Complete";
+  }
+}
+
+void print_decorations (const std::string &label, const AutoPacket::t_decorationMap &d) {
+  std::cout << label << " {\n";
+  for (auto it : d) {
+    std::cout << "    " << autowiring::demangle(it.first.ti) << " : " << decoration_status_string(it.second.m_state) << '\n';
+  }
+  std::cout << "}\n";
+}
+
+TEST_F(AutoFilterTest, AutoOut2) {
+  
+  // NOTE: this test uses implementation details of DecorationDisposition, which is not part of the public API,
+  // and should be refactored once that part is cleaned up (in particular, AutoPacket::GetDecorations is
+  // what is exposing that, and should be moved into autowiring::dbg, out of the public API for AutoPacket).
+  
+  AutoRequired<AutoPacketFactory> factory;
+  {
+    auto packet = factory->NewPacket();
+    auto d = packet->GetDecorations(); // This really should be called "GetAllAutoFilterParameters".
+    ASSERT_EQ(0, d.size()) << "Unexpected number of AutoFilter parameters.";
+    
+    packet->Decorate(123.45);
+    d = packet->GetDecorations(); // This really should be called "GetAllAutoFilterParameters".
+    ASSERT_EQ(1, d.size()) << "Unexpected number of AutoFilter parameters.";
+    ASSERT_EQ(DispositionState::Complete, d[DecorationKey(typeid(auto_id<double>),0)].m_state) << "Incorrect `double` decoration disposition.";
+    ASSERT_EQ(1, d[DecorationKey(typeid(auto_id<double>),0)].m_decorations.size()) << "Incorrect `double` decoration disposition.";
+
+    bool filter_0_called = false;
+    auto filter_0 = [&filter_0_called](const double &x, auto_out<int> y) {
+      filter_0_called = true;
+    };
+    bool filter_1_called = false;
+    auto filter_1 = [&filter_1_called](int y) {
+      filter_1_called = true;
+    };
+    
+    ASSERT_FALSE(filter_0_called) << "We expected filter_0 to not have been called by now.";
+    ASSERT_FALSE(filter_1_called) << "We expected filter_1 to not have been called by now.";
+    
+    *packet += filter_0;
+    
+    ASSERT_TRUE(filter_0_called) << "We expected filter_0 to have been called by now.";
+    ASSERT_FALSE(filter_1_called) << "We expected filter_0 to not have been called by now.";
+    d = packet->GetDecorations(); // This really should be called "GetAllAutoFilterParameters".
+    ASSERT_EQ(2, d.size()) << "Unexpected number of AutoFilter parameters.";
+    ASSERT_EQ(DispositionState::Complete, d[DecorationKey(typeid(auto_id<double>),0)].m_state) << "Incorrect `double` decoration disposition.";
+    ASSERT_EQ(1, d[DecorationKey(typeid(auto_id<double>),0)].m_decorations.size()) << "Incorrect `double` decoration disposition.";
+    // Being Complete and having no decorations indicates that it has been MarkUnsatisfiable()'d.
+    ASSERT_EQ(DispositionState::Complete, d[DecorationKey(typeid(auto_id<int>),0)].m_state) << "Incorrect `int` decoration disposition.";
+    ASSERT_EQ(0, d[DecorationKey(typeid(auto_id<int>),0)].m_decorations.size()) << "Incorrect `int` decoration disposition.";
+
+    // Because the auto_out<int> was never assigned to, it went unsatisfiable, so this filter should never be called.
+    *packet += filter_1;
+    ASSERT_TRUE(filter_0_called) << "We expected filter_0 to have been called by now.";
+    ASSERT_FALSE(filter_1_called) << "We expected filter_0 to not have been called by now.";
+  }
+}
+
+TEST_F(AutoFilterTest, AutoOut3) {
+  
+  // NOTE: this test uses implementation details of DecorationDisposition, which is not part of the public API,
+  // and should be refactored once that part is cleaned up (in particular, AutoPacket::GetDecorations is
+  // what is exposing that, and should be moved into autowiring::dbg, out of the public API for AutoPacket).
+  
+  AutoRequired<AutoPacketFactory> factory;
+  {
+    auto packet = factory->NewPacket();
+    auto d = packet->GetDecorations(); // This really should be called "GetAllAutoFilterParameters".
+    ASSERT_EQ(0, d.size()) << "Unexpected number of AutoFilter parameters.";
+
+    bool filter_1_called = false;
+    auto filter_1 = [&filter_1_called](int y) {
+      filter_1_called = true;
+    };
+    *packet += filter_1;
+    
+    packet->Decorate(123.45);
+    d = packet->GetDecorations(); // This really should be called "GetAllAutoFilterParameters".
+    ASSERT_EQ(2, d.size()) << "Unexpected number of AutoFilter parameters.";
+    ASSERT_EQ(DispositionState::Complete, d[DecorationKey(typeid(auto_id<double>),0)].m_state) << "Incorrect `double` decoration disposition.";
+    ASSERT_EQ(1, d[DecorationKey(typeid(auto_id<double>),0)].m_decorations.size()) << "Incorrect `double` decoration disposition.";
+    ASSERT_EQ(DispositionState::Unsatisfied, d[DecorationKey(typeid(auto_id<int>),0)].m_state) << "Incorrect `int` decoration disposition.";
+    ASSERT_EQ(0, d[DecorationKey(typeid(auto_id<int>),0)].m_decorations.size()) << "Incorrect `int` decoration disposition.";
+
+    bool filter_0_called = false;
+    auto filter_0 = [&filter_0_called](const double &x, auto_out<int> y) {
+      filter_0_called = true;
+    };
+    
+    ASSERT_FALSE(filter_0_called) << "We expected filter_0 to not have been called by now.";
+    ASSERT_FALSE(filter_1_called) << "We expected filter_1 to not have been called by now.";
+    
+    *packet += filter_0;
+    
+    ASSERT_TRUE(filter_0_called) << "We expected filter_0 to have been called by now.";
+    ASSERT_FALSE(filter_1_called) << "We expected filter_0 to not have been called by now.";
+    d = packet->GetDecorations(); // This really should be called "GetAllAutoFilterParameters".
+    ASSERT_EQ(2, d.size()) << "Unexpected number of AutoFilter parameters.";
+    ASSERT_EQ(DispositionState::Complete, d[DecorationKey(typeid(auto_id<double>),0)].m_state) << "Incorrect `double` decoration disposition.";
+    ASSERT_EQ(1, d[DecorationKey(typeid(auto_id<double>),0)].m_decorations.size()) << "Incorrect `double` decoration disposition.";
+    // Being Complete and having no decorations indicates that it has been MarkUnsatisfiable()'d.
+    ASSERT_EQ(DispositionState::Complete, d[DecorationKey(typeid(auto_id<int>),0)].m_state) << "Incorrect `int` decoration disposition.";
+    ASSERT_EQ(0, d[DecorationKey(typeid(auto_id<int>),0)].m_decorations.size()) << "Incorrect `int` decoration disposition.";
+
+    // Because the auto_out<int> was never assigned to, it went unsatisfiable, so this filter should never be called.
+    ASSERT_TRUE(filter_0_called) << "We expected filter_0 to have been called by now.";
+    ASSERT_FALSE(filter_1_called) << "We expected filter_0 to not have been called by now.";
+  }
+}
+
+TEST_F(AutoFilterTest, AutoOut4) {
+  
+  // NOTE: this test uses implementation details of DecorationDisposition, which is not part of the public API,
+  // and should be refactored once that part is cleaned up (in particular, AutoPacket::GetDecorations is
+  // what is exposing that, and should be moved into autowiring::dbg, out of the public API for AutoPacket).
+  
+  AutoRequired<AutoPacketFactory> factory;
+  {
+    auto packet = factory->NewPacket();
+    auto d = packet->GetDecorations(); // This really should be called "GetAllAutoFilterParameters".
+    ASSERT_EQ(0, d.size()) << "Unexpected number of AutoFilter parameters.";
+
+    bool filter_1_called = false;
+    auto filter_1 = [&filter_1_called](int y) {
+      filter_1_called = true;
+    };
+    *packet += filter_1;
+    
+    packet->Decorate(123.45);
+    d = packet->GetDecorations(); // This really should be called "GetAllAutoFilterParameters".
+    ASSERT_EQ(2, d.size()) << "Unexpected number of AutoFilter parameters.";
+    ASSERT_EQ(DispositionState::Complete, d[DecorationKey(typeid(auto_id<double>),0)].m_state) << "Incorrect `double` decoration disposition.";
+    ASSERT_EQ(1, d[DecorationKey(typeid(auto_id<double>),0)].m_decorations.size()) << "Incorrect `double` decoration disposition.";
+    ASSERT_EQ(DispositionState::Unsatisfied, d[DecorationKey(typeid(auto_id<int>),0)].m_state) << "Incorrect `int` decoration disposition.";
+    ASSERT_EQ(0, d[DecorationKey(typeid(auto_id<int>),0)].m_decorations.size()) << "Incorrect `int` decoration disposition.";
+
+    bool filter_0_called = false;
+    auto_out<int> ao;
+    auto filter_0 = [&ao, &filter_0_called](const double &x, auto_out<int> y) {
+      ao = y;
+      filter_0_called = true;
+    };
+    
+    ASSERT_FALSE(filter_0_called) << "We expected filter_0 to not have been called by now.";
+    ASSERT_FALSE(filter_1_called) << "We expected filter_1 to not have been called by now.";
+    
+    *packet += filter_0;
+    
+    ASSERT_TRUE(filter_0_called) << "We expected filter_0 to have been called by now.";
+    ASSERT_FALSE(filter_1_called) << "We expected filter_0 to not have been called by now.";
+    d = packet->GetDecorations(); // This really should be called "GetAllAutoFilterParameters".
+    ASSERT_EQ(2, d.size()) << "Unexpected number of AutoFilter parameters.";
+    ASSERT_EQ(DispositionState::Complete, d[DecorationKey(typeid(auto_id<double>),0)].m_state) << "Incorrect `double` decoration disposition.";
+    ASSERT_EQ(1, d[DecorationKey(typeid(auto_id<double>),0)].m_decorations.size()) << "Incorrect `double` decoration disposition.";
+    // Being Complete and having no decorations indicates that it has been MarkUnsatisfiable()'d.
+    ASSERT_EQ(DispositionState::Unsatisfied, d[DecorationKey(typeid(auto_id<int>),0)].m_state) << "Incorrect `int` decoration disposition.";
+    ASSERT_EQ(0, d[DecorationKey(typeid(auto_id<int>),0)].m_decorations.size()) << "Incorrect `int` decoration disposition.";
+
+    // Assign to ao, thereby decorating the packet with int.
+    ao = 42;
+    
+    ASSERT_TRUE(filter_0_called) << "We expected filter_0 to have been called by now.";
+    ASSERT_TRUE(filter_1_called) << "We expected filter_0 to have been called by now.";
+    d = packet->GetDecorations(); // This really should be called "GetAllAutoFilterParameters".
+    ASSERT_EQ(2, d.size()) << "Unexpected number of AutoFilter parameters.";
+    ASSERT_EQ(DispositionState::Complete, d[DecorationKey(typeid(auto_id<double>),0)].m_state) << "Incorrect `double` decoration disposition.";
+    ASSERT_EQ(1, d[DecorationKey(typeid(auto_id<double>),0)].m_decorations.size()) << "Incorrect `double` decoration disposition.";
+    ASSERT_EQ(DispositionState::Complete, d[DecorationKey(typeid(auto_id<int>),0)].m_state) << "Incorrect `int` decoration disposition.";
+    ASSERT_EQ(1, d[DecorationKey(typeid(auto_id<int>),0)].m_decorations.size()) << "Incorrect `int` decoration disposition.";
+  }
+}

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -98,20 +98,21 @@ TEST_F(AutoFilterTest, VerifyAutoOut) {
   ASSERT_EQ(result0->i, 1) << "Output incorrect";
 }
 
-// TEST_F(AutoFilterTest, VerifyAutoOutPooled) {
-//   AutoRequired<AutoPacketFactory> factory;
-//   ObjectPool<Decoration<0>> pool;
-// 
-//   *factory += [&](auto_out<Decoration<0>> out) {
-//     Decoration<0> &val = out = pool();
-//     val.i = 1;
-//   };
-// 
-//   std::shared_ptr<AutoPacket> packet = factory->NewPacket();
-//   const Decoration<0>* result0 = nullptr;
-//   ASSERT_TRUE(packet->Get(result0)) << "Output missing";
-//   ASSERT_EQ(result0->i, 1) << "Output incorrect";
-// }
+TEST_F(AutoFilterTest, VerifyAutoOutPooled) {
+  AutoRequired<AutoPacketFactory> factory;
+  ObjectPool<Decoration<0>> pool;
+
+  *factory += [&](auto_out<Decoration<0>> out) {
+    auto p = pool();
+    p->i = 1;
+    out = p;
+  };
+
+  std::shared_ptr<AutoPacket> packet = factory->NewPacket();
+  const Decoration<0>* result0 = nullptr;
+  ASSERT_TRUE(packet->Get(result0)) << "Output missing";
+  ASSERT_EQ(result0->i, 1) << "Output incorrect";
+}
 
 TEST_F(AutoFilterTest, VerifyNoMultiDecorate) {
   AutoRequired<FilterA> filterA;

--- a/src/autowiring/test/AutoOutputTest.cpp
+++ b/src/autowiring/test/AutoOutputTest.cpp
@@ -16,11 +16,11 @@ public:
     m_called = true;
 
     // Record the decoration address:
-    m_rcvDecAddr = out1;
+    Decoration<1> &ref = out1 = Decoration<1>();
+    m_rcvDecAddr = &ref;
 
     // Satisfy our other decoration:
-    if(out1)
-      out1->i = -100;
+    ref.i = -100;
   }
 
   Decoration<1>* m_rcvDecAddr;
@@ -39,14 +39,14 @@ public:
     m_called = true;
 
     // Record the decoration address:
-    m_rcvDecAddr1 = out1;
-    m_rcvDecAddr2 = out2;
+    Decoration<1> &ref1 = out1 = Decoration<1>();
+    m_rcvDecAddr1 = &ref1;
+    Decoration<2> &ref2 = out2 = Decoration<2>();
+    m_rcvDecAddr2 = &ref2;
 
     // Satisfy our other decoration:
-    if(out1)
-      out1->i = -100;
-    if(out2)
-      out2->i = -101;
+    ref1.i = -100;
+    ref2.i = -101;
   }
 
   Decoration<1>* m_rcvDecAddr1;

--- a/src/autowiring/test/TestFixtures/Decoration.hpp
+++ b/src/autowiring/test/TestFixtures/Decoration.hpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <autowiring/CoreThread.h>
+#include <autowiring/auto_out.h>
 #include <autowiring/auto_tuple.h>
 #include <autowiring/has_autofilter.h>
 #include STL_TUPLE_HEADER
@@ -206,7 +207,7 @@ public:
     void AutoFilter(AutoPacket& pkt, auto_out<Decoration<0>> zero) {
       ++m_called;
       pkt.Decorate(Decoration<1>());
-      ++zero->i;
+      zero = Decoration<0>(1);
     }
 };
 
@@ -219,6 +220,6 @@ public FilterRoot {
 public:
   void AutoFilter(auto_out<Decoration<2>> two) {
     ++m_called;
-    two = std::make_shared<Decoration<2>>();
+    two = Decoration<2>();
   }
 };


### PR DESCRIPTION
Added the newly designed auto_out feature, which allows for autofilters to have deferred output, while avoiding the trapdoor of manual packet decoration.  The presence of auto_out<T> in the parameter list of an autofilter allows the output to be treated as first class, and in particular, discoverable and visualizable by the autofilter graph output debug tool.
