### PR TITLE
Implement Windows XP fallback mechanism for thread pools

### DIFF
--- a/autowiring/ThreadPool.h
+++ b/autowiring/ThreadPool.h
@@ -35,6 +35,9 @@ protected:
   /// <summary>
   /// Called when the thread pool is being cleaned up
   /// </summary>
+  /// <remarks>
+  /// Where possible, this method should return immediately.
+  /// </remarks>
   virtual void OnStop(void) {}
 
 public:
@@ -48,6 +51,10 @@ public:
   /// <remarks>
   /// This method is idempotent.  Unlike CoreThread instances, a thread pool may be restarted.
   /// The returned shared pointer must be held for as long as the thread pool should be kept running.
+  /// If the returned token is destroyed, the thread pool will be stopped automatically.  Termination
+  /// of work items in the thread pool may occur at a later time on certain platforms; in some cases,
+  /// a call to Start may result in the creation of a new thread pool before the previous thread
+  /// pool is completely torn down.
   /// </remarks>
   virtual std::shared_ptr<void> Start(void);
 

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -195,6 +195,10 @@ add_windows_sources(Autowiring_SRCS
   CoreThreadWin.cpp
   SystemThreadPoolWin.cpp
   SystemThreadPoolWin.hpp
+  SystemThreadPoolWinXP.cpp
+  SystemThreadPoolWinXP.hpp
+  SystemThreadPoolWinLH.cpp
+  SystemThreadPoolWinLH.hpp
   InterlockedExchangeWin.cpp
   thread_specific_ptr_win.h
 )

--- a/src/autowiring/SystemThreadPoolWin.cpp
+++ b/src/autowiring/SystemThreadPoolWin.cpp
@@ -1,79 +1,33 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "SystemThreadPoolWin.hpp"
+#include "SystemThreadPoolWinLH.hpp"
+#include "SystemThreadPoolWinXP.hpp"
 #include "DispatchThunk.h"
 
 using namespace autowiring;
+using namespace autowiring::detail;
+
+static const HMODULE hKernel32 = LoadLibrary("kernel32.dll");
+const decltype(&CreateThreadpoolWork) autowiring::detail::g_CreateThreadpoolWork = (decltype(&CreateThreadpoolWork)) GetProcAddress(hKernel32, "CreateThreadpoolWork");
+const decltype(&CloseThreadpoolWork) autowiring::detail::g_CloseThreadpoolWork = (decltype(&CloseThreadpoolWork)) GetProcAddress(hKernel32, "CloseThreadpoolWork");
 
 SystemThreadPoolWin::SystemThreadPoolWin(void) :
   m_toBeDone(~0)
 {}
 
-SystemThreadPoolWin::~SystemThreadPoolWin(void)
-{
-  if (m_pwkSingle)
-    CloseThreadpoolWork(m_pwkSingle);
-  if (m_pwkDispatchRundown)
-    CloseThreadpoolWork(m_pwkDispatchRundown);
-}
+SystemThreadPoolWin::~SystemThreadPoolWin(void) {}
 
 std::shared_ptr<SystemThreadPool> SystemThreadPool::New(void)
 {
-  return std::make_shared<SystemThreadPoolWin>();
-}
+  if (!g_CreateThreadpoolWork)
+    // Fallback to the XP APIs:
+    return std::make_shared<SystemThreadPoolWinXP>();
 
-void SystemThreadPoolWin::OnStartUnsafe(void) {
-  m_pwkDispatchRundown = CreateThreadpoolWork(
-    [](PTP_CALLBACK_INSTANCE Instance, void* Context, PTP_WORK Work) {
-      auto* pThis = static_cast<SystemThreadPoolWin*>(Context);
-
-      // Grab an arbitrary dispatch queue from the set of pending queues:
-      std::shared_ptr<DispatchQueue> dqEntry;
-      if (!pThis->m_rundownTargets.try_pop(dqEntry))
-        // Short circuit, someone must have got to it already
-        return;
-
-      // Now just dispatch everything in order:
-      dqEntry->DispatchAllEvents();
-    },
-    this,
-    nullptr
-  );
-
-  m_pwkSingle = CreateThreadpoolWork(
-    [](PTP_CALLBACK_INSTANCE Instance, void* Context, PTP_WORK Work) {
-      // Spin down our dispatch queue until it is empty:
-      static_cast<SystemThreadPoolWin*>(Context)->m_toBeDone.DispatchAllEvents();
-    },
-    this,
-    nullptr
-  );
+  // Use the latest greatest API:
+  return std::make_shared<SystemThreadPoolWinLH>();
 }
 
 void SystemThreadPoolWin::OnStop(void) {
   m_toBeDone.Abort();
-
-  std::lock_guard<std::mutex> lk(m_lock);
-  CloseThreadpoolWork(m_pwkSingle);
-  m_pwkSingle = nullptr;
-  CloseThreadpoolWork(m_pwkDispatchRundown);
-  m_pwkDispatchRundown = nullptr;
-}
-
-void SystemThreadPoolWin::Consume(const std::shared_ptr<DispatchQueue>& dq)
-{
-  // Append the entry and then signal the rundown queue that there is work to be done
-  std::lock_guard<std::mutex> lk(m_lock);
-  m_rundownTargets.push(dq);
-  if (m_pwkDispatchRundown)
-    SubmitThreadpoolWork(m_pwkDispatchRundown);
-}
-
-bool SystemThreadPoolWin::Submit(std::unique_ptr<DispatchThunkBase>&& thunk)
-{
-  std::lock_guard<std::mutex> lk(m_lock);
-  m_toBeDone.AddExisting(std::move(thunk));
-  if (m_pwkSingle)
-    SubmitThreadpoolWork(m_pwkSingle);
-  return true;
 }

--- a/src/autowiring/SystemThreadPoolWin.hpp
+++ b/src/autowiring/SystemThreadPoolWin.hpp
@@ -7,8 +7,13 @@
 
 namespace autowiring {
 
+  namespace detail {
+    extern const decltype(&CreateThreadpoolWork) g_CreateThreadpoolWork;
+    extern const decltype(&CloseThreadpoolWork) g_CloseThreadpoolWork;
+  }
+
 /// <summary>
-/// A thread pool that makes use of the underlying system's APIs
+/// Abstract base class used by Windows XP and LH compatibility layers
 /// </summary>
 class SystemThreadPoolWin:
   public SystemThreadPool
@@ -17,11 +22,7 @@ public:
   SystemThreadPoolWin(void);
   ~SystemThreadPoolWin(void);
 
-private:
-  // Work item for single dispatchers
-  PTP_WORK m_pwkDispatchRundown;
-  PTP_WORK m_pwkSingle;
-
+protected:
   // Vector of dispathc queues that need to be run down
   concurrency::concurrent_queue<std::shared_ptr<DispatchQueue>> m_rundownTargets;
 
@@ -29,13 +30,7 @@ private:
   DispatchQueue m_toBeDone;
 
   // ThreadPool overrides:
-  void OnStartUnsafe(void) override;
   void OnStop(void) override;
-
-public:
-  // ThreadPool overrides:
-  void Consume(const std::shared_ptr<DispatchQueue>& dq) override;
-  bool Submit(std::unique_ptr<DispatchThunkBase>&& thunk) override;
 };
 
 }

--- a/src/autowiring/SystemThreadPoolWinLH.cpp
+++ b/src/autowiring/SystemThreadPoolWinLH.cpp
@@ -1,0 +1,73 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "SystemThreadPoolWinLH.hpp"
+#include "DispatchThunk.h"
+
+using namespace autowiring;
+using namespace autowiring::detail;
+
+SystemThreadPoolWinLH::SystemThreadPoolWinLH(void) {}
+
+SystemThreadPoolWinLH::~SystemThreadPoolWinLH(void)
+{
+  if (m_pwkSingle)
+    g_CloseThreadpoolWork(m_pwkSingle);
+  if (m_pwkDispatchRundown)
+    g_CloseThreadpoolWork(m_pwkDispatchRundown);
+}
+
+void SystemThreadPoolWinLH::OnStartUnsafe(void) {
+  m_pwkDispatchRundown = CreateThreadpoolWork(
+    [](PTP_CALLBACK_INSTANCE Instance, void* Context, PTP_WORK Work) {
+      auto* pThis = static_cast<SystemThreadPoolWinLH*>(Context);
+
+      // Grab an arbitrary dispatch queue from the set of pending queues:
+      std::shared_ptr<DispatchQueue> dqEntry;
+      if (!pThis->m_rundownTargets.try_pop(dqEntry))
+        // Short circuit, someone must have got to it already
+        return;
+
+      // Now just dispatch everything in order:
+      dqEntry->DispatchAllEvents();
+    },
+    this,
+    nullptr
+  );
+
+  m_pwkSingle = CreateThreadpoolWork(
+    [](PTP_CALLBACK_INSTANCE Instance, void* Context, PTP_WORK Work) {
+      // Spin down our dispatch queue until it is empty:
+      static_cast<SystemThreadPoolWinLH*>(Context)->m_toBeDone.DispatchAllEvents();
+    },
+    this,
+    nullptr
+  );
+}
+
+void SystemThreadPoolWinLH::OnStop(void) {
+  SystemThreadPoolWin::OnStop();
+
+  std::lock_guard<std::mutex> lk(m_lock);
+  CloseThreadpoolWork(m_pwkSingle);
+  m_pwkSingle = nullptr;
+  CloseThreadpoolWork(m_pwkDispatchRundown);
+  m_pwkDispatchRundown = nullptr;
+}
+
+void SystemThreadPoolWinLH::Consume(const std::shared_ptr<DispatchQueue>& dq)
+{
+  // Append the entry and then signal the rundown queue that there is work to be done
+  std::lock_guard<std::mutex> lk(m_lock);
+  m_rundownTargets.push(dq);
+  if (m_pwkDispatchRundown)
+    SubmitThreadpoolWork(m_pwkDispatchRundown);
+}
+
+bool SystemThreadPoolWinLH::Submit(std::unique_ptr<DispatchThunkBase>&& thunk)
+{
+  std::lock_guard<std::mutex> lk(m_lock);
+  m_toBeDone.AddExisting(std::move(thunk));
+  if (m_pwkSingle)
+    SubmitThreadpoolWork(m_pwkSingle);
+  return true;
+}

--- a/src/autowiring/SystemThreadPoolWinLH.hpp
+++ b/src/autowiring/SystemThreadPoolWinLH.hpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "DispatchQueue.h"
+#include "SystemThreadPoolWin.hpp"
+#include <Windows.h>
+#include <concurrent_queue.h>
+
+namespace autowiring {
+
+/// <summary>
+/// A thread pool that makes use of the underlying system's APIs
+/// </summary>
+class SystemThreadPoolWinLH:
+  public SystemThreadPoolWin
+{
+public:
+  SystemThreadPoolWinLH(void);
+  ~SystemThreadPoolWinLH(void);
+
+private:
+  // Work item for single dispatchers
+  PTP_WORK m_pwkDispatchRundown;
+  PTP_WORK m_pwkSingle;
+
+  // ThreadPool overrides:
+  void OnStartUnsafe(void) override;
+  void OnStop(void) override;
+
+public:
+  // ThreadPool overrides:
+  void Consume(const std::shared_ptr<DispatchQueue>& dq) override;
+  bool Submit(std::unique_ptr<DispatchThunkBase>&& thunk) override;
+};
+
+}

--- a/src/autowiring/SystemThreadPoolWinXP.cpp
+++ b/src/autowiring/SystemThreadPoolWinXP.cpp
@@ -1,0 +1,50 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "SystemThreadPoolWinXP.hpp"
+#include "DispatchThunk.h"
+
+using namespace autowiring;
+
+SystemThreadPoolWinXP::SystemThreadPoolWinXP(void) {}
+
+SystemThreadPoolWinXP::~SystemThreadPoolWinXP(void) {}
+
+void SystemThreadPoolWinXP::Consume(const std::shared_ptr<DispatchQueue>& dq)
+{
+  // Append the entry and then signal the rundown queue that there is work to be done
+  std::lock_guard<std::mutex> lk(m_lock);
+  m_rundownTargets.push(dq);
+  QueueUserWorkItem(
+    [](void* Context) {
+      auto* pThis = static_cast<SystemThreadPoolWinXP*>(Context);
+
+      // Grab an arbitrary dispatch queue from the set of pending queues:
+      std::shared_ptr<DispatchQueue> dqEntry;
+      if (!pThis->m_rundownTargets.try_pop(dqEntry))
+        // Short circuit, someone must have got to it already
+        return 0UL;
+
+      // Now just dispatch everything in order:
+      dqEntry->DispatchAllEvents();
+      return 0UL;
+    },
+    this,
+    WT_EXECUTEDEFAULT
+  );
+}
+
+bool SystemThreadPoolWinXP::Submit(std::unique_ptr<DispatchThunkBase>&& thunk)
+{
+  std::lock_guard<std::mutex> lk(m_lock);
+  m_toBeDone.AddExisting(std::move(thunk));
+  QueueUserWorkItem(
+    [](void* Context) {
+      // Spin down our dispatch queue until it is empty:
+      static_cast<SystemThreadPoolWinXP*>(Context)->m_toBeDone.DispatchAllEvents();
+      return 0UL;
+    },
+    this,
+    WT_EXECUTEDEFAULT
+  );
+  return true;
+}

--- a/src/autowiring/SystemThreadPoolWinXP.hpp
+++ b/src/autowiring/SystemThreadPoolWinXP.hpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "DispatchQueue.h"
+#include "SystemThreadPoolWin.hpp"
+#include <Windows.h>
+#include <concurrent_queue.h>
+
+namespace autowiring {
+
+/// <summary>
+/// A thread pool that makes use of the underlying system's APIs
+/// </summary>
+class SystemThreadPoolWinXP:
+  public SystemThreadPoolWin
+{
+public:
+  SystemThreadPoolWinXP(void);
+  ~SystemThreadPoolWinXP(void);
+
+public:
+  // ThreadPool overrides:
+  void Consume(const std::shared_ptr<DispatchQueue>& dq) override;
+  bool Submit(std::unique_ptr<DispatchThunkBase>&& thunk) override;
+};
+
+}


### PR DESCRIPTION
This is necessary to ensure that compatibility libraries that use Autowiring are still dynamically linkable on Windows XP without delay loading.  Hopefully this is the last LH+ API that needs to be refactored.