### PR TITLE
Don't use stacks

### DIFF
--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -15,7 +15,6 @@
 #include "thread_specific_ptr.h"
 #include "ThreadPool.h"
 #include <sstream>
-#include <stack>
 #include <stdexcept>
 
 using namespace autowiring;
@@ -819,14 +818,14 @@ void CoreContext::SatisfyAutowiring(std::unique_lock<std::mutex>& lk, MemoEntry&
   // Now we need to take on the responsibility of satisfying this deferral.  We will do this by
   // nullifying the flink, and by ensuring that the memo is satisfied at the point where we
   // release the lock.
-  std::stack<DeferrableAutowiring*> stk;
-  stk.push(entry.pFirst);
+  std::vector<DeferrableAutowiring*> stk;
+  stk.push_back(entry.pFirst);
   entry.pFirst = nullptr;
 
   // Depth-first search
   while (!stk.empty()) {
-    auto top = stk.top();
-    stk.pop();
+    auto top = stk.back();
+    stk.pop_back();
 
     for (DeferrableAutowiring* pCur = top; pCur; pCur = pCur->GetFlink()) {
       pCur->SatisfyAutowiring(entry.m_value);
@@ -834,7 +833,7 @@ void CoreContext::SatisfyAutowiring(std::unique_lock<std::mutex>& lk, MemoEntry&
       // See if there's another chain we need to process:
       auto child = pCur->ReleaseDependentChain();
       if (child)
-        stk.push(child);
+        stk.push_back(child);
 
       // Not everyone needs to be finalized.  The entities that don't require finalization
       // are identified by an empty strategy, and we just skip them.
@@ -892,7 +891,7 @@ void CoreContext::UpdateDeferredElements(std::unique_lock<std::mutex>&& lk, cons
     // also removed at the same time.
     //
     // Each connected nonroot deferrable autowiring is referred to as a "dependant chain".
-    std::stack<DeferrableAutowiring*> stk;
+    std::vector<DeferrableAutowiring*> stk;
     for (auto& cur : m_typeMemos) {
       MemoEntry& value = cur.second;
 
@@ -915,13 +914,13 @@ void CoreContext::UpdateDeferredElements(std::unique_lock<std::mutex>&& lk, cons
       // Now we need to take on the responsibility of satisfying this deferral.  We will do this by
       // nullifying the flink, and by ensuring that the memo is satisfied at the point where we
       // release the lock.
-      stk.push(value.pFirst);
+      stk.push_back(value.pFirst);
       value.pFirst = nullptr;
 
       // Finish satisfying the remainder of the chain while we hold the lock:
       while (!stk.empty()) {
-        auto top = stk.top();
-        stk.pop();
+        auto top = stk.back();
+        stk.pop_back();
 
         for (DeferrableAutowiring* pNext = top; pNext; pNext = pNext->GetFlink()) {
           pNext->SatisfyAutowiring(value.m_value);
@@ -929,7 +928,7 @@ void CoreContext::UpdateDeferredElements(std::unique_lock<std::mutex>&& lk, cons
           // See if there's another chain we need to process:
           auto child = pNext->ReleaseDependentChain();
           if (child)
-            stk.push(child);
+            stk.push_back(child);
 
           // Not everyone needs to be finalized.  The entities that don't require finalization
           // are identified by an empty strategy, and we just skip them.


### PR DESCRIPTION
Stacks are slow, and `std::vector` is faster and has all of the same features.  The semantic simplicity of a stack is attractive, but unnecessary where we're using it.