### PR TITLE
Need a const cast for this nullptr

### DIFF
--- a/autowiring/AutowirableSlot.h
+++ b/autowiring/AutowirableSlot.h
@@ -129,7 +129,7 @@ public:
   typedef T value_type;
 
   AutowirableSlot(const std::shared_ptr<CoreContext>& ctxt) :
-    DeferrableAutowiring(AnySharedPointerT<T>(), ctxt)
+    DeferrableAutowiring(AnySharedPointerT<typename std::remove_const<T>::type>(), ctxt)
   {
     SlotInformationStackLocation::RegisterSlot(this);
   }


### PR DESCRIPTION
`DeferrableAutowiring` may be deferring a `const` field, but `const` type erasure is required to prevent underlying system complexity from overloading.  Allow the `Autowired` front-end for this type to handle const correctness for us rather than pushing this to the subystem.