### PR TITLE
Fix compatibility, implement ObjPool placement constructor

### DIFF
--- a/autowiring/ObjectPool.h
+++ b/autowiring/ObjectPool.h
@@ -21,7 +21,7 @@ void DefaultFinalize(T&){}
 
 namespace autowiring {
   struct placement_t {};
-  static const placement_t placement;
+  static const placement_t placement{};
 }
 
 /// <summary>
@@ -437,6 +437,7 @@ public:
     m_outstanding = rhs.m_outstanding;
     std::swap(m_objs, rhs.m_objs);
     std::swap(m_alloc, rhs.m_alloc);
+    std::swap(m_placement, rhs.m_placement);
 
     // Now we can take ownership of this monitor object:
     m_monitor->owner = this;

--- a/autowiring/ObjectPool.h
+++ b/autowiring/ObjectPool.h
@@ -66,8 +66,15 @@ public:
     const std::function<void(T&)>& final = &DefaultFinalize<T>
   ), "Superceded by the placement construction version");
 
-  /// <param name="limit">The maximum number of objects this pool will allow to be outstanding at any time.</param>
-  /// <param name="maxPooled">The maximum number of objects cached by the pool.</param>
+  /// <param name="placement">
+  /// A placement constructor to be used on the memory allocated for objects
+  /// </param>
+  /// <param name="maxPooled">
+  /// The initializer that will be run on all objects issued by the pool before returning them to callers
+  /// </param>
+  /// <param name="final">
+  /// The finalizer that will be run on objects as they return to the pool
+  /// </param>
   ObjectPool(
     const autowiring::placement_t&,
     const std::function<void(T*)>& placement,

--- a/src/autowiring/test/ObjectPoolTest.cpp
+++ b/src/autowiring/test/ObjectPoolTest.cpp
@@ -388,3 +388,19 @@ TEST_F(ObjectPoolTest, VerifyInitializerFinalizer) {
   ASSERT_FALSE(*initFlag) << "Returned item incorrectly caused a new initialization";
   ASSERT_TRUE(*termFlag) << "Returned item was not correctly finalized";
 }
+
+TEST_F(ObjectPoolTest, PlacementConstructor) {
+  ObjectPool<int> pool(
+    autowiring::placement,
+    [](int* pVal) {
+      *pVal = 109;
+    },
+    [](int& val) {
+      ASSERT_EQ(val, 109) << "Value was not placement constructed properly";
+      val = 110;
+    }
+  );
+
+  auto obj = pool();
+  ASSERT_EQ(110, *obj) << "Value was not correctly initialized";
+}


### PR DESCRIPTION
We would like to deprecate the allocating constructor variant of `ObjectPool`, but we cannot do this all at once.  Encourage users to use a placement constructor rather than an allocating constructor.