### PR TITLE
android: restore autoboost headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,12 +191,14 @@ if(NOT AUTOWIRING_IS_EMBEDDED)
   )
  
   # Install autoboost headers on ARM, which still requires them
-  if(autowiring_BUILD_ANDROID)
-    install(
-      DIRECTORY ${PROJECT_SOURCE_DIR}/contrib/autoboost/autoboost
-      DESTINATION include
-      COMPONENT autowiring
-    )
+  if(CMAKE_COMPILER_IS_GNUCC AND ("${CMAKE_CXX_COMPILER}" MATCHES "androideabi"))
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9")
+      install(
+        DIRECTORY ${PROJECT_SOURCE_DIR}/contrib/autoboost/autoboost
+        DESTINATION include
+        COMPONENT autowiring
+      )
+    endif()
   endif()
  
   # Targets file is needed in order to describe how to link Autowiring to the rest of the system

--- a/autowiring/C++11/cpp11.h
+++ b/autowiring/C++11/cpp11.h
@@ -102,7 +102,7 @@
 /*********************
  * future availability
  *********************/
-#if (_MSC_VER >= 1700 || (STL11_ALLOWED)) && !__ANDROID__
+#if (_MSC_VER >= 1700 || (STL11_ALLOWED)) && (!__ANDROID__ || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9) || __GNUC__ >= 5)
   #define FUTURE_HEADER <future>
 #else
   // As of NDK r10, we still don't have an implementation of "future" for Android

--- a/autowiring/C++11/cpp11.h
+++ b/autowiring/C++11/cpp11.h
@@ -102,7 +102,7 @@
 /*********************
  * future availability
  *********************/
-#if (_MSC_VER >= 1700 || (STL11_ALLOWED)) && (!__ANDROID__ || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9) || __GNUC__ >= 5)
+#if (_MSC_VER >= 1700 || (STL11_ALLOWED)) && (!__ANDROID__ || GCC_CHECK(4, 9))
   #define FUTURE_HEADER <future>
 #else
   // As of NDK r10, we still don't have an implementation of "future" for Android

--- a/src/autowiring/CoreJob.cpp
+++ b/src/autowiring/CoreJob.cpp
@@ -6,7 +6,7 @@
 
 // Arm doesn't have std::future, but does have std::chrono. We need to convert from std::chrono
 // to autoboost::chrono when passing arguments to "std::future"(alias to autoboost::future) on arm.
-#if autowiring_BUILD_ANDROID
+#if __ANDROID__ && !GCC_CHECK(4, 9)
 autoboost::chrono::nanoseconds NanosecondsForFutureWait(const std::chrono::nanoseconds& time) {
   return autoboost::chrono::nanoseconds(time.count());
 }


### PR DESCRIPTION
The changes in #612 are suspect, using a macro called autowiring_BUILD_ANDROID that is never defined, effectively disabling autoboost and the workaround NanosecondsForFutureWait()

This branch restores autoboost to 32-bit gcc 4.8 Android, while helping 64-bit gcc 4.9 move forward to use the \<future> header without autoboost.

Tested <tt>make install</tt> for both configurations to confirm that autoboost installs, or doesn't, as intended.