### PR TITLE
Break AutowirableSlot inheritance from AnySharedPointer

### DIFF
--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -112,12 +112,7 @@ public:
     AutowirableSlot<T>(ctxt)
   {
     if(ctxt)
-      ctxt->Autowire(
-      *static_cast<AnySharedPointerT<T>*>(
-        static_cast<AnySharedPointer*>(this)
-      ),
-      *this
-    );
+      ctxt->Autowire(static_cast<AnySharedPointerT<T>&>(this->m_ptr), *this);
   }
 
   ~Autowired(void) {
@@ -150,12 +145,7 @@ private:
 
 public:
   operator const std::shared_ptr<T>&(void) const {
-    return
-      static_cast<const AnySharedPointerT<T>*>(
-        static_cast<const AnySharedPointer*>(
-          this
-        )
-      )->get();
+    return static_cast<const AnySharedPointerT<T>&>(this->m_ptr).get();
   }
   
   operator std::weak_ptr<T>(void) const {
@@ -231,7 +221,7 @@ public:
       if(pFirstChild == this) {
         // Trivially satisfy, and then return.  This might look like a leak, but it's not, because we know
         // that Finalize is going to destroy the object.
-        newHead->SatisfyAutowiring(*this);
+        newHead->SatisfyAutowiring(this->m_ptr);
         newHead->Finalize();
         return;
       }

--- a/src/autowiring/AutowirableSlot.cpp
+++ b/src/autowiring/AutowirableSlot.cpp
@@ -9,7 +9,7 @@
 using namespace std;
 
 DeferrableAutowiring::DeferrableAutowiring(AnySharedPointer&& witness, const std::shared_ptr<CoreContext>& context) :
-  AnySharedPointer(std::move(witness)),
+  m_ptr(std::move(witness)),
   m_context(context),
   m_pFlink(nullptr)
 {}


### PR DESCRIPTION
This inheritance is causing operator overload resolution to be a lot more complex, simplify it by breaking an inappropriate inheritance relation.