### PR TITLE
Relax constraint requiring that AutoFilters have unique output types

### DIFF
--- a/autowiring/has_autofilter.h
+++ b/autowiring/has_autofilter.h
@@ -50,30 +50,6 @@ struct has_autofilter_arity<W, false>:
   static const int N = -1;
 };
 
-//=============================================
-// Test whether AutoFilter has unique arguments
-//=============================================
-template<class MemFn>
-struct all_distinct_arguments;
-
-// IMPORTANT: This evaluation must occur only when it has been
-// determined that the class has a unique AutoFilter method taking
-// at least one argument.
-template<class R, class W, class... Args>
-struct all_distinct_arguments<R(W::*)(Args...)>:
-  std::integral_constant<bool, !is_any_repeated<Args...>::value>
-{};
-
-template<class W, bool Selector = true>
-struct has_distinct_arguments:
-  all_distinct_arguments<decltype(&W::AutoFilter)>
-{};
-
-template<class W>
-struct has_distinct_arguments<W, false>:
-  std::false_type
-{};
-
 //===========================================================
 // Test for existence of unique AutoFilter with > 0 arguments
 //===========================================================
@@ -101,17 +77,15 @@ struct has_unambiguous_autofilter
 
   // Evaluates to true only if T includes a unique AutoFilter method,
   // with a meaningful return type,
-  // with at least one argument,
-  // and with all argument id types distinct
+  // with at least one argument
   static const bool value =
-    has_distinct_arguments<T,
-      has_autofilter_arity<T,
+      has_autofilter_arity<
+        T,
         has_autofilter_return<
           T,
           decltype(select<T>(nullptr))::value
         >::value
-      >::value
-    >::value;
+      >::value;
 };
 
 class AutoPacket;

--- a/src/autowiring/test/AutoFilterMultiDecorateTest.cpp
+++ b/src/autowiring/test/AutoFilterMultiDecorateTest.cpp
@@ -132,10 +132,22 @@ TEST_F(AutoFilterMultiDecorateTest, ArrayOfSharedPointers) {
   ASSERT_EQ(2, f2) << "const shared_ptr[] input decoration count mismatch";
 }
 
+class SameOutputTwiceWithInput {
+public:
+  void AutoFilter(Decoration<0>& one, Decoration<0>& two) {
+    one.i = 101;
+    two.i = 102;
+  }
+};
+
+static_assert(has_unambiguous_autofilter<SameOutputTwiceWithInput>::value, "AutoFilter appears to be ambiguous on a multi-out type");
+static_assert(has_autofilter<SameOutputTwiceWithInput>::value, "AutoFilter not detected on a multi-out class");
+
 TEST_F(AutoFilterMultiDecorateTest, SingleFunctionDoubleOutput) {
   AutoRequired<AutoPacketFactory> factory;
   AutoCurrentContext()->Initiate();
 
+  AutoRequired<SameOutputTwiceWithInput>();
   *factory += [](Decoration<0>& one, Decoration<0>& two) {
     ASSERT_NE(&one, &two) << "When the same decoration type is mentioned more than once in a signature, the two outputs should be distinct";
     one.i = 1;
@@ -149,5 +161,6 @@ TEST_F(AutoFilterMultiDecorateTest, SingleFunctionDoubleOutput) {
   };
 
   factory->NewPacket();
-  ASSERT_EQ(2UL, nArgs) << "A filter that multiply attaches decorations did not correctly do so";
+  ASSERT_EQ(4UL, nArgs) << "Two filters that multiply attach decorations did not correctly do so";
 }
+


### PR DESCRIPTION
Should be able to declare an `AutoFilter` method that has the same argument type twice as an output without problems, as this behavior is already supported for lambda functions and behaves the way one might expect.