### PR TITLE
Create an explicit RunCounter type for use with run tracking

### DIFF
--- a/autowiring/CoreContextStateBlock.h
+++ b/autowiring/CoreContextStateBlock.h
@@ -1,10 +1,29 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include "CoreObject.h"
 #include <memory>
 #include MUTEX_HEADER
 
-class CoreObject;
 class CoreContext;
+struct CoreContextStateBlock;
+
+namespace autowiring {
+  /// <summary>
+  /// Container type used for state block referencing
+  /// </summary>
+  class RunCounter:
+    public CoreObject
+  {
+  public:
+    RunCounter(const std::shared_ptr<CoreContextStateBlock>& stateBlock, const std::shared_ptr<CoreContext>& owner);
+    ~RunCounter(void);
+
+  private:
+    const std::shared_ptr<CoreContextStateBlock> stateBlock;
+    const std::shared_ptr<RunCounter> parentCount;
+    std::shared_ptr<CoreContext> owner;
+  };
+}
 
 struct CoreContextStateBlock:
   std::enable_shared_from_this<CoreContextStateBlock>
@@ -24,7 +43,7 @@ public:
 
   // Clever use of shared pointer to expose the number of outstanding CoreRunnable instances.
   // Destructor does nothing; this is by design.
-  std::weak_ptr<CoreObject> m_outstanding;
+  std::weak_ptr<autowiring::RunCounter> m_outstanding;
 
   /// \internal
   /// <summary>
@@ -39,6 +58,6 @@ public:
   ///
   /// The caller is responsible for exterior synchronization
   /// </remarks>
-  std::shared_ptr<CoreObject> IncrementOutstandingThreadCount(std::shared_ptr<CoreContext> owner);
+  std::shared_ptr<autowiring::RunCounter> IncrementOutstandingThreadCount(std::shared_ptr<CoreContext> owner);
 };
 

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -570,12 +570,12 @@ bool CoreContext::IsQuiescent(void) const {
 
 void CoreContext::Wait(void) {
   std::unique_lock<std::mutex> lk(m_stateBlock->m_lock);
-  m_stateBlock->m_stateChanged.wait(lk, [this] {return IsShutdown() && m_stateBlock->m_outstanding.expired(); });
+  m_stateBlock->m_stateChanged.wait(lk, [this] { return IsShutdown() && m_stateBlock->m_outstanding.expired(); });
 }
 
 bool CoreContext::Wait(const std::chrono::nanoseconds duration) {
   std::unique_lock<std::mutex> lk(m_stateBlock->m_lock);
-  return m_stateBlock->m_stateChanged.wait_for(lk, duration, [this] {return IsShutdown() && m_stateBlock->m_outstanding.expired(); });
+  return m_stateBlock->m_stateChanged.wait_for(lk, duration, [this] { return IsShutdown() && m_stateBlock->m_outstanding.expired(); });
 }
 
 bool CoreContext::DelayUntilInitiated(void) {

--- a/src/autowiring/CoreContextStateBlock.cpp
+++ b/src/autowiring/CoreContextStateBlock.cpp
@@ -3,51 +3,52 @@
 #include "CoreContextStateBlock.h"
 #include "CoreContext.h"
 
+using namespace autowiring;
+
+RunCounter::RunCounter(const std::shared_ptr<CoreContextStateBlock>& stateBlock, const std::shared_ptr<CoreContext>& owner) :
+  stateBlock(stateBlock),
+  owner(owner),
+
+  // Increment the parent's outstanding count as well.  This will be held by the lambda, and will cause the enclosing
+  // context's outstanding thread count to be incremented by one as long as we have any threads still running in our
+  // context.  This property is relied upon in order to get the Wait function to operate properly.
+  parentCount(
+    stateBlock->parent ?
+    stateBlock->parent->IncrementOutstandingThreadCount(owner->GetParentContext()) :
+    nullptr
+  )
+{}
+
+RunCounter::~RunCounter(void) {
+  // Reset the owner before performing any other type of notification, we don't want to hold a reference
+  // to the owner and prevent its destruction before signaling or resetting anything
+  owner.reset();
+
+  std::weak_ptr<CoreObject> outstanding;
+  std::lock_guard<std::mutex> lk(stateBlock->m_lock);
+
+  // Unfortunately, this destructor callback is made before weak pointers are
+  // invalidated, which requires that we manually reset the outstanding count
+  // We don't want to free memory while holding the lock, so defer
+  outstanding = std::move(stateBlock->m_outstanding);
+  stateBlock->m_outstanding.reset();
+
+  // Wake everyone up
+  stateBlock->m_stateChanged.notify_all();
+}
+
 CoreContextStateBlock::CoreContextStateBlock(std::shared_ptr<CoreContextStateBlock> parent) :
   parent(parent)
 {}
 
 CoreContextStateBlock::~CoreContextStateBlock(void) {}
 
-std::shared_ptr<CoreObject> CoreContextStateBlock::IncrementOutstandingThreadCount(std::shared_ptr<CoreContext> owner) {
-  // Optimistic check
-  std::shared_ptr<CoreObject> retVal = m_outstanding.lock();
-  if (retVal)
-    return retVal;
-
-  // Double-check
+std::shared_ptr<RunCounter> CoreContextStateBlock::IncrementOutstandingThreadCount(std::shared_ptr<CoreContext> owner) {
   std::lock_guard<std::mutex> lk(m_lock);
-  retVal = m_outstanding.lock();
-  if (retVal)
-    return retVal;
-
-  // Increment the parent's outstanding count as well.  This will be held by the lambda, and will cause the enclosing
-  // context's outstanding thread count to be incremented by one as long as we have any threads still running in our
-  // context.  This property is relied upon in order to get the Wait function to operate properly.
-  std::shared_ptr<CoreObject> parentCount;
-  if (parent)
-    parentCount = parent->IncrementOutstandingThreadCount(owner->GetParentContext());
-
-  auto self = shared_from_this();
-  retVal.reset(
-    (CoreObject*) 1,
-    [this, self, parentCount, owner](CoreObject*) mutable {
-      // Reset the owner before performing any other type of notification, we don't want to hold a reference
-      // to the owner and prevent its destruction before signalling or resetting anything
-      owner.reset();
-
-      // Object being destroyed, notify all recipients
-      std::lock_guard<std::mutex> lk(m_lock);
-
-      // Unfortunately, this destructor callback is made before weak pointers are
-      // invalidated, which requires that we manually reset the outstanding count
-      m_outstanding.reset();
-
-      // Wake everyone up
-      m_stateChanged.notify_all();
-    }
-  );
-
-  m_outstanding = retVal;
+  auto retVal = m_outstanding.lock();
+  if (!retVal) {
+    retVal = std::make_shared<RunCounter>(shared_from_this(), owner);
+    m_outstanding = retVal;
+  }
   return retVal;
 }


### PR DESCRIPTION
Create a `RunCounter` type to allow us to make proper use of `shared_ptr` construction rules by avoiding having the hacked integer `1` cast as a pointer type to ensure the deleter gets called.  Also create a convenient place to store state variables that were formerly only held inside the deleter itself; an explicit structure for such an important datatype is certainly more appropriate.

Move the deleter logic into `RunCounter::~RunCounter`.