### PR TITLE
Unlink the Autowired field on reset

### DIFF
--- a/autowiring/AutowirableSlot.h
+++ b/autowiring/AutowirableSlot.h
@@ -98,10 +98,17 @@ public:
     return m_ptr.type();
   }
   
-  // Reset this pointer. Similar to shared_ptr::reset().
-  void reset() {
-    m_ptr.reset();
-  }
+  /// <summary>
+  /// Performs a full reset of this slot
+  /// </summary>
+  /// <remarks>
+  /// This operation prevents the slot from being satisfied, if it hasn't already been satisfied, and causes
+  /// the pointed-to object to be set to null.  Any attached dependant chains are also destroyed.
+  ///
+  /// This method may not be safely called from an unsynchronized context.  Callers must ensure that
+  /// this field is not in use during the call to reset or a data race will result.
+  /// </remarks>
+  void reset();
 
   /// <returns>
   /// The strategy that should be used to satisfy this slot

--- a/src/autowiring/AutowirableSlot.cpp
+++ b/src/autowiring/AutowirableSlot.cpp
@@ -19,6 +19,11 @@ DeferrableAutowiring::~DeferrableAutowiring(void) {
   assert(m_context.expired());
 }
 
+void DeferrableAutowiring::reset(void) {
+  m_ptr.reset();
+  CancelAutowiring();
+}
+
 void DeferrableAutowiring::CancelAutowiring(void) {
   auto context = m_context.lock();
   if(!context)

--- a/src/autowiring/AutowirableSlot.cpp
+++ b/src/autowiring/AutowirableSlot.cpp
@@ -22,6 +22,7 @@ DeferrableAutowiring::~DeferrableAutowiring(void) {
 void DeferrableAutowiring::reset(void) {
   m_ptr.reset();
   CancelAutowiring();
+  m_context.reset();
 }
 
 void DeferrableAutowiring::CancelAutowiring(void) {

--- a/src/autowiring/test/ScopeTest.cpp
+++ b/src/autowiring/test/ScopeTest.cpp
@@ -275,3 +275,10 @@ TEST_F(ScopeTest, RecursiveInject) {
   ASSERT_EQ(a_inner, a_inner_2);
   ASSERT_EQ(a_inner->GetContext(), a_inner_2->GetContext());
 }
+
+TEST_F(ScopeTest, NoPostHocAfterReset) {
+  Autowired<SimpleObject> sobj;
+  sobj.reset();
+  AutoRequired<SimpleObject>();
+  ASSERT_FALSE(sobj.IsAutowired()) << "An autowired slot was incorrectly satisfied after having been reset";
+}


### PR DESCRIPTION
This prevents an autowired slot that's been reset with a call to `reset` from being satisfied at some later time.  Reset should be a non-reversible operation typically called only on context teardown.