### PR TITLE
Eliminate Autowired::GetContext

### DIFF
--- a/autowiring/AutowirableSlot.h
+++ b/autowiring/AutowirableSlot.h
@@ -85,11 +85,6 @@ public:
   }
 
   /// <returns>
-  /// The context corresponding to this slot, if it hasn't already expired
-  /// </returns>
-  std::shared_ptr<CoreContext> GetContext(void) const { return m_context.lock(); }
-
-  /// <returns>
   /// The type on which this deferred slot is bound
   /// </returns>
   auto_id GetType(void) const {

--- a/src/autowiring/test/ScopeTest.cpp
+++ b/src/autowiring/test/ScopeTest.cpp
@@ -181,7 +181,6 @@ TEST_F(ScopeTest, RequireVsWire) {
 
   Autowired<A> a_wired_inner;
   ASSERT_FALSE(a_wired_inner.IsAutowired()) << "Autowired member became autowired too quickly";
-  ASSERT_EQ(a_wired_inner.GetContext(), ctxt_inner) << "Autowired member created in the wrong context";
 
   AutoRequired<A> a_required_outer(ctxt_outer);
   ASSERT_TRUE(a_required_outer.IsAutowired()) << "AutoRequired member unsatisfied after construction";


### PR DESCRIPTION
Eliminate this low-level internal routine, as its use implies an antipattern.  Users instead should track their contexts themselves, and only use `Autowired` to access the type that's actually been wired in.  This change will allow us greater flexibility in deciding how to use `m_context` and when to reset it .