### PR TITLE
Move specializations of auto_arg to their respective types

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -24,6 +24,9 @@ class CoreContext;
 struct AutoFilterDescriptor;
 struct AutoFilterArgument;
 
+template<class T>
+class auto_arg;
+
 template<class MemFn>
 struct Decompose;
 
@@ -627,4 +630,28 @@ public:
 
   /// Get the context of this packet (The context of the AutoPacketFactory that created this context)
   std::shared_ptr<CoreContext> GetContext(void) const;
+};
+
+/// <summary>
+/// AutoPacket specialization
+/// </summary>
+/// <remarks>
+/// Because this type is immediately satisfied, it is neither an input nor an output
+/// </remarks>
+template<>
+class auto_arg<AutoPacket&>
+{
+public:
+  typedef AutoPacket& type;
+  typedef AutoPacket& arg_type;
+  typedef AutoPacket id_type;
+  static const bool is_input = false;
+  static const bool is_output = false;
+  static const bool is_shared = false;
+  static const bool is_multi = false;
+  static const int tshift = 0;
+
+  static AutoPacket& arg(AutoPacket& packet) {
+    return packet;
+  }
 };

--- a/autowiring/auto_arg.h
+++ b/autowiring/auto_arg.h
@@ -3,7 +3,6 @@
 #include "auto_id.h"
 #include "auto_in.h"
 #include "auto_out.h"
-#include "auto_prev.h"
 #include "SharedPointerSlot.h"
 
 class AutoPacket;
@@ -108,14 +107,6 @@ public:
     return packet.template Get<const T*>();
   }
 };
-
-/// <summary>
-/// Specialization for equivalent T auto_in<T>
-/// </summary>
-template<class T>
-class auto_arg<auto_in<T>>:
-  public auto_arg<T>
-{};
 
 /// <summary>
 /// Construction helper for output-by-reference decoration types
@@ -235,52 +226,6 @@ class auto_arg<auto_out<T>>:
 {
 public:
   typedef auto_out<T> arg_type;
-};
-
-template<class T, int N>
-class auto_arg<auto_prev<T, N>>
-{
-public:
-  typedef auto_prev<T, N> type;
-  typedef auto_prev<T, N> arg_type;
-  typedef auto_id<T> id_type;
-
-  static const bool is_input = true;
-  static const bool is_output = false;
-  static const bool is_shared = true;
-  static const bool is_multi = false;
-  static const int tshift = N;
-
-  template<class C>
-  static const T* arg(C& packet) {
-    const T* retVal;
-    packet.template Get<T>(retVal, N);
-    return retVal;
-  }
-};
-
-/// <summary>
-/// AutoPacket specialization
-/// </summary>
-/// <remarks>
-/// Because this type is immediately satisfied, it is neither an input nor an output
-/// </remarks>
-template<>
-class auto_arg<AutoPacket&>
-{
-public:
-  typedef AutoPacket& type;
-  typedef auto_in<AutoPacket> arg_type;
-  typedef AutoPacket id_type;
-  static const bool is_input = false;
-  static const bool is_output = false;
-  static const bool is_shared = false;
-  static const bool is_multi = false;
-  static const int tshift = 0;
-
-  static AutoPacket& arg(AutoPacket& packet) {
-    return packet;
-  }
 };
 
 /// <summary>

--- a/autowiring/auto_in.h
+++ b/autowiring/auto_in.h
@@ -1,9 +1,13 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include "auto_arg.h"
 #include MEMORY_HEADER
 #include <vector>
 
 class AutoPacket;
+
+template<class T>
+class auto_arg;
 
 /// <summary>
 /// Fundamental type of required input arguments of AutoFilter methods.
@@ -61,3 +65,11 @@ private:
 public:
   operator const T**() { return &m_values[0]; }
 };
+
+/// <summary>
+/// Specialization for equivalent T auto_in<T>
+/// </summary>
+template<class T>
+class auto_arg<auto_in<T>> :
+  public auto_arg<T>
+{};

--- a/autowiring/auto_prev.h
+++ b/autowiring/auto_prev.h
@@ -1,5 +1,9 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include "auto_arg.h"
+
+template<class T>
+class auto_arg;
 
 /// <summary>
 /// Identifier for AutoFilter inputs from the previous packet
@@ -28,4 +32,26 @@ public:
   }
 
   const T* const value;
+};
+
+template<class T, int N>
+class auto_arg<auto_prev<T, N>>
+{
+public:
+  typedef auto_prev<T, N> type;
+  typedef auto_prev<T, N> arg_type;
+  typedef auto_id<T> id_type;
+
+  static const bool is_input = true;
+  static const bool is_output = false;
+  static const bool is_shared = true;
+  static const bool is_multi = false;
+  static const int tshift = N;
+
+  template<class C>
+  static const T* arg(C& packet) {
+    const T* retVal;
+    packet.template Get<T>(retVal, N);
+    return retVal;
+  }
 };

--- a/autowiring/autowiring.h
+++ b/autowiring/autowiring.h
@@ -3,3 +3,6 @@
 
 #include "Autowired.h"
 #include "AutoNetServer.h"
+#include "auto_in.h"
+#include "auto_out.h"
+#include "auto_prev.h"


### PR DESCRIPTION
These specializations require access to AutoPacket arguments.  Move them to the types they specialize, where possible, to break a dependency cycle.