### PR TITLE
Update documentation, clarify some varnames

### DIFF
--- a/autowiring/auto_id.h
+++ b/autowiring/auto_id.h
@@ -13,7 +13,7 @@
 template<class T>
 struct auto_id {
   
-  // Return this type_info for this type with 'const' and 'volitile' removed
+  // Return this type_info for this type with 'const' and 'volatile' removed
   static const std::type_info& key(void) {
     return typeid(auto_id<typename std::remove_cv<T>::type>);
   }

--- a/src/autowiring/AutoPacketInternal.cpp
+++ b/src/autowiring/AutoPacketInternal.cpp
@@ -33,7 +33,7 @@ void AutoPacketInternal::Initialize(bool isFirstPacket) {
 
   // Mark timeshifted decorations as unsatisfiable on the first packet
   if (isFirstPacket)
-    for (auto& dec : m_decorations) {
+    for (auto& dec : m_decoration_map) {
       auto& key = dec.first;
       if (key.tshift) {
         MarkUnsatisfiable(key);

--- a/src/autowiring/test/AutoFilterFunctionTest.cpp
+++ b/src/autowiring/test/AutoFilterFunctionTest.cpp
@@ -53,7 +53,7 @@ TEST_F(AutoFilterFunctionalTest, FunctionDecorationLambdaTest) {
     auto sentry = std::make_shared<bool>(true);
     *packet +=
       [addType, sentry](const Decoration<0>& typeIn, auto_out<Decoration<1>> typeOut) {
-        typeOut->i += 1 + typeIn.i;
+        typeOut = Decoration<1>(1 + 1 + typeIn.i);
       };
 
     // Sentry's use count should be precisely two at this point
@@ -72,7 +72,7 @@ TEST_F(AutoFilterFunctionalTest, FunctionInjectorTest) {
   auto packet = factory->NewPacket();
   int addType = 1;
   packet->AddRecipient([addType](auto_out<Decoration<0>> typeOut) {
-    typeOut->i += addType;
+    typeOut = Decoration<0>(addType);
   });
   const Decoration<0>* getdec;
   ASSERT_TRUE(packet->Get(getdec)) << "Decoration function was not called";

--- a/src/autowiring/test/TestFixtures/Decoration.hpp
+++ b/src/autowiring/test/TestFixtures/Decoration.hpp
@@ -206,7 +206,7 @@ public:
     void AutoFilter(AutoPacket& pkt, auto_out<Decoration<0>> zero) {
       ++m_called;
       pkt.Decorate(Decoration<1>());
-      ++zero->i;
+      zero = Decoration<0>(1);
     }
 };
 


### PR DESCRIPTION
The name `m_decorations` was misleading, replace it with `m_decoration_map`.

This change was originally proposed in #621