### PR TITLE
Minor optimization for zero-duration delayed dispatchers

### DIFF
--- a/autowiring/DispatchQueue.h
+++ b/autowiring/DispatchQueue.h
@@ -236,16 +236,41 @@ public:
   /// </remarks>
   std::chrono::steady_clock::time_point SuggestSoonestWakeupTimeUnsafe(std::chrono::steady_clock::time_point latestTime) const;
 
-  class DispatchThunkDelayedExpression {
+  class DispatchThunkDelayedExpressionRel {
   public:
-    DispatchThunkDelayedExpression(DispatchQueue* pParent, std::chrono::steady_clock::time_point wakeup) :
+    DispatchThunkDelayedExpressionRel(DispatchQueue* pParent, std::chrono::microseconds delay) :
+      m_pParent(pParent),
+      m_delay(delay)
+    {}
+
+  private:
+    DispatchQueue* const m_pParent;
+    const std::chrono::microseconds m_delay;
+
+  public:
+    template<class _Fx>
+    void operator,(_Fx&& fx) {
+      // Let the parent handle this one directly after composing a delayed dispatch thunk r-value
+      if (m_delay.count())
+        *m_pParent += DispatchThunkDelayed(
+          std::chrono::steady_clock::now() + m_delay,
+          new DispatchThunk<_Fx>(std::forward<_Fx&&>(fx))
+        );
+      else
+        *m_pParent += std::forward<_Fx&&>(fx);
+    }
+  };
+
+  class DispatchThunkDelayedExpressionAbs {
+  public:
+    DispatchThunkDelayedExpressionAbs(DispatchQueue* pParent, std::chrono::steady_clock::time_point wakeup) :
       m_pParent(pParent),
       m_wakeup(wakeup)
     {}
 
   private:
-    DispatchQueue* m_pParent;
-    std::chrono::steady_clock::time_point m_wakeup;
+    DispatchQueue* const m_pParent;
+    const std::chrono::steady_clock::time_point m_wakeup;
 
   public:
     template<class _Fx>
@@ -266,8 +291,12 @@ public:
   /// <summary>
   /// Overload for the introduction of a delayed dispatch thunk
   /// </summary>
+  /// <remarks>
+  /// If the passed duration is equal to zero, the returned expression template will pend a lambda
+  /// to the dispatch queue as though that lambda were added with operator+= without any delay.
+  /// </remarks>
   template<class Rep, class Period>
-  DispatchThunkDelayedExpression operator+=(std::chrono::duration<Rep, Period> rhs) {
+  DispatchThunkDelayedExpressionRel operator+=(std::chrono::duration<Rep, Period> rhs) {
     // Verify that the duration is at least microseconds.  If you're getting an assertion here, try
     // using std::duration_cast<std::chrono::microseconds>(duration)
     static_assert(
@@ -276,13 +305,13 @@ public:
     );
 
     std::chrono::steady_clock::time_point timepoint = std::chrono::steady_clock::now() + rhs;
-    return *this += timepoint;
+    return{this, rhs};
   }
 
   /// <summary>
   /// Overload for absolute-time based delayed dispatch thunk
   /// </summary>
-  DispatchThunkDelayedExpression operator+=(std::chrono::steady_clock::time_point rhs);
+  DispatchThunkDelayedExpressionAbs operator+=(std::chrono::steady_clock::time_point rhs);
 
   /// <summary>
   /// Directly pends a delayed dispatch thunk

--- a/src/autowiring/DispatchQueue.cpp
+++ b/src/autowiring/DispatchQueue.cpp
@@ -312,8 +312,8 @@ void DispatchQueue::operator+=(DispatchQueue&& rhs) {
   OnPended(std::move(lk));
 }
 
-DispatchQueue::DispatchThunkDelayedExpression DispatchQueue::operator+=(std::chrono::steady_clock::time_point rhs) {
-  return DispatchThunkDelayedExpression(this, rhs);
+DispatchQueue::DispatchThunkDelayedExpressionAbs DispatchQueue::operator+=(std::chrono::steady_clock::time_point rhs) {
+  return{this, rhs};
 }
 
 void DispatchQueue::operator+=(DispatchThunkDelayed&& rhs) {

--- a/src/autowiring/test/DispatchQueueTest.cpp
+++ b/src/autowiring/test/DispatchQueueTest.cpp
@@ -207,3 +207,19 @@ TEST_F(DispatchQueueTest, MoveConstructor) {
   }
   ASSERT_EQ(counter, 3) << "Lambdas not trasfered by move constructor";
 }
+
+TEST_F(DispatchQueueTest, ZeroIdenticalToPend) {
+  DispatchQueue dq;
+
+  int reference = 101;
+  int observation = 1;
+  dq += std::chrono::seconds(0), [&] { observation = reference; };
+  dq += [&] { reference = 102; };
+  ASSERT_EQ(2UL, dq.GetDispatchQueueLength()) << "Two dispatchers were added but two were not detected on the queue";
+
+  // Verify that the lambdas were executed in order:
+  dq.DispatchAllEvents();
+  ASSERT_EQ(0UL, dq.GetDispatchQueueLength()) << "Not all dispatchers were executed even though all dispatchers should have been ready";
+  ASSERT_NE(1, observation) << "Zero-delay lambda was not executed";
+  ASSERT_EQ(101, observation) << "Zero-delay lambda did not run in the order it was pended";
+}


### PR DESCRIPTION
If a delayed lambda is pended to a `DispatchQueue` with a delay duration of zero, then just pend this to the ready queue directly, completely bypassing the waiting queue.

Also, change the time offset calculation for relatively delayed lambdas to be performed after the lambda is constructed and about to be pended to the queue.