### PR TITLE
Support an "all" operation to autowiring::parallel

### DIFF
--- a/src/autowiring/test/ParallelTest.cpp
+++ b/src/autowiring/test/ParallelTest.cpp
@@ -26,8 +26,11 @@ TEST_F(ParallelTest, Basic) {
   }
 
   std::vector<int> result;
-  for (auto it = p.begin<int>(); it != p.end<int>(); ++it) {
+  auto it = p.begin<int>();
+  result.push_back(*it++);
+  while (it != p.end<int>()) {
     result.push_back(*it);
+    ++it;
   }
 
   ASSERT_EQ(result.size(), 6) << "Didn't receive all value";
@@ -36,4 +39,19 @@ TEST_F(ParallelTest, Basic) {
   for (int i = 0; i < static_cast<int>(result.size()); ++i) {
     ASSERT_EQ(i, result[i]) << "Didn't receive correct values";
   }
+}
+
+TEST_F(ParallelTest, All) {
+  AutoCurrentContext()->Initiate();
+  autowiring::parallel p;
+
+  for (size_t i = 0; i < 10; i++)
+    p += [i] { return i; };
+
+  std::vector<size_t> entries;
+  for(size_t cur : p.all<size_t>())
+    entries.push_back(cur);
+  std::sort(entries.begin(), entries.end());
+  for (size_t i = 1; i < entries.size(); i++)
+    ASSERT_EQ(entries[i - 1], entries[i] - 1) << "Entry did not complete as expected";
 }


### PR DESCRIPTION
This allows for a much more compact parallel enumeration form that doesn't require the use of explicit iterators.  New syntax looks like this:

```C++
autowiring::parallel ll;
ll += [] {return 1;}
ll += [] {return 2;}

for(int val : ll.all<int>()) {
  std::cout << "Value: " << val << std::endl;
}
```

Also clean up some syntactic issues in parallel, support a prefix `operator++`, and ensure that our incrementation operators are actually [InputIterator](http://en.cppreference.com/w/cpp/concept/InputIterator) compatible.