### PR TITLE
Relax constraints on incomplete AutoFilter types

### DIFF
--- a/autowiring/auto_arg.h
+++ b/autowiring/auto_arg.h
@@ -38,7 +38,7 @@ public:
 
   template<class C>
   static const T& arg(C& packet) {
-    (void) auto_id_t_init<T, false>::init;
+    (void) auto_id_t_init<T, true>::init;
     return packet.template Get<T>();
   }
 };
@@ -55,9 +55,24 @@ class auto_arg<const T>:
 /// Specialization for "const T&" ~ auto_in<T>
 /// </summary>
 template<class T>
-class auto_arg<const T&> :
-  public auto_arg<T>
-{};
+class auto_arg<const T&>
+{
+public:
+  typedef const T& type;
+  typedef type arg_type;
+  typedef auto_id_t<T> id_type;
+  static const bool is_input = true;
+  static const bool is_output = false;
+  static const bool is_shared = false;
+  static const bool is_multi = false;
+  static const int tshift = 0;
+
+  template<class C>
+  static const T& arg(C& packet) {
+    (void)auto_id_t_init<T, false>::init;
+    return packet.template Get<T>();
+  }
+};
 
 /// <summary>
 /// Specialization for "std::shared_ptr<const T>" ~ auto_in<T>

--- a/autowiring/auto_id.h
+++ b/autowiring/auto_id.h
@@ -5,6 +5,8 @@
 #include TYPE_INDEX_HEADER
 
 namespace autowiring {
+  template<typename> struct s {};
+
   /// <summary>
   /// Returns an index for use with the auto_id system
   /// </summary>
@@ -27,8 +29,9 @@ namespace autowiring {
   struct auto_id_block {
     auto_id_block(void) = default;
 
-    auto_id_block(int index):
+    auto_id_block(int index, const std::type_info& ti_synth):
       index(index),
+      ti_synth(&ti_synth),
       pToObj(NullToObj),
       pFromObj(NullFromObj)
     {}
@@ -44,6 +47,7 @@ namespace autowiring {
     ):
       index(index),
       ti(&typeid(T)),
+      ti_synth(&typeid(s<T>)),
       ncb(sizeof(T)),
       align(safe_align_of<T>::value),
       pToObj(
@@ -57,6 +61,9 @@ namespace autowiring {
     // Index and underlying type
     int index;
     const std::type_info* ti;
+
+    // Synthetic ID.  This ID is always valid but it's created as a template substitution.
+    const std::type_info* ti_synth;
 
     // General properties of the underlying type
     size_t ncb;
@@ -184,7 +191,7 @@ class auto_id_t_init<T, false>
 {
   auto_id_t_init(void) {
     auto* ptr = &auto_id_t<T>::s_block;
-    new (ptr) autowiring::auto_id_block(ptr->index ? ptr->index : autowiring::CreateIndex());
+    new (ptr) autowiring::auto_id_block(ptr->index ? ptr->index : autowiring::CreateIndex(), typeid(autowiring::s<T>));
   }
 
 public:

--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -38,16 +38,23 @@ bool autowiring::dbg::IsLambda(const std::type_info& ti) {
 #endif
 
 static std::string DemangleWithAutoID(auto_id id) {
-  auto retVal = demangle(id.block->ti);
+  if (id.block->ti)
+    return demangle(id.block->ti);
+
+  // Full type information unavailable.  Provide incomplete information instead.
+  std::string retVal = demangle(id.block->ti_synth);
 
   // prefix is at the beginning of the string, skip over it
-  static const char prefix [] = "auto_id_t<";
+  static const char prefix[] = "autowiring::s<";
 
   if (retVal.compare(0, sizeof(prefix) - 1, prefix) == 0) {
     size_t off = sizeof(prefix) - 1;
     size_t end = retVal.find_last_not_of(' ', retVal.find_last_of('>') - 1);
     retVal = retVal.substr(off, end - off + 1);
   }
+
+  // Append an "[i]" to signify that this type is incomplete
+  retVal.append(" [i]");
   return retVal;
 }
 

--- a/src/autowiring/test/AutoFilterConstructRulesTest.cpp
+++ b/src/autowiring/test/AutoFilterConstructRulesTest.cpp
@@ -100,9 +100,15 @@ public:
   void AutoFilter(std::shared_ptr<const UnnamedExternalClass>) {}
 };
 
+class ProducesUnnamedExternalClassSharedPtr {
+public:
+  void AutoFilter(std::shared_ptr<UnnamedExternalClass>&) {}
+};
+
 TEST_F(AutoFilterConstructRulesTest, CanAcceptUndefinedSharedPointerInput) {
   AutoRequired<AcceptsUnnamedExternalClass> auec;
   AutoRequired<AcceptsUnnamedExternalClassSharedPtr> auecsp;
+  AutoRequired<ProducesUnnamedExternalClassSharedPtr> puecsp;
 }
 
 class GeneratesCustomAllocatedType {

--- a/src/autowiring/test/AutowiringDebugTest.cpp
+++ b/src/autowiring/test/AutowiringDebugTest.cpp
@@ -124,3 +124,21 @@ TEST_F(AutowiringDebugTest, BasicAutoFilterGraph) {
   std::stringstream ss;
   autowiring::dbg::WriteAutoFilterGraph(ss);
 }
+
+struct IncompleteOutputType;
+
+class SyntheticFilterIDClass {
+public:
+  void AutoFilter(std::shared_ptr<IncompleteOutputType>&) {}
+};
+
+TEST_F(AutowiringDebugTest, FilterWithSyntheticID) {
+  AutoRequired<SyntheticFilterIDClass>();
+
+  std::ostringstream os;
+  autowiring::dbg::WriteAutoFilterGraph(os);
+  std::string str = os.str();
+
+  size_t off = str.find("IncompleteOutputType [i]", 0);
+  ASSERT_NE(std::string::npos, off) << "AutoFilterGraph dump failed to correctly handle an uninstantiated output type";
+}


### PR DESCRIPTION
Certain AutoFilter networks may consist entirely of incomplete types.  In this case, we do not have full type information, and should fall back to a synthetic type instead, and inform the user in the graph printout of the presence of an incomplete class.