### PR TITLE
Restore Windows XP build compatibility

### DIFF
--- a/src/autowiring/CoreThreadWin.cpp
+++ b/src/autowiring/CoreThreadWin.cpp
@@ -42,7 +42,7 @@ void SetThreadName(DWORD dwThreadID, LPCSTR szThreadName)
 }
 
 void BasicThread::SetCurrentThreadName(void) const {
-  DWORD threadId = ::GetThreadId(m_state->m_thisThread.native_handle());
+  DWORD threadId = ::GetCurrentThreadId();
   ::SetThreadName(threadId, m_name);
 }
 


### PR DESCRIPTION
`GetThreadId` can be replaced with `GetCurrentThreadId` in the only place where it's called.