### PR TITLE
Disable deprecation warnings internally

### DIFF
--- a/autowiring/C++11/cpp11.h
+++ b/autowiring/C++11/cpp11.h
@@ -26,6 +26,13 @@
 // If Boost.Thread is used, we want it to provide the new name for its <future> class
 #define BOOST_THREAD_PROVIDES_FUTURE
 
+#ifdef AUTOWIRING_IS_BEING_BUILT
+  // We know that we're using deprecated stuff in our unit tests, but the tests still
+  // need to do what they do.  Undefine all of the deprecated macros so we don't get
+  // spammed with warnings telling us what we already know.
+  #define AUTOWIRING_NO_DEPRECATE
+#endif
+
 #ifndef __has_feature
   #define __has_feature(x) (AUTOWIRE_##x)
 #endif
@@ -339,7 +346,7 @@
 /*********************
  * Deprecation convenience macro
  *********************/
-#ifndef _DEBUG
+#if !defined(_DEBUG) && !defined(AUTOWIRING_NO_DEPRECATE)
   #ifdef _MSC_VER
     #define DEPRECATED(signature, msg) __declspec(deprecated(msg)) signature
     #define DEPRECATED_CLASS(classname, msg) __declspec(deprecated(msg)) classname

--- a/autowiring/ObjectPool.h
+++ b/autowiring/ObjectPool.h
@@ -43,7 +43,9 @@ class ObjectPool
 {
 public:
   ObjectPool(void) :
-    ObjectPool(~0, ~0)
+    m_monitor(std::make_shared<ObjectPoolMonitorT<T>>(this, &DefaultInitialize<T>, &DefaultFinalize<T>)),
+    m_maxPooled(~0),
+    m_limit(~0)
   {}
 
   ObjectPool(ObjectPool&& rhs)
@@ -82,7 +84,6 @@ public:
     const std::function<void(T&)>& final = &DefaultFinalize<T>
   ) :
     m_monitor(std::make_shared<ObjectPoolMonitorT<T>>(this, initial, final)),
-    m_alloc(&DefaultCreate<T>),
     m_placement(placement)
   {}
 
@@ -154,7 +155,7 @@ protected:
   size_t m_outstanding = 0;
 
   // Allocator, placement ctor:
-  std::function<T*()> m_alloc;
+  std::function<T*()> m_alloc { &DefaultCreate<T> };
   std::function<void(T*)> m_placement{ [](T*) {} };
 
   /// <summary>


### PR DESCRIPTION
Do not warn of deprecated uses of types and methods when those uses are by the Autowiring project itself.  Generally speaking, we are aware of such uses, and they will be removed when the corresponding deprecated methods and classes are themselves removed.