### PR TITLE
Eliminate copy ctor for AutoPacketFactory

### DIFF
--- a/autowiring/AutoPacketFactory.h
+++ b/autowiring/AutoPacketFactory.h
@@ -25,6 +25,7 @@ class AutoPacketFactory:
 {
 public:
   AutoPacketFactory(void);
+  AutoPacketFactory(const AutoPacketFactory& rhs) = delete;
   ~AutoPacketFactory(void);
 
 private:


### PR DESCRIPTION
This type cannot be safely copied as it is concurrent anyway, might as well make this explicit.