### PR TITLE
Implement a heterogenous block concept

### DIFF
--- a/autowiring/C++11/cpp11.h
+++ b/autowiring/C++11/cpp11.h
@@ -52,7 +52,7 @@
 #if defined(_MSC_VER) && _MSC_VER <= 1800
   #define AUTO_ALIGNOF __alignof
 #else
-  #define AUTO_ALIGNAS alignof
+  #define AUTO_ALIGNOF alignof
 #endif
 
 /*********************

--- a/autowiring/HeteroBlock.h
+++ b/autowiring/HeteroBlock.h
@@ -1,0 +1,59 @@
+#pragma once
+#include "auto_id.h"
+#include <initializer_list>
+
+namespace autowiring {
+
+/// <summary>
+/// A single heterogenous block entry
+/// </summary>
+struct HeteroBlockEntry {
+  // The size of the type that will be constructed
+  size_t ncb;
+};
+
+/// <summary>
+/// Constructs a heterogenous lookaside block
+/// </summary>
+/// <remarks>
+/// A heterogenous block
+/// </remarks>
+class HeteroBlock
+{
+public:
+  HeteroBlock(std::initializer_list<HeteroBlockEntry> entries);
+  ~HeteroBlock();
+
+private:
+  // A shared pointer to the block proper.  This shared pointer points to a memory block
+  // containing all of the subelements allocated in the arena.
+  std::shared_ptr<void> block;
+
+  struct entry {
+    auto_id id;
+    size_t index;
+  };
+  struct entry_hash {
+    size_t operator()(const entry& e) const {
+      std::hash<auto_id> h;
+      return h(e.id) + e.index;
+    }
+  };
+
+  // A map of identifier entries to their offsets in the block
+  std::unordered_map<entry, void*, entry_hash> offsets;
+
+public:
+  /// <summary>
+  /// Retrieves the nth instance of type T on the block
+  /// </summary>
+  template<typename T>
+  std::shared_ptr<T> get(size_t index) {
+    auto q = offsets.find({auto_id_t<T>{}, index});
+    if (q == offsets.end())
+      throw std::runtime_error("Attempted to obtain an index not provided by this type");
+    ;
+  }
+};
+
+}

--- a/autowiring/HeteroBlock.h
+++ b/autowiring/HeteroBlock.h
@@ -1,15 +1,62 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "auto_id.h"
 #include <initializer_list>
+#include <unordered_map>
+#include <vector>
 
 namespace autowiring {
+
+struct HeteroBlockEntryBase {
+  HeteroBlockEntryBase(auto_id id, size_t index) :
+    id(id),
+    index(index)
+  {}
+
+  // Block entry for the constructed type.  This entry must be fully instantiated
+  auto_id id;
+
+  // A unique index for this block entry
+  size_t index;
+
+  struct hash {
+    size_t operator()(const HeteroBlockEntryBase& e) const {
+      std::hash<auto_id> h;
+      return h(e.id) + e.index;
+    }
+  };
+
+  bool operator==(const HeteroBlockEntryBase& rhs) const {
+    return id == rhs.id && index == rhs.index;
+  }
+};
 
 /// <summary>
 /// A single heterogenous block entry
 /// </summary>
-struct HeteroBlockEntry {
-  // The size of the type that will be constructed
-  size_t ncb;
+struct HeteroBlockEntry:
+  HeteroBlockEntryBase
+{
+  template<typename T>
+  HeteroBlockEntry(auto_id_t<T> id, size_t index) :
+    HeteroBlockEntryBase{ id, index },
+    pfnCtor(&PlacementNew<T>),
+    pfnDtor(&Destructor<T>)
+  {
+    (void) auto_id_t_init<T>::init;
+  }
+
+  template<typename T>
+  static void PlacementNew(void* pMem) { new (pMem) T; }
+
+  template<typename T>
+  static void Destructor(void* pMem) { ((T*)pMem)->~T(); }
+
+  // Constructor for this entry:
+  void(*pfnCtor)(void*);
+
+  // Destructor for this entry:
+  void(*pfnDtor)(void*);
 };
 
 /// <summary>
@@ -21,38 +68,87 @@ struct HeteroBlockEntry {
 class HeteroBlock
 {
 public:
-  HeteroBlock(std::initializer_list<HeteroBlockEntry> entries);
+  HeteroBlock(const HeteroBlockEntry* pFirst, const HeteroBlockEntry* pLast);
+  HeteroBlock(std::initializer_list<HeteroBlockEntry> entries) :
+    HeteroBlock(entries.begin(), entries.end())
+  {}
   ~HeteroBlock();
 
 private:
   // A shared pointer to the block proper.  This shared pointer points to a memory block
-  // containing all of the subelements allocated in the arena.
+  // containing all of the subelements allocated in the arena.  Entries in the block are
+  // structured like this:
+  //
+  //  <--- sizeof(T) ---> | sizeof(void*) | sizeof(void*) | <--- sizeof(U) ---> | sizeof(void*) | sizeof(void*)
+  //  T ----------------- | &T::~T        | sizeof(U)     | U ----------------- | &U::~U        | sizeof(V)
+  //
+  // The last entry looks like this:
+  //
+  // 
+  //  <--- sizeof(X) ---> | sizeof(void*) | sizeof(void*)
+  //  X ----------------- | &X::~X        | 0
   std::shared_ptr<void> block;
 
-  struct entry {
-    auto_id id;
-    size_t index;
+  // Structure describing the layout of block headers
+  struct BlockHeader {
+    // Deleter we'll be using to free the "data" field
+    void(*pfnDtor)(void*);
+
+    // Size of the next block's data field
+    size_t nextSize;
   };
-  struct entry_hash {
-    size_t operator()(const entry& e) const {
-      std::hash<auto_id> h;
-      return h(e.id) + e.index;
-    }
+
+  struct entry {
+    // Offset, from the base of the block, where the object is stored
+    size_t offset;
+
+    // May potentially be null, if the shared pointer isn't initialized
+    std::shared_ptr<void> ptr;
   };
 
   // A map of identifier entries to their offsets in the block
-  std::unordered_map<entry, void*, entry_hash> offsets;
+  std::unordered_map<HeteroBlockEntryBase, entry, HeteroBlockEntryBase::hash> entries;
 
 public:
   /// <summary>
   /// Retrieves the nth instance of type T on the block
   /// </summary>
+  /// <param name="T">The type to be obtained, must be complete at the time of the call</param>
+  /// <param name="index">The index of the type to be obtained</param>
   template<typename T>
-  std::shared_ptr<T> get(size_t index) {
-    auto q = offsets.find({auto_id_t<T>{}, index});
-    if (q == offsets.end())
-      throw std::runtime_error("Attempted to obtain an index not provided by this type");
-    ;
+  T& get(size_t index) {
+    auto q = entries.find({auto_id_t<T>{}, index});
+    if (q == entries.end())
+      throw std::runtime_error("Attempted to obtain a type or index not initialized on this block");
+    return *(T*)((uint8_t*)block.get() + q->second.offset);
+  }
+
+  /// <summary>
+  /// Identical to get, except retrieves a shared pointer
+  /// </summary>
+  /// <param name="T">The type to be obtained, must be complete at the time of the call</param>
+  /// <param name="index">The index of the type to be obtained</param>
+  /// <remarks>
+  /// In a multithreaded environment, this method can have worse performance than the non-shared override.
+  /// This is due to the fact that initializing a shared_ptr requires a memory barrier, and barriers are
+  /// very slow.
+  /// </remarks>
+  template<typename T>
+  std::shared_ptr<T>& get_shared(size_t index) {
+    auto q = entries.find({ auto_id_t<T>{}, index });
+    if (q == entries.end())
+      throw std::runtime_error("Attempted to obtain a type or index not initialized on this block");
+
+    if (!q->second.ptr)
+      // Need to initialize now
+      q->second.ptr = std::shared_ptr<void>(
+        block,
+        (uint8_t*)block.get() + q->second.offset
+      );
+
+    // Safety is assured by AnySharedPointer unit tests.  We use a native reinterpret_cast and not
+    // std::static_pointer_cast because we are using a form of type erasure on std::shared_ptr<void>
+    return reinterpret_cast<std::shared_ptr<T>&>(q->second.ptr);
   }
 };
 

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -121,6 +121,8 @@ set(Autowiring_SRCS
   has_static_new.h
   has_validate.h
   hash_tuple.h
+  HeteroBlock.h
+  HeteroBlock.cpp
   index_tuple.h
   InterlockedExchange.h
   InvokeRelay.h

--- a/src/autowiring/CreationRulesUnix.cpp
+++ b/src/autowiring/CreationRulesUnix.cpp
@@ -5,7 +5,7 @@
 
 void* autowiring::aligned_malloc(size_t ncb, size_t align) {
   void* pRetVal;
-  if(posix_memalign(&pRetVal, ncb, align))
+  if(posix_memalign(&pRetVal, align, ncb))
     return nullptr;
   return pRetVal;
 }

--- a/src/autowiring/HeteroBlock.cpp
+++ b/src/autowiring/HeteroBlock.cpp
@@ -58,7 +58,10 @@ HeteroBlock::HeteroBlock(const HeteroBlockEntry* pFirst, const HeteroBlockEntry*
     // Increment past the header:
     ncb += sizeof(BlockHeader);
   }
-  uint8_t* pBlock = (uint8_t*)autowiring::aligned_malloc(ncb + sizeof(BlockHeader), maxAlign);
+
+  size_t alignedRequest = ncb + sizeof(BlockHeader);
+  alignedRequest += (maxAlign - alignedRequest) % maxAlign;
+  uint8_t* pBlock = (uint8_t*)autowiring::aligned_malloc(alignedRequest, maxAlign);
   if (!pBlock)
     throw std::bad_alloc();
 

--- a/src/autowiring/HeteroBlock.cpp
+++ b/src/autowiring/HeteroBlock.cpp
@@ -3,6 +3,7 @@
 #include "HeteroBlock.h"
 #include "CreationRules.h"
 #include <functional>
+#include <new>
 #include <numeric>
 
 using namespace autowiring;
@@ -58,6 +59,8 @@ HeteroBlock::HeteroBlock(const HeteroBlockEntry* pFirst, const HeteroBlockEntry*
     ncb += sizeof(BlockHeader);
   }
   uint8_t* pBlock = (uint8_t*)autowiring::aligned_malloc(ncb + sizeof(BlockHeader), maxAlign);
+  if (!pBlock)
+    throw std::bad_alloc();
 
   // Initialize the deleter sentinel with null:
   *(BlockHeader*)(pBlock + ncb) = {};

--- a/src/autowiring/HeteroBlock.cpp
+++ b/src/autowiring/HeteroBlock.cpp
@@ -44,6 +44,18 @@ HeteroBlock::HeteroBlock(const HeteroBlockEntry* pFirst, const HeteroBlockEntry*
 
     // Shift over the amount needed due to misalignment.  This works because we always
     // assume that the space at offset [0] is perfectly aligned for all data.
+    // This crazy arithmetic is a simplification of the following expression:
+    //
+    //  size_t slop = ncb % align;
+    //  size_t slack = (align - slop) % align;
+    //  ncb += slack;
+    //
+    // Written in one line, this is jsut:
+    //
+    //  ncb += (align - (ncb % align)) % align;
+    //
+    // However, `modulo x` is an idempotent operation under addition and subtraction,
+    // which means that the above expression simplifies down to just this:
     ncb += (align - ncb) % align;
 
     // Update the offset, advance by the size of the block header

--- a/src/autowiring/HeteroBlock.cpp
+++ b/src/autowiring/HeteroBlock.cpp
@@ -1,20 +1,105 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "HeteroBlock.h"
+#include "CreationRules.h"
 #include <functional>
+#include <numeric>
 
 using namespace autowiring;
 
-HeteroBlock::HeteroBlock(std::initializer_list<HeteroBlockEntry> entries)
+HeteroBlock::HeteroBlock(const HeteroBlockEntry* pFirst, const HeteroBlockEntry* pLast)
 {
-  // Compute the total amount of space that will be needed
-  size_t nTotal = 0;
-  for (const auto& entry : entries)
-    nTotal += entry.ncb;
+  entries.reserve(pLast - pFirst);
 
-  // Allocate just this much space
-  block.reset(new uint8_t[nTotal]);
+  // All entries we will stamp on the block space once everything is figured out
+  std::vector<BlockHeader> headers;
+  headers.resize(pLast - pFirst);
+
+  // Minimum alignment requirement for the entire space
+  size_t maxAlign = sizeof(void*);
+
+  // Need to set up the first and last entries
+  headers.front().pfnDtor = pFirst->pfnDtor;
+
+  // Allocate enough space for everything:
+  size_t ncb = 0;
+  
+  size_t temp;
+  size_t* sizePrior = &temp;
+
+  for (size_t i = 0; i < headers.size(); i++) {
+    // Minimum alignment is the word size for this architecture.  This prevents bytes
+    // from getting sliced up and shared among multiple processors, which can create
+    // performance problems.  This also ensures that the data members of the block
+    // header are correctly aligned.
+    size_t align = pFirst[i].id.block->align;
+    if (align <= sizeof(void*))
+      align = sizeof(void*);
+    else if (maxAlign < align)
+      maxAlign = align;
+
+    // Shift amount is the amount by which ncb changes in the next block
+    *sizePrior = ncb;
+
+    // Shift over the amount needed due to misalignment.  This works because we always
+    // assume that the space at offset [0] is perfectly aligned for all data.
+    ncb += (align - ncb) % align;
+
+    // Update the offset, advance by the size of the block header
+    entries[pFirst[i]].offset = ncb;
+    ncb += pFirst[i].id.block->ncb;
+
+    // Store the block entry
+    *sizePrior = ncb - *sizePrior;
+    sizePrior = &headers[i].nextSize;
+    headers[i].pfnDtor = pFirst[i].pfnDtor;
+
+    // Increment past the header:
+    ncb += sizeof(BlockHeader);
+  }
+  uint8_t* pBlock = (uint8_t*)autowiring::aligned_malloc(ncb + sizeof(BlockHeader), maxAlign);
+
+  // Initialize the deleter sentinel with null:
+  *(BlockHeader*)(pBlock + ncb) = {};
+
+  size_t firstSize = pFirst->id.block->ncb;
+  block.reset(
+    pBlock,
+    [firstSize] (void* ptr) {
+      size_t curSize = firstSize;
+      for (
+        BlockHeader* pCur = (BlockHeader*)((uint8_t*)ptr + firstSize);
+        pCur->pfnDtor;
+        curSize = pCur->nextSize,
+        pCur = (BlockHeader*)((uint8_t*)pCur + pCur->nextSize) + 1
+      )
+        // Run the deleter here
+        pCur->pfnDtor((uint8_t*)pCur - curSize);
+
+      // Now we can free the whole space
+      autowiring::aligned_free(ptr);
+    }
+  );
+
+  // Placement construct all objects and accumulate the offset:
+  size_t curSize = firstSize;
+  BlockHeader* pCurHeader = (BlockHeader*)&pBlock[firstSize];
+  for (size_t i = 0; i < headers.size(); i++) {
+    try {
+      // Allocate this space right away:
+      pFirst[i].pfnCtor((uint8_t*)pCurHeader - curSize);
+    }
+    catch (...) {
+      // Zeroize the deleter, something went wrong, and forward the exception
+      pCurHeader->pfnDtor = nullptr;
+      throw;
+    }
+
+    // Initialize, track, and advance
+    *pCurHeader = headers[i];
+    curSize = pCurHeader->nextSize;
+    pCurHeader = (BlockHeader*)((uint8_t*)pCurHeader + pCurHeader->nextSize) + 1;
+  }
 }
 
-HeteroBlock::~HeteroBlock(void)
-{
-}
+HeteroBlock::~HeteroBlock(void) {}

--- a/src/autowiring/HeteroBlock.cpp
+++ b/src/autowiring/HeteroBlock.cpp
@@ -1,0 +1,20 @@
+#include "stdafx.h"
+#include "HeteroBlock.h"
+#include <functional>
+
+using namespace autowiring;
+
+HeteroBlock::HeteroBlock(std::initializer_list<HeteroBlockEntry> entries)
+{
+  // Compute the total amount of space that will be needed
+  size_t nTotal = 0;
+  for (const auto& entry : entries)
+    nTotal += entry.ncb;
+
+  // Allocate just this much space
+  block.reset(new uint8_t[nTotal]);
+}
+
+HeteroBlock::~HeteroBlock(void)
+{
+}

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -48,6 +48,7 @@ set(AutowiringTest_SRCS
   GlobalInitTest.hpp
   GlobalInitTest.cpp
   GuardObjectTest.cpp
+  HeteroBlockTest.cpp
   InterlockedRoutinesTest.cpp
   MultiInheritTest.cpp
   ObjectPoolTest.cpp

--- a/src/autowiring/test/HeteroBlockTest.cpp
+++ b/src/autowiring/test/HeteroBlockTest.cpp
@@ -1,0 +1,79 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "TestFixtures/Decoration.hpp"
+#include <autowiring/HeteroBlock.h>
+
+using autowiring::HeteroBlock;
+using autowiring::HeteroBlockEntry;
+
+class HeteroBlockTest:
+  public testing::Test
+{};
+
+TEST_F(HeteroBlockTest, ObjectOrganizationTest) {
+  HeteroBlock block{
+    HeteroBlockEntry { auto_id_t<Decoration<0>>(), 0 },
+    HeteroBlockEntry { auto_id_t<Decoration<0>>(), 1 },
+    HeteroBlockEntry { auto_id_t<Decoration<0>>(), 2 }
+  };
+
+  // Obtain one of each of the known entries:
+  auto& obj0 = block.get<Decoration<0>>(0);
+  auto& obj1 = block.get<Decoration<0>>(1);
+  auto& obj2 = block.get<Decoration<0>>(2);
+  ASSERT_LT(&obj0, &obj1);
+  ASSERT_LT(&obj1, &obj2);
+}
+
+TEST_F(HeteroBlockTest, SharedPtrAliasTest) {
+  HeteroBlock block{
+    { auto_id_t<Decoration<0>>(), 0 },
+    { auto_id_t<Decoration<0>>(), 1 },
+    { auto_id_t<Decoration<0>>(), 2 }
+  };
+
+  // Obtain one of each of the known entries:
+  auto& obj0 = block.get<Decoration<0>>(0);
+  auto obj0Shared = block.get_shared<Decoration<0>>(0);
+  auto& obj1 = block.get<Decoration<0>>(1);
+  auto obj1Shared = block.get_shared<Decoration<0>>(1);
+  auto& obj2 = block.get<Decoration<0>>(2);
+  auto obj2Shared = block.get_shared<Decoration<0>>(2);
+  ASSERT_EQ(&obj0, obj0Shared.get());
+  ASSERT_EQ(&obj1, obj1Shared.get());
+  ASSERT_EQ(&obj2, obj2Shared.get());
+}
+
+struct HeteroBlockTest_DestructorValidationTest {
+  HeteroBlockTest_DestructorValidationTest(void) {}
+
+  std::shared_ptr<bool> destroyed;
+};
+
+TEST_F(HeteroBlockTest, DestroyObjTest) {
+  std::shared_ptr<bool> ref;
+  {
+    HeteroBlock block{
+      { auto_id_t<HeteroBlockTest_DestructorValidationTest>(), 0 },
+      { auto_id_t<HeteroBlockTest_DestructorValidationTest>(), 1 },
+      { auto_id_t<HeteroBlockTest_DestructorValidationTest>(), 2 }
+    };
+    auto& obj0 = block.get<HeteroBlockTest_DestructorValidationTest>(0);
+    obj0.destroyed = std::make_shared<bool>(false);
+    ref = obj0.destroyed;
+  }
+  ASSERT_TRUE(ref.unique()) << "Object referred to by a shared pointer was not destroyed as expected";
+}
+
+TEST_F(HeteroBlockTest, DestroySharedPtrTest) {
+  std::shared_ptr<bool> ref;
+  {
+    HeteroBlock block {
+      { auto_id_t<HeteroBlockTest_DestructorValidationTest>(), 0 }
+    };
+    auto& ptr0 = block.get_shared<HeteroBlockTest_DestructorValidationTest>(0);
+    ptr0->destroyed = std::make_shared<bool>(false);
+    ref = ptr0->destroyed;
+  }
+  ASSERT_TRUE(ref.unique()) << "Object referred to by a shared pointer was not destroyed as expected";
+}


### PR DESCRIPTION
Heterogenous blocks are intended to be used by AutoPacket.  They contain a multitude of unrelated types that are packed together in the same arena based allocator.  The intended use case is for situations where a particular decoration is known to never be needed as a `shared_ptr`.  Such cases free us from having to prospectively allocate a shared pointer.

The heterogenous block will also need to be designed to support post-hoc generation of a shared pointer.  This is necessary because there will be a minority of cases where a shared pointer is unexpectedly needed.

- [x] Create unit tests
- [x] Implement post-hoc shared pointer generation