### PR TITLE
Add a cross-platform alignment concept

### DIFF
--- a/autowiring/C++11/cpp11.h
+++ b/autowiring/C++11/cpp11.h
@@ -38,6 +38,24 @@
 #endif
 
 /*********************
+ * alignas support added in all versions of GCC, but not until MSVC 2015
+ *********************/
+#if defined(_MSC_VER) && _MSC_VER <= 1800
+  #define AUTO_ALIGNAS(n) __declspec(align(n))
+#else
+  #define AUTO_ALIGNAS alignas
+#endif
+
+/*********************
+ * alignof has similar support, but has a strange name in older versions
+ *********************/
+#if defined(_MSC_VER) && _MSC_VER <= 1800
+  #define AUTO_ALIGNOF __alignof
+#else
+  #define AUTO_ALIGNAS alignof
+#endif
+
+/*********************
  * Location of the unordered_set header
  *********************/
 #if defined(__APPLE__) && !defined(_LIBCPP_VERSION)

--- a/autowiring/CreationRules.h
+++ b/autowiring/CreationRules.h
@@ -33,6 +33,16 @@ struct select_strategy {
     construction_strategy::standard;
 };
 
+/// <summary>
+/// Performs a platform-independent aligned allocation
+/// </summary>
+void* aligned_malloc(size_t ncb, size_t align);
+
+/// <summary>
+/// Corrolary of aligned_malloc
+/// </summary>
+void aligned_free(void* ptr);
+
 template<construction_strategy>
 struct strategy_impl {};
 

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -194,6 +194,7 @@ add_conditional_sources(
 add_windows_sources(Autowiring_SRCS
   auto_future_win.h
   CoreThreadWin.cpp
+  CreationRulesWin.cpp
   SystemThreadPoolWin.cpp
   SystemThreadPoolWin.hpp
   SystemThreadPoolWinXP.cpp
@@ -210,6 +211,7 @@ add_mac_sources(Autowiring_SRCS
 )
 
 add_unix_sources(Autowiring_SRCS
+  CreationRulesUnix.cpp
   InterlockedExchangeUnix.cpp
   thread_specific_ptr_unix.h
 )

--- a/src/autowiring/CreationRulesUnix.cpp
+++ b/src/autowiring/CreationRulesUnix.cpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "CreationRules.h"
+#include <cstdlib>
+
+void* autowiring::aligned_malloc(size_t ncb, size_t align) {
+  void* pRetVal;
+  if(posix_memalign(&pRetVal, ncb, align))
+    return nullptr;
+  return pRetVal;
+}
+
+void autowiring::aligned_free(void* ptr) {
+  free(ptr);
+}

--- a/src/autowiring/CreationRulesWin.cpp
+++ b/src/autowiring/CreationRulesWin.cpp
@@ -1,0 +1,11 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "CreationRules.h"
+
+void* autowiring::aligned_malloc(size_t ncb, size_t align) {
+  return _aligned_malloc(ncb, align);
+}
+
+void autowiring::aligned_free(void* ptr) {
+  return _aligned_free(ptr);
+}

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -34,6 +34,7 @@ set(AutowiringTest_SRCS
   ContextMapTest.cpp
   ContextMemberTest.cpp
   CoreThreadTest.cpp
+  CreationRulesTest.cpp
   CurrentContextPusherTest.cpp
   DecoratorTest.cpp
   DemangleTest.cpp

--- a/src/autowiring/test/CreationRulesTest.cpp
+++ b/src/autowiring/test/CreationRulesTest.cpp
@@ -1,0 +1,29 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "TestFixtures/Decoration.hpp"
+#include <autowiring/CreationRules.h>
+
+class CreationRulesTest:
+  public testing::Test
+{};
+
+struct AlignedFreer {
+  void operator()(void* pMem) const {
+    autowiring::aligned_free(pMem);
+  }
+};
+
+TEST_F(CreationRulesTest, AlignedAllocation) {
+  // Use a vector because we don't want the underlying allocator to give us the same memory block
+  // over and over--we are, after all, freeing memory and then immediately asking for another block
+  // with identical size requirements.
+  std::vector<std::unique_ptr<void, AlignedFreer>> memory;
+  memory.resize(100);
+
+  // Allocate one byte of 256-byte aligned memory 100 times.  If the aligned allocator isn't working
+  // properly, then the odds are good that at least one of these allocations will be wrong.
+  for (auto& ptr : memory) {
+    ptr.reset(autowiring::aligned_malloc(1, 256));
+    ASSERT_EQ(0UL, (size_t)ptr.get() % 256) << "Aligned allocator did not return a correctly aligned pointer";
+  }
+}


### PR DESCRIPTION
[`alignof`](http://en.cppreference.com/w/cpp/language/alignof) has been present in MSVC since VS 2003, and [`alignas`](http://en.cppreference.com/w/cpp/language/alignas) has been present as `__declspec(align(n))` since the same date.  Because memory magic is going to be increasingly important for performance reasons in `AutoPacket`, provide alignment declaration in a cross-platform way with `AUTO_ALIGN` for use by downstream clients.