### PR TITLE
Add `autowiring::is_complete`

### DIFF
--- a/autowiring/is_complete.h
+++ b/autowiring/is_complete.h
@@ -1,0 +1,29 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include <utility>
+
+namespace autowiring {
+  template<typename T, int>
+  struct is_complete {
+#ifdef _MSC_VER
+    // MSVC requires that we try to invoke the copy ctor in order for SFINAE to
+    // work properly.  The copy ctor will be missing, and the other overload selected.
+    static T & getT();
+    static std::true_type select(T);
+    static std::false_type select(...);
+    static const bool value = decltype(select(getT()))::value;
+#else
+    // GCC/CLANG requires that we attempt to take the size, as the SFINAE behavior
+    // that works on MSVC is not portable.
+    template<typename U>
+    static std::integral_constant<bool, sizeof(U) == sizeof(U)> select(U*);
+
+    template<typename U>
+    static std::false_type select(...);
+
+    static const bool value = decltype(select<T>(nullptr))::value;
+#endif
+  };
+};
+
+// Current target platforms all support __COUNTER__
+#define AUTO_IS_COMPLETE(T) ::autowiring::is_complete<T, __COUNTER__>::value

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -124,6 +124,7 @@ set(Autowiring_SRCS
   InterlockedExchange.h
   InvokeRelay.h
   is_any.h
+  is_complete.h
   is_shared_ptr.h
   JunctionBox.h
   JunctionBoxBase.cpp

--- a/src/autowiring/test/CommonUseCasesTest.cpp
+++ b/src/autowiring/test/CommonUseCasesTest.cpp
@@ -1,6 +1,18 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "HasForwardOnlyType.hpp"
+#include <autowiring/is_complete.h>
+
+struct MyIncompleteType;
+static_assert(!AUTO_IS_COMPLETE(MyIncompleteType), "Type known to be incomplete was marked complete");
+static_assert(AUTO_IS_COMPLETE(std::mutex), "Type known to be complete was marked incomplete");
+
+// Now provide the definition of our formerly incomplete type and verify that we get updated
+struct MyIncompleteType {
+  MyIncompleteType() = delete;
+  MyIncompleteType(const MyIncompleteType&) = delete;
+};
+static_assert(AUTO_IS_COMPLETE(MyIncompleteType), "Type that was completed later was not identified as having been completed");
 
 class CommonUseCasesTest:
   public testing::Test


### PR DESCRIPTION
This will be used to determine at compile time whether a particular type is fully defined.  The utility of this compile time trait is pretty high; right now it's tough to know whether we can use `typeid` safely because types substituted in template methods and classes are often forward-declared.  At some point, however, they _do_ become completely defined, and we'd like to be able to instantiate types that rely upon total definition when that happens.

- [ ] Fix the Windows build