### PR TITLE
Fix unit test valgrind hangs

### DIFF
--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -201,9 +201,11 @@ TEST_F(CoreContextTest, NoEnumerateBeforeBoltReturn) {
   });
 
   // Verify that the context does not appear until the bolt has finished running:
-  while(!*finished)
+  while(!*finished) {
     for(auto cur : ContextEnumeratorT<NoEnumerateBeforeBoltReturn>(ctxt))
       ASSERT_TRUE(longTime->m_bDoneRunning) << "A context was enumerated before a bolt finished running";
+    AutoRequired<CoreThread>()->WaitForEvent(std::chrono::milliseconds(100));
+  }
 
   // Need to block until this thread is done
   t.join();

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -204,7 +204,7 @@ TEST_F(CoreContextTest, NoEnumerateBeforeBoltReturn) {
   while(!*finished) {
     for(auto cur : ContextEnumeratorT<NoEnumerateBeforeBoltReturn>(ctxt))
       ASSERT_TRUE(longTime->m_bDoneRunning) << "A context was enumerated before a bolt finished running";
-    AutoRequired<CoreThread>()->WaitForEvent(std::chrono::milliseconds(100));
+    AutoRequired<CoreThread>()->WaitForEvent(std::chrono::milliseconds(1));
   }
 
   // Need to block until this thread is done

--- a/src/autowiring/test/EventReceiverTest.cpp
+++ b/src/autowiring/test/EventReceiverTest.cpp
@@ -299,7 +299,9 @@ TEST_F(EventReceiverTest, PathologicalTransmitterTest) {
   }
 
   // Spin until the jammer has transmitted a thousand messages:
-  while(jammer->totalXmit < 1000);
+  while(jammer->totalXmit < 1000) {
+    jammer->WaitForEvent(std::chrono::milliseconds(1));
+  }
   jammer->Stop();
   jammer->Wait();
 

--- a/src/autowiring/test/EventReceiverTest.cpp
+++ b/src/autowiring/test/EventReceiverTest.cpp
@@ -279,7 +279,9 @@ TEST_F(EventReceiverTest, PathologicalChildContextTest) {
   }
 
   // Spin until the jammer has transmitted a thousand messages:
-  while(jammer->totalXmit < 1000);
+  while(jammer->totalXmit < 1000) {
+    jammer->WaitForEvent(std::chrono::milliseconds(1));
+  }
   jammer->Stop();
   jammer->Wait();
 

--- a/src/autowiring/test/TestFixtures/FiresManyEventsWhenRun.hpp
+++ b/src/autowiring/test/TestFixtures/FiresManyEventsWhenRun.hpp
@@ -17,9 +17,10 @@ public:
   AutoFired<CallableInterface> m_ci;
 
   void Run(void) override {
-    while(!ShouldStop() && totalXmit < 0x7FFFF000)
-      // Jam for awhile in an asynchronous way:
-    while(++totalXmit % 100)
-      m_ci(&CallableInterface::ZeroArgs)();
+    while(!ShouldStop() && totalXmit < 0x7FFFF000) {
+        // Jam for awhile in an asynchronous way:
+      while(++totalXmit % 100)
+        m_ci(&CallableInterface::ZeroArgs)();
+    }
   }
 };

--- a/src/autowiring/test/TestFixtures/FiresManyEventsWhenRun.hpp
+++ b/src/autowiring/test/TestFixtures/FiresManyEventsWhenRun.hpp
@@ -21,6 +21,7 @@ public:
         // Jam for awhile in an asynchronous way:
       while(++totalXmit % 100)
         m_ci(&CallableInterface::ZeroArgs)();
+      WaitForEvent(std::chrono::milliseconds(1));
     }
   }
 };

--- a/src/autowiring/test/TestFixtures/FiresManyEventsWhenRun.hpp
+++ b/src/autowiring/test/TestFixtures/FiresManyEventsWhenRun.hpp
@@ -21,7 +21,8 @@ public:
         // Jam for awhile in an asynchronous way:
       while(++totalXmit % 100)
         m_ci(&CallableInterface::ZeroArgs)();
-      WaitForEvent(std::chrono::milliseconds(1));
+      if (totalXmit % 2000 == 0)
+        WaitForEvent(std::chrono::milliseconds(1));
     }
   }
 };


### PR DESCRIPTION
Three unit tests were consistently hanging under valgrind, making it impractical to do sanity-checks with <tt>valgrind ./AutowiringTest</tt>. Until now I had to run select tests or use <tt>--gtest_filter</tt> with a negative pattern.

How this fixes it: There seems to be no guarantee that a spin-loop thread will ever yield. Adding these WaitForEvent() calls ensure that bolt/transmitter/receiver actually gets a chance to run.