### PR TITLE
Add CoreContext::Quiescent

### DIFF
--- a/autowiring/AutowiringEnclosure.h
+++ b/autowiring/AutowiringEnclosure.h
@@ -107,6 +107,9 @@ public:
     // and Wait itself with the extended teardown period specified.
     ASSERT_TRUE(ctxt->Wait(std::chrono::seconds(5))) << "Test case took too long to tear down, unit tests running after this point are untrustworthy";
 
+    // Global context should return to quiescence:
+    ASSERT_TRUE(AutoGlobalContext()->Quiescent(std::chrono::seconds(5))) << "Contexts took too long to release all references to the global context";
+
     static const char sc_autothrow [] = "AUTOTHROW_";
     if(!strncmp(sc_autothrow, info.name(), sizeof(sc_autothrow) - 1))
       // Throw expected, end here

--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -902,12 +902,17 @@ public:
   /// total control over injection and subcontext creation events.  In a single-threaded system, the currrent
   /// context and all child contexts are guaranteed to have no CoreRunnable instances in a running state.
   /// </remarks>
-  void Quiescent(void);
+  void Quiescent(void) const;
 
   /// <summary>
   /// Timed version of Quiescent
   /// </summary>
-  bool Quiescent(std::chrono::nanoseconds duration);
+  bool Quiescent(std::chrono::nanoseconds duration) const;
+
+  /// <summary>
+  /// Retrieves the system's current quiescence status
+  /// </summary>
+  bool IsQuiescent(void) const;
 
   /// <summary>
   /// Waits until the context begins shutting down (IsShutdown is true)

--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -895,6 +895,21 @@ public:
   void SignalTerminate(bool wait = true) { SignalShutdown(wait, ShutdownMode::Immediate); }
 
   /// <summary>
+  /// Identical to Wait, except blocks only until the threads in this and all descendant contexts have stopped
+  /// </summary>
+  /// <remarks>
+  /// This method intrinsically may imply a race condition unless the caller is careful to ensure it retains
+  /// total control over injection and subcontext creation events.  In a single-threaded system, the currrent
+  /// context and all child contexts are guaranteed to have no CoreRunnable instances in a running state.
+  /// </remarks>
+  void Quiescent(void);
+
+  /// <summary>
+  /// Timed version of Quiescent
+  /// </summary>
+  bool Quiescent(std::chrono::nanoseconds duration);
+
+  /// <summary>
   /// Waits until the context begins shutting down (IsShutdown is true)
   /// and all threads and child threads have terminated.
   /// </summary>

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -553,14 +553,19 @@ void CoreContext::SignalShutdown(bool wait, ShutdownMode shutdownMode) {
     Wait();
 }
 
-void CoreContext::Quiescent(void) {
+void CoreContext::Quiescent(void) const {
   std::unique_lock<std::mutex> lk(m_stateBlock->m_lock);
   m_stateBlock->m_stateChanged.wait(lk, [this] { return m_stateBlock->m_outstanding.expired(); });
 }
 
-bool CoreContext::Quiescent(const std::chrono::nanoseconds duration) {
+bool CoreContext::Quiescent(const std::chrono::nanoseconds duration) const {
   std::unique_lock<std::mutex> lk(m_stateBlock->m_lock);
   return m_stateBlock->m_stateChanged.wait_for(lk, duration, [this] { return m_stateBlock->m_outstanding.expired(); });
+}
+
+bool CoreContext::IsQuiescent(void) const {
+  std::lock_guard<std::mutex> lk(m_stateBlock->m_lock);
+  return m_stateBlock->m_outstanding.expired();
 }
 
 void CoreContext::Wait(void) {

--- a/src/autowiring/test/CoreThreadTest.cpp
+++ b/src/autowiring/test/CoreThreadTest.cpp
@@ -590,3 +590,17 @@ TEST_F(CoreThreadTest, SubContextHoldsParentContext) {
   }
   ASSERT_TRUE(parent->Wait(std::chrono::seconds(5))) << "Signalled thread did not terminate in a timely fashion";
 }
+
+class DoesNothingButQuit:
+  public CoreThread
+{
+public:
+  void Run(void) override {}
+};
+
+TEST_F(CoreThreadTest, QuiescentNotTerminated) {
+  AutoCurrentContext ctxt;
+  ctxt->Initiate();
+  AutoRequired<DoesNothingButQuit> ct;
+  ASSERT_TRUE(ctxt->Quiescent(std::chrono::seconds(5))) << "Quiescence was not achieved in a thread that should have self-terminated";
+}

--- a/src/autowiring/test/CoreThreadTest.cpp
+++ b/src/autowiring/test/CoreThreadTest.cpp
@@ -603,4 +603,5 @@ TEST_F(CoreThreadTest, QuiescentNotTerminated) {
   ctxt->Initiate();
   AutoRequired<DoesNothingButQuit> ct;
   ASSERT_TRUE(ctxt->Quiescent(std::chrono::seconds(5))) << "Quiescence was not achieved in a thread that should have self-terminated";
+  ASSERT_TRUE(ctxt->IsQuiescent()) << "Delayed for quiescence, but this was not the state entered when checked on return";
 }


### PR DESCRIPTION
Sometimes it's helpful to know when all child contexts of a current context have terminated without actually terminating the current context, for sequencing purposes.  Autowiring unit tests make use of this property extensively, and have to do this because test segregation is a critical aspect of proper test validation.