### PR TITLE
Handle uninitialized block cases

### DIFF
--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -38,6 +38,9 @@ bool autowiring::dbg::IsLambda(const std::type_info& ti) {
 #endif
 
 static std::string DemangleWithAutoID(auto_id id) {
+  if (!id.block->ti)
+    return "<unknown>";
+
   auto retVal = demangle(id.block->ti);
 
   // prefix is at the beginning of the string, skip over it


### PR DESCRIPTION
Sometimes an ID will be demangled that was never instantiated in the system.  Handle these cases by presenting an appropriate "unknown" indicator.