### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,13 @@
 # Purpose
 
-Autowiring is an [inversion-of-control](http://en.wikipedia.org/wiki/Inversion_of_control) framework for C++11. It provides a declarative way to manage resources through [dependency injection](http://en.wikipedia.org/wiki/Dependency_injection). Instead of explicitly instantiating dependencies, simply declare what you need and Autowiring will manage object creation and wiring.
+Autowiring is an [inversion-of-control](http://en.wikipedia.org/wiki/Inversion_of_control) framework for C++11. It provides a declarative way to manage resources through
+[dependency injection](http://en.wikipedia.org/wiki/Dependency_injection). Instead of explicitly instantiating dependencies, simply declare what you need and Autowiring
+will manage object creation and wiring.
 
 # Build [![Build Status](https://travis-ci.org/leapmotion/autowiring.png)](https://travis-ci.org/leapmotion/autowiring)
 
-Autowiring project structure is specified with [CMake](http://www.cmake.org/). Simply point CMake to the root project directory and generate your desired project file. While Autowiring is written using C++11 features, it supports linking the non-C++11 STL. The `C++11/` directory provides [boost](http://www.boost.org/) shims for missing C++11 library features.
-
-### CMake Options
-
-Because AutoNet has a Boost dependency, it can sometimes be desirable to influence how Boost should be linked to the project.  You can influence the decision
-making process by setting CMake Boost attributes, which are described by the [cmake documentation](http://www.cmake.org/cmake/help/v3.0/module/FindBoost.html).
-A common use case is to statically link to a pre-specified installation of boost.  To do this, run CMake as follows:
-
-    cmake . \ 
-      -DBOOST_ROOT:PATH=/path/to/boost \ 
-      -DBoost_USE_STATIC_LIBS:BOOL=ON \ 
-      -DBoost_NO_SYSTEM_PATHS:BOOL=ON
-
-Watch the cases, you will get "unused variable" warnings if you don't match what is written above exactly.
+Autowiring project structure is specified with [CMake](http://www.cmake.org/). Simply point CMake to the root project directory and generate your desired project file.
+The `C++11/` directory provides [boost](http://www.boost.org/) shims for platforms that have incomplete C++11 support.
 
 ### Mac
 
@@ -25,7 +15,7 @@ Mac dependencies are installed with [port](http://guide.macports.org/) or [brew]
 
     git clone git@github.com:leapmotion/autowiring.git
     cd autowiring
-    sudo port install boost cmake
+    sudo port install cmake
     cmake .
     make
     make test
@@ -35,16 +25,14 @@ This will configure the project to build fat binaries by default.  If you wish t
 
     cmake . -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64
 
-Note that AutoNet will be built for 64-bit only, unless your Boost installation was built as fat binaries.
-
-### Unix
+### Linix
 
 The commands for Unix are different depending on what package manager you're using.  Ubuntu's package manager is apt-get, OpenSUSE uses zypper, and
 CentOS systems use yum.  The major apparent difference to the user will be that the package to install has a different name.  For Ubuntu, do this:
 
     git clone git@github.com:leapmotion/autowiring.git
     cd autowiring
-    sudo apt-get install libboost-dev cmake
+    sudo apt-get install cmake
     cmake .
     make
     make test
@@ -56,19 +44,19 @@ If you want to build for 32-bit Linux, run the following CMake command instead:
 
 ### Windows
 
-Unfortunately, Windows doesn't have any sort of nifty package manager, and this requires that you download and install the boost dependency by hand.  Once
-you've followed the instructions for installing boost as indicated [here](http://www.boost.org/doc/libs/1_55_0/doc/html/bbv2/installation.html) you will
-need to set BOOST_ROOT during cmake configuration time to point to the path where boost was built.  Here's the magic incantation required, assuming you're
-running from a MinGW terminal (comes for free with [Git Extensions](https://code.google.com/p/gitextensions/).  You're also going to need a copy of Visual
-Studio 2012 or better.  Other build systems will probably work, but they aren't officially supported here.
+Unfortunately, Windows doesn't have any sort of nifty package manager, and this requires that you download and install cmake yourself.  Once that's done,
+Here's the magic incantation required, assuming you're running from a MinGW terminal (comes for free with [Git Extensions](https://code.google.com/p/gitextensions/).
+You're also going to need a copy of Visual Studio 2012 or better.  Other build systems will probably work, but they aren't officially supported here.
 
     git clone git@github.com:leapmotion/autowiring.git
     cd autowiring
-    cmake . -DBOOST_ROOT:Path=<path/to/boost/with/forward/slashes>
+    cmake .
 
 At this point, you'll have a solution file in your root directory called "Autowiring.sln", if you run Visual Studio as an adminstrator and build the INSTALL
 target then Autowiring will be installed on your system.  As with the other platforms, CMake will be able to find autowiring when it's installed this way
-via the [find_package](http://www.cmake.org/cmake/help/v3.0/command/find_package.html) command.
+via the [find_package](http://www.cmake.org/cmake/help/v3.0/command/find_package.html) command.  Alternatively, if you prefer to build from the command line:
+
+    cmake --build . --config Release
 
 ### Arm-linux
 


### PR DESCRIPTION
Autowiring no longer has any sort of boost dependency, lines requiring boost installation are no longer correct.