### PR TITLE
Fix deprecated method calls in unit tests and internal calls

### DIFF
--- a/autowiring/auto_out.h
+++ b/autowiring/auto_out.h
@@ -66,7 +66,7 @@ public:
       if (m_decoration)
         m_packet->Decorate<T>(std::move(m_decoration));
       else
-        m_packet->Unsatisfiable<T>();
+        m_packet->MarkUnsatisfiable<T>();
     }
 
   private:

--- a/src/autowiring/test/AutoFilterMultiDecorateTest.cpp
+++ b/src/autowiring/test/AutoFilterMultiDecorateTest.cpp
@@ -90,7 +90,7 @@ TEST_F(AutoFilterMultiDecorateTest, UnsatDecTest) {
 
   auto packet = f->NewPacket();
   packet->Decorate(Decoration<0>{});
-  packet->Unsatisfiable<Decoration<1>>();
+  packet->MarkUnsatisfiable<Decoration<1>>();
   packet->Decorate(Decoration<2>{});
 
   auto strs = packet->GetAll<std::string>();

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -227,7 +227,7 @@ TEST_F(AutoFilterTest, VerifyAntiDecorate) {
   {
     // Obtain a new packet and mark an unsatisfiable decoration:
     auto packet = factory->NewPacket();
-    packet->Unsatisfiable<Decoration<0>>();
+    packet->MarkUnsatisfiable<Decoration<0>>();
     ASSERT_ANY_THROW(packet->Decorate(Decoration<0>())) << "Incorrectly allowed a decoration to be added to a packet when that decoration was unsatisfiable";
   }
 
@@ -235,7 +235,7 @@ TEST_F(AutoFilterTest, VerifyAntiDecorate) {
     // Obtain a new packet and try to make a satisfied decoration unsatisfiable.
     auto packet = factory->NewPacket();
     packet->Decorate(Decoration<0>());
-    ASSERT_NO_THROW(packet->Unsatisfiable<Decoration<0>>()) << "Failed to expunge a decoration from a packet";
+    ASSERT_NO_THROW(packet->MarkUnsatisfiable<Decoration<0>>()) << "Failed to expunge a decoration from a packet";
   }
 }
 

--- a/src/autowiring/test/SatisfiabilityTest.cpp
+++ b/src/autowiring/test/SatisfiabilityTest.cpp
@@ -25,7 +25,7 @@ TEST_F(SatisfiabilityTest, MarkUnsatisfiableCalls) {
   bool bSharedPtrCalled = false;
   *packet += [&bSharedPtrCalled](std::shared_ptr<const Decoration<0>> dec) { bSharedPtrCalled = true; };
 
-  packet->Unsatisfiable<Decoration<0>>();
+  packet->MarkUnsatisfiable<Decoration<0>>();
 
   ASSERT_FALSE(bRefCalled) << "Reference version should not have been called";
   ASSERT_TRUE(bSharedPtrCalled) << "Shared pointer version should have been called as a result of Unsatisfiable";


### PR DESCRIPTION
`AutoPacket::Unsatisfiable` has been marked as deprecated since 0.7.1, failing to refactor Autowiring to use the new method name was an oversight.