### PR TITLE
Rename "internal" to "detail"

### DIFF
--- a/autowiring/AutoFilterDescriptor.h
+++ b/autowiring/AutoFilterDescriptor.h
@@ -265,7 +265,7 @@ public:
 };
 
 namespace autowiring {
-namespace internal {
+namespace detail {
 /// <summary>
 /// Alias for AutoFilterDescriptor(ptr)
 /// </summary>
@@ -295,7 +295,7 @@ AutoFilterDescriptor MakeAFDescriptor(const std::shared_ptr<T>&, std::false_type
 /// </remarks>
 template<class T>
 AutoFilterDescriptor MakeAutoFilterDescriptor(const std::shared_ptr<T>& ptr) {
-  return autowiring::internal::MakeAFDescriptor(ptr, std::integral_constant<bool, has_autofilter<T>::value>());
+  return autowiring::detail::MakeAFDescriptor(ptr, std::integral_constant<bool, has_autofilter<T>::value>());
 }
 
 namespace std {

--- a/src/autowiring/auto_signal.cpp
+++ b/src/autowiring/auto_signal.cpp
@@ -4,7 +4,7 @@
 #include "SlotInformation.h"
 
 using namespace autowiring;
-using namespace autowiring::internal;
+using namespace autowiring::detail;
 
 void signal_base::operator-=(const registration_t& reg) {
   *this -= reg.entry;


### PR DESCRIPTION
This name conveys a better message, and it's what boost uses to refer to implementation details.  It also has the advantage of being a little shorter.