### PR TITLE
Use GetProcAddress for SubmitThreadpoolWork() on XP

### DIFF
--- a/src/autowiring/SystemThreadPoolWin.cpp
+++ b/src/autowiring/SystemThreadPoolWin.cpp
@@ -11,6 +11,7 @@ using namespace autowiring::detail;
 static const HMODULE hKernel32 = LoadLibrary("kernel32.dll");
 const decltype(&CreateThreadpoolWork) autowiring::detail::g_CreateThreadpoolWork = (decltype(&CreateThreadpoolWork)) GetProcAddress(hKernel32, "CreateThreadpoolWork");
 const decltype(&CloseThreadpoolWork) autowiring::detail::g_CloseThreadpoolWork = (decltype(&CloseThreadpoolWork)) GetProcAddress(hKernel32, "CloseThreadpoolWork");
+const decltype(&SubmitThreadpoolWork) autowiring::detail::g_SubmitThreadpoolWork = (decltype(&SubmitThreadpoolWork)) GetProcAddress(hKernel32, "SubmitThreadpoolWork");
 
 SystemThreadPoolWin::SystemThreadPoolWin(void) :
   m_toBeDone(~0)

--- a/src/autowiring/SystemThreadPoolWin.hpp
+++ b/src/autowiring/SystemThreadPoolWin.hpp
@@ -10,6 +10,7 @@ namespace autowiring {
   namespace detail {
     extern const decltype(&CreateThreadpoolWork) g_CreateThreadpoolWork;
     extern const decltype(&CloseThreadpoolWork) g_CloseThreadpoolWork;
+    extern const decltype(&SubmitThreadpoolWork) g_SubmitThreadpoolWork;
   }
 
 /// <summary>

--- a/src/autowiring/SystemThreadPoolWinLH.cpp
+++ b/src/autowiring/SystemThreadPoolWinLH.cpp
@@ -60,7 +60,7 @@ void SystemThreadPoolWinLH::Consume(const std::shared_ptr<DispatchQueue>& dq)
   std::lock_guard<std::mutex> lk(m_lock);
   m_rundownTargets.push(dq);
   if (m_pwkDispatchRundown)
-    SubmitThreadpoolWork(m_pwkDispatchRundown);
+    g_SubmitThreadpoolWork(m_pwkDispatchRundown);
 }
 
 bool SystemThreadPoolWinLH::Submit(std::unique_ptr<DispatchThunkBase>&& thunk)
@@ -68,6 +68,6 @@ bool SystemThreadPoolWinLH::Submit(std::unique_ptr<DispatchThunkBase>&& thunk)
   std::lock_guard<std::mutex> lk(m_lock);
   m_toBeDone.AddExisting(std::move(thunk));
   if (m_pwkSingle)
-    SubmitThreadpoolWork(m_pwkSingle);
+    g_SubmitThreadpoolWork(m_pwkSingle);
   return true;
 }


### PR DESCRIPTION
This appears to be the last entrypoint specific to Autowiring that prevents running on Windows XP.

However, there are are additional problematic entrypoints used by Leap.dll that will need to be resolved so this can be fully tested.