### PR TITLE
Performance improvement to SetCurrent

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -1000,7 +1000,7 @@ public:
   /// context is assigned before invoking a CoreRunnable instance's Run method, and it's also assigned
   /// when a context is first constructed by a thread.
   /// </remarks>
-  static std::shared_ptr<CoreContext> CurrentContextOrNull(void);
+  static const std::shared_ptr<CoreContext>& CurrentContextOrNull(void);
 
   /// <summary>
   /// Identical to CurrentContextNoCheck, except returns the global context instead of a null pointer

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -1269,7 +1269,14 @@ std::ostream& operator<<(std::ostream& os, const CoreContext& rhs) {
 }
 
 std::shared_ptr<CoreContext> CoreContext::SetCurrent(const std::shared_ptr<CoreContext>& ctxt) {
-  std::shared_ptr<CoreContext> retVal = CoreContext::CurrentContextOrNull();
+  auto currentContext = autoCurrentContext.get();
+
+  // Short-circuit test, no need to proceed if we aren't changing the context:
+  if (*currentContext == ctxt)
+    return *currentContext;
+
+  // Value is changing, update:
+  auto retVal = *currentContext;
   if (ctxt)
     autoCurrentContext.reset(new std::shared_ptr<CoreContext>(ctxt));
   else

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -1270,14 +1270,14 @@ std::ostream& operator<<(std::ostream& os, const CoreContext& rhs) {
 }
 
 std::shared_ptr<CoreContext> CoreContext::SetCurrent(const std::shared_ptr<CoreContext>& ctxt) {
-  auto currentContext = autoCurrentContext.get();
+  const auto& currentContext = CurrentContextOrNull();
 
   // Short-circuit test, no need to proceed if we aren't changing the context:
-  if (*currentContext == ctxt)
-    return *currentContext;
+  if (currentContext == ctxt)
+    return currentContext;
 
   // Value is changing, update:
-  auto retVal = *currentContext;
+  auto retVal = currentContext;
   if (ctxt)
     autoCurrentContext.reset(new std::shared_ptr<CoreContext>(ctxt));
   else

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -617,9 +617,10 @@ bool CoreContext::DelayUntilInitiated(void) {
   return !IsShutdown();
 }
 
-std::shared_ptr<CoreContext> CoreContext::CurrentContextOrNull(void) {
+const std::shared_ptr<CoreContext>& CoreContext::CurrentContextOrNull(void) {
+  static const std::shared_ptr<CoreContext> empty;
   auto retVal = autoCurrentContext.get();
-  return retVal ? *retVal : nullptr;
+  return retVal ? *retVal : empty;
 }
 
 std::shared_ptr<CoreContext> CoreContext::CurrentContext(void) {


### PR DESCRIPTION
Very simple improvement that does not change the current context if no change is necessary.

Also improve performance of `CurrentContextOrNull`