### PR TITLE
Devirtualize SatisfyAutowiring

### DIFF
--- a/autowiring/AutowirableSlot.h
+++ b/autowiring/AutowirableSlot.h
@@ -116,7 +116,7 @@ public:
   /// <summary>
   /// Satisfies autowiring with a so-called "witness slot" which is guaranteed to be satisfied on the same type
   /// </summary>
-  virtual void SatisfyAutowiring(const AnySharedPointer& ptr) {
+  void SatisfyAutowiring(const AnySharedPointer& ptr) {
     (AnySharedPointer&)*this = ptr;
   }
 };


### PR DESCRIPTION
This method used to be virtual back when `AnySharedPointer` was a much less useful type.  `DeferrableAutowiring::SatisfyAutowiring` is no longer overridden by anyone, we can devirtualize it.