### PR TITLE
UnsnoopAutoPacket does not need to be recursive

### DIFF
--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -1213,10 +1213,6 @@ void CoreContext::UnsnoopAutoPacket(const CoreObjectDescriptor& traits) {
   
   // Always remove from this context's PacketFactory:
   Inject<AutoPacketFactory>()->RemoveSubscriber(traits.subscriber);
-  
-  // Handoff to parent:
-  if (m_pParent)
-    m_pParent->UnsnoopAutoPacket(traits);
 }
 
 std::ostream& operator<<(std::ostream& os, const CoreContext& rhs) {


### PR DESCRIPTION
Context-recursive packet processing has been deprecated for several major versions, there is no need to recursively create packet factories to the root when unsnooping.