### PR TITLE
Fix Android build break

### DIFF
--- a/src/autowiring/CreationRulesUnix.cpp
+++ b/src/autowiring/CreationRulesUnix.cpp
@@ -4,10 +4,14 @@
 #include <cstdlib>
 
 void* autowiring::aligned_malloc(size_t ncb, size_t align) {
+#if _POSIX_C_SOURCE < 200112L && _XOPEN_SOURCE < 600 && !defined(__APPLE__)
+  return memalign(align, ncb);
+#else
   void* pRetVal;
-  if(posix_memalign(&pRetVal, align, ncb))
+  if (posix_memalign(&pRetVal, align, ncb))
     return nullptr;
   return pRetVal;
+#endif
 }
 
 void autowiring::aligned_free(void* ptr) {


### PR DESCRIPTION
Android doesn't have  `posix_memalign`, detect this case with preprocessor macros and compile accordingly.