### PR TITLE
Improve object pool performance

### DIFF
--- a/src/autowiring/ObjectPoolMonitor.cpp
+++ b/src/autowiring/ObjectPoolMonitor.cpp
@@ -2,9 +2,7 @@
 #include "stdafx.h"
 #include "ObjectPoolMonitor.h"
 
-ObjectPoolMonitor::ObjectPoolMonitor(void* pOwner) :
-  m_pOwner(pOwner)
-{}
+ObjectPoolMonitor::ObjectPoolMonitor(void) {}
 
 void ObjectPoolMonitor::Abandon(void) {
   (std::lock_guard<std::mutex>)*this,


### PR DESCRIPTION
Reduce the number of things that have to be copied to perform an allocation to just two--the pool version and the monitor reference.