### PR TITLE
Clarify a static assertion

### DIFF
--- a/autowiring/has_autofilter.h
+++ b/autowiring/has_autofilter.h
@@ -140,6 +140,6 @@ struct has_autofilter {
   static_assert(
     value ||
     has_unambiguous_autofilter<detect_ambiguous_autofilter>::value,
-    "Cannot define more than one AutoFilter method and all AutoFilter methods must be public"
+    "Cannot define more than one AutoFilter method and all AutoFilter methods must be public and all AutoFilter reference-output arguments must be completely defined"
   );
 };


### PR DESCRIPTION
This one comes up often when a reference output argument is not defined in the compilation unit where the enclosing AutoFilter is declared.  Clarify this static assertion to ensure users check this case.