### PR TITLE
Fix context leakage in unit tests

### DIFF
--- a/src/autowiring/test/BoltTest.cpp
+++ b/src/autowiring/test/BoltTest.cpp
@@ -88,6 +88,9 @@ TEST_F(BoltTest, VerifyMapping) {
 
   // Now try to autowire a listener:
   AutoRequired<Listener> myListener;
+  auto cleanup = MakeAtExit([myListener] {
+    myListener->createdContext.reset();
+  });
 
   // Create a second context, verify that the listener got the message:
   AutoCreateContextT<Pipeline> createdContext;
@@ -108,6 +111,9 @@ TEST_F(BoltTest, VerifyCreationBubbling) {
 
   // Put the listener in the parent context:
   AutoRequired<Listener> listener;
+  auto cleanup = MakeAtExit([listener] {
+    listener->createdContext.reset();
+  });
 
   AutoCurrentContext outer;
 

--- a/src/autowiring/test/CoreRunnableTest.cpp
+++ b/src/autowiring/test/CoreRunnableTest.cpp
@@ -17,6 +17,10 @@ public:
     m_myContext->Initiate();
     return false;
   }
+  
+  void OnStop(bool) override {
+    m_myContext.reset();
+  }
 };
 
 TEST_F(CoreRunnableTest, CanStartSubcontextWhileInitiating) {

--- a/src/autowiring/test/EventReceiverTest.cpp
+++ b/src/autowiring/test/EventReceiverTest.cpp
@@ -207,7 +207,10 @@ TEST_F(EventReceiverTest, VerifyDescendantContextWiring) {
       // Verify that it gets caught:
       ASSERT_TRUE(rcvr->m_zero) << "Event receiver in descendant context was not properly autowired";
 
-      subCtxt->SignalShutdown(true);
+      subCtxt->SignalShutdown();
+      subCtxt->Wait();
+      pshr.Pop();
+      ASSERT_EQ(1UL, subCtxt.use_count()) << "A subcontext that should be going away was incorrectly referenced";
     }
 
     // Verify subcontext is gone:

--- a/src/autowiring/test/SnoopTest.cpp
+++ b/src/autowiring/test/SnoopTest.cpp
@@ -284,22 +284,21 @@ TEST_F(SnoopTest, SimplePackets) {
   Pipeline->AddSnooper(filter);
   ASSERT_FALSE(!!filter->m_called) << "Filter called prematurely";
   ASSERT_FALSE(detachedFilter->m_called) << "Filter called prematurely";
-  
+
   // Add factory to pipeline
   AutoRequired<AutoPacketFactory> factory(Pipeline);
   auto packet = factory->NewPacket();
-  
+
   packet->Decorate(Decoration<0>());
   ASSERT_FALSE(!!filter->m_called) << "Filter called prematurely";
-  
+
   // Now compleletly satisfy filter. Should snoop across contexts
   packet->Decorate(Decoration<1>());
   ASSERT_TRUE(!!filter->m_called) << "A snooper did not receive an AutoPacket originating in a snooped context";
   ASSERT_FALSE(detachedFilter->m_called) << "Received a packet from a different context";
-  
+
   //reset
   filter->m_called = false;
-  
   Pipeline->RemoveSnooper(filter);
   auto packet2 = factory->NewPacket();
   packet2->Decorate(Decoration<0>());


### PR DESCRIPTION
Adding a context leakage check in `AutowiringEnclosure` has revealed that a frightening number of unit tests suffer from race conditions and other issues that prevent total test isolation and good cleanup logic.  Fix these issues and keep the leakage check in place to ensure they don't arise again in the future.