### PR TITLE
Fix issue where unit test is allowing state leakage

### DIFF
--- a/autowiring/AutowiringDebug.h
+++ b/autowiring/AutowiringDebug.h
@@ -27,6 +27,7 @@ std::string ContextName(void);
 /// </summary>
 void PrintContextTree(void);
 void PrintContextTree(std::ostream& os);
+void PrintContextTree(std::ostream& os, const std::shared_ptr<CoreContext>& ctxt);
 
 /// <returns>
 /// The current packet under processing

--- a/src/autowiring/test/AutowiringDebugTest.cpp
+++ b/src/autowiring/test/AutowiringDebugTest.cpp
@@ -66,26 +66,25 @@ TEST_F(AutowiringDebugTest, ContextPrintout) {
   auto ctxt5 = hCtxt->Create<Derp>();
 
   // This is the expected output
-  std::string tree = "GlobalCoreContext\n"
-                     "└── void(Current Context)\n"
+  std::string tree = "void(Current Context)\n"
+                     "├── Derp\n"
+                     "│   ├── Herp\n"
+                     "│   │   └── int\n"
+                     "│   └── Derp\n"
+                     "└── Herp\n"
                      "    ├── Derp\n"
-                     "    │   ├── Herp\n"
-                     "    │   │   └── int\n"
-                     "    │   └── Derp\n"
-                     "    └── Herp\n"
-                     "        ├── Derp\n"
-                     "        └── Derp\n";
+                     "    └── Derp\n";
 
   // Remove whitespace so test is more robust
   tree.erase(std::remove_if(tree.begin(), tree.end(), [](char ch) { return ch == ' '; }), tree.end());
 
   // Write output to stringstream an remove whitespace
   std::stringstream ss;
-  autowiring::dbg::PrintContextTree(ss);
+  autowiring::dbg::PrintContextTree(ss, ctxt);
   auto output = ss.str();
   output.erase(std::remove_if(output.begin(), output.end(), [](char ch) { return ch == ' '; }), output.end());
 
-  ASSERT_EQ(tree, output) << "Didn't print correct tree";
+  ASSERT_STREQ(tree.c_str(), output.c_str()) << "Didn't print correct tree";
 }
 
 struct IntOutputer {


### PR DESCRIPTION
This unit test uses the global context, and so is allowing leakage of state in cases where contexts do not cleanly tear down in other tests.  Fix it so it references only those elements created locally in order to prevent spurious errors from being reported here.  Also add an override to `PrintContextTree` that accepts a specific `CoreContext` whose tree is to be printed.