### PR TITLE
Add a benchmark test for the object pool

### DIFF
--- a/src/autowiring/benchmark/AutoBench.cpp
+++ b/src/autowiring/benchmark/AutoBench.cpp
@@ -4,6 +4,7 @@
 #include "ContextSearchBm.h"
 #include "ContextTrackingBm.h"
 #include "DispatchQueueBm.h"
+#include "ObjectPoolBm.h"
 #include "PrintableDuration.h"
 #include "PriorityBoost.h"
 #include <map>
@@ -46,6 +47,7 @@ static std::map<std::string, Entry> sc_commands = {
   MakeEntry("dispatch", "Dispatch queue execution rate", &DispatchQueueBm::Dispatch),
   MakeEntry("contextenum", "CoreContextEnumerator profiling", &ContextTrackingBm::ContextEnum),
   MakeEntry("contextmap", "ContextMap profiling", &ContextTrackingBm::ContextMap),
+  MakeEntry("objpool", "Object pool behaviors", &ObjectPoolBm::Allocation),
 };
 
 static Benchmark All(void) {

--- a/src/autowiring/benchmark/CMakeLists.txt
+++ b/src/autowiring/benchmark/CMakeLists.txt
@@ -9,6 +9,8 @@ set(AutoBench_SRCS
   DispatchQueueBm.h
   DispatchQueueBm.cpp
   Foo.h
+  ObjectPoolBm.h
+  ObjectPoolBm.cpp
   PriorityBoost.h
   PriorityBoost.cpp
   PrintableDuration.h

--- a/src/autowiring/benchmark/ObjectPoolBm.cpp
+++ b/src/autowiring/benchmark/ObjectPoolBm.cpp
@@ -60,6 +60,6 @@ Benchmark ObjectPoolBm::Allocation(void) {
     { "basic", &profile_basic<tenPack> },
     { "complex", &profile_basic<filling_vector> },
     { "pool_basic", &profile_pool<tenPack> },
-    { "pool_complex", &profile_pool<tenPack> }
+    { "pool_complex", &profile_pool<filling_vector> }
   };
 }

--- a/src/autowiring/benchmark/ObjectPoolBm.cpp
+++ b/src/autowiring/benchmark/ObjectPoolBm.cpp
@@ -1,0 +1,65 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "ObjectPoolBm.h"
+#include "Benchmark.h"
+#include <autowiring/ObjectPool.h>
+#include <functional>
+#include <vector>
+
+static const size_t n = 100;
+
+// Dummy struct of ten integers--needed because unique_ptr<int[10]> doesn't compile
+struct tenPack { int dummy[10]; };
+
+// Type that will perform a secondary allocation on construction
+struct filling_vector {
+  filling_vector(void) {
+    other.resize(100);
+  }
+
+  std::vector<int> other;
+};
+
+template<typename T>
+void profile_basic(Stopwatch& sw) {
+  std::vector<std::unique_ptr<T>> mem;
+
+  // Initial set of allocations:
+  for (size_t i = n; i--;)
+    mem.emplace_back(new T);
+  mem.clear();
+
+  // Now simulate something where an object pool might have been handy
+  for (size_t k = n; k--;) {
+    sw.Start();
+    for (size_t i = n; i--;)
+      mem.emplace_back(new T);
+    sw.Stop(n * n);
+    mem.clear();
+  }
+}
+
+template<typename T>
+void profile_pool(Stopwatch& sw) {
+  ObjectPool<T> pool;
+  pool.Preallocate(n);
+
+  // Now simulate something where an object pool might have been handy
+  std::vector<std::shared_ptr<T>> mem;
+  for (size_t k = n; k--;) {
+    sw.Start();
+    for (size_t i = n; i--;)
+      mem.emplace_back(pool());
+    sw.Stop(n * n);
+    mem.clear();
+  }
+}
+
+Benchmark ObjectPoolBm::Allocation(void) {
+  return {
+    { "basic", &profile_basic<tenPack> },
+    { "complex", &profile_basic<filling_vector> },
+    { "pool_basic", &profile_pool<tenPack> },
+    { "pool_complex", &profile_pool<tenPack> }
+  };
+}

--- a/src/autowiring/benchmark/ObjectPoolBm.h
+++ b/src/autowiring/benchmark/ObjectPoolBm.h
@@ -1,0 +1,9 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+
+struct Benchmark;
+
+class ObjectPoolBm {
+public:
+  static Benchmark Allocation(void);
+};


### PR DESCRIPTION
`ObjectPool` will need to be a performant type.  Add a benchmark so we can track its improvement.  Current object pool times show `ObjectPool` as about 4x slower than `malloc` for flat datatypes, and 2x slower than `malloc` for types that allocate additional memory.  This is clearly an unacceptable situation.

Addresses #674