### PR TITLE
Add a reference overload for WriteAutoFilterGraph

### DIFF
--- a/autowiring/AutowiringDebug.h
+++ b/autowiring/AutowiringDebug.h
@@ -60,6 +60,7 @@ std::vector<std::string> ListRootDecorations(void);
 std::string AutoFilterGraphStr(void);
 void WriteAutoFilterGraph(std::ostream& os);
 void WriteAutoFilterGraph(std::ostream& os, const std::shared_ptr<CoreContext>& ctxt);
+void WriteAutoFilterGraph(std::ostream& os, CoreContext& ctxt);
 
 /// <summary>
 /// Initializes the Autowiring debug library

--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -210,11 +210,14 @@ std::string autowiring::dbg::AutoFilterGraphStr(void) {
 }
 
 void autowiring::dbg::WriteAutoFilterGraph(std::ostream& os, const std::shared_ptr<CoreContext>& ctxt) {
-  CurrentContextPusher pshr(ctxt);
-  Autowired<AutoPacketFactory> factory;
+  return autowiring::dbg::WriteAutoFilterGraph(os, *ctxt);
+}
+
+void autowiring::dbg::WriteAutoFilterGraph(std::ostream& os, CoreContext& ctxt) {
+  AutowiredFast<AutoPacketFactory> factory(&ctxt);
 
   // Write opening and closing parts of file. Now, we only need to write edges
-  os << "digraph " << autowiring::demangle(ctxt->GetSigilType()) << " {" << std::endl;
+  os << "digraph " << autowiring::demangle(ctxt.GetSigilType()) << " {" << std::endl;
   auto exit = MakeAtExit([&os]{
     os << "}" << std::endl;
   });


### PR DESCRIPTION
Also switch this method to use `AutowiredFast`.