### PR TITLE
Add a benchmark for ContextEnumerator versus ContextMap

### DIFF
--- a/src/autowiring/benchmark/AutoBench.cpp
+++ b/src/autowiring/benchmark/AutoBench.cpp
@@ -2,6 +2,7 @@
 #include "stdafx.h"
 #include "Benchmark.h"
 #include "ContextSearchBm.h"
+#include "ContextTrackingBm.h"
 #include "DispatchQueueBm.h"
 #include "PrintableDuration.h"
 #include "PriorityBoost.h"
@@ -42,7 +43,9 @@ static std::map<std::string, Entry> sc_commands = {
   MakeEntry("search", "Autowiring context search cost", &ContextSearchBm::Search),
   MakeEntry("cache", "Autowiring cache behavior", &ContextSearchBm::Cache),
   MakeEntry("fast", "Autowired versus AutowiredFast", &ContextSearchBm::Fast),
-  MakeEntry("dispatch", "Dispatch queue execution rate", &DispatchQueueBm::Dispatch)
+  MakeEntry("dispatch", "Dispatch queue execution rate", &DispatchQueueBm::Dispatch),
+  MakeEntry("contextenum", "CoreContextEnumerator profiling", &ContextTrackingBm::ContextEnum),
+  MakeEntry("contextmap", "ContextMap profiling", &ContextTrackingBm::ContextMap),
 };
 
 static Benchmark All(void) {

--- a/src/autowiring/benchmark/Benchmark.h
+++ b/src/autowiring/benchmark/Benchmark.h
@@ -9,6 +9,9 @@ struct Stopwatch {
     start = std::chrono::profiling_clock::now();
   }
 
+  /// <summary>
+  /// Stops timing, with [n] operations having been conducted between start and stop
+  /// </summary>
   void Stop(size_t n) {
     auto stop = std::chrono::profiling_clock::now();
     std::chrono::duration<double> delta = stop - start;

--- a/src/autowiring/benchmark/CMakeLists.txt
+++ b/src/autowiring/benchmark/CMakeLists.txt
@@ -4,6 +4,8 @@ set(AutoBench_SRCS
   Benchmark.cpp
   ContextSearchBm.h
   ContextSearchBm.cpp
+  ContextTrackingBm.h
+  ContextTrackingBm.cpp
   DispatchQueueBm.h
   DispatchQueueBm.cpp
   Foo.h

--- a/src/autowiring/benchmark/ContextTrackingBm.cpp
+++ b/src/autowiring/benchmark/ContextTrackingBm.cpp
@@ -1,0 +1,127 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "ContextTrackingBm.h"
+#include "Benchmark.h"
+#include <autowiring/ContextMap.h>
+#include <functional>
+#include <thread>
+
+static const size_t n = 100;
+
+static std::vector<std::shared_ptr<CoreContext>> create(void) {
+  // Create a bunch of subcontexts from here
+  std::vector<std::shared_ptr<CoreContext>> contexts(n);
+  for (size_t i = n; i--;)
+    contexts[i] = AutoCreateContext();
+  return contexts;
+}
+
+template<size_t N>
+static void do_parallel_enum(Stopwatch& sw) {
+  AutoCurrentContext ctxt;
+  auto all = create();
+
+  // Create threads which will cause contention:
+  auto proceed = std::make_shared<bool>(true);
+  for (size_t nParallel = N; nParallel--;) {
+    std::thread([proceed, all, ctxt] {
+      while (*proceed)
+        for (auto cur : ContextEnumerator(ctxt))
+          ;
+    }).detach();
+  }
+  auto cleanup = MakeAtExit([&] { *proceed = false; });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // Perform parallel enumeration
+  sw.Start();
+  for (auto cur : ContextEnumerator(ctxt))
+    ;
+  sw.Stop(n);
+}
+
+Benchmark ContextTrackingBm::ContextEnum(void) {
+  return {
+    {
+      "single",
+      [](Stopwatch& sw) {
+        auto all = create();
+
+        // Now enumerate
+        sw.Start();
+        AutoCurrentContext ctxt;
+        for (auto cur : ContextEnumerator(ctxt))
+          ;
+        sw.Stop(n);
+      }
+    },
+    {
+      "parallel",
+      do_parallel_enum<1>
+    },
+    {
+      "parallel x10",
+      do_parallel_enum<1>
+    }
+  };
+}
+
+template<size_t N>
+static void do_parallel_map(Stopwatch& sw) {
+  // Create a bunch of subcontexts from here and put them in a map
+  auto all = create();
+  ::ContextMap<size_t> mp;
+  for (size_t i = N; i < all.size(); i++)
+    mp.Add(i, all[i]);
+
+  // Now the threads that will make progress hard:
+  auto proceed = std::make_shared<bool>(true);
+  for (size_t i = N; i--;)
+    std::thread([proceed, mp] {
+      while (*proceed)
+        for (const auto& cur : mp)
+          ;
+    }).detach();
+  auto cleanup = MakeAtExit([&] { *proceed = false; });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // Enumerate the map while iteration is underway
+  sw.Start();
+  for (auto& cur : mp)
+    ;
+  sw.Stop(n);
+}
+
+Benchmark ContextTrackingBm::ContextMap(void) {
+  static const size_t n = 100;
+
+  return {
+    {
+      "single",
+      [](Stopwatch& sw) {
+        // Create a bunch of subcontexts from here and put them in a map
+        auto all = create();
+        ::ContextMap<size_t> mp;
+        for (size_t i = 0; i < all.size(); i++)
+          mp.Add(i, all[i]);
+
+        // Just enumerate the map, not much to it
+        sw.Start();
+        for (auto& cur : mp)
+          ;
+        sw.Stop(n);
+      }
+    },
+    {
+      "parallel",
+      do_parallel_map<1>
+    },
+    {
+      "parallel x10",
+      do_parallel_map<10>
+    }
+  };
+
+}

--- a/src/autowiring/benchmark/ContextTrackingBm.h
+++ b/src/autowiring/benchmark/ContextTrackingBm.h
@@ -1,0 +1,10 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+
+struct Benchmark;
+
+class ContextTrackingBm {
+public:
+  static Benchmark ContextEnum(void);
+  static Benchmark ContextMap(void);
+};


### PR DESCRIPTION
There have recently been some concerns that `ContextEnumerator` may be very slow in parallel environments.  Determine whether this is true, and then benchmark `ContextMap` in the same setting to ensure that it is suitable as a higher performance alternative.