### PR TITLE
Restore run-compatibility with libc 2.15 / libstdc++ 3.4.15 systems

### DIFF
--- a/src/autowiring/SystemThreadPoolStl.cpp
+++ b/src/autowiring/SystemThreadPoolStl.cpp
@@ -44,7 +44,8 @@ void SystemThreadPoolStl::OnStartUnsafe(void) {
     // Do nothing if the pool size was already set by someone else
     return;
 
-  // TODO:  Set this number according to std::thread::hardware_concurrency.  This can't
+  // TODO:  Set this number according to std::thread::hardware_concurrency (or
+  // get_nprocs() on gcc, to retain libstdc++ backwards-compatibility).  This can't
   // be done right now due to the fact that DispatchQueue has terrible concurrency
   // performance.
   while (m_outstanding < 2)

--- a/src/autowiring/SystemThreadPoolStl.cpp
+++ b/src/autowiring/SystemThreadPoolStl.cpp
@@ -40,7 +40,6 @@ void SystemThreadPoolStl::AddWorkerThreadUnsafe(void) {
 }
 
 void SystemThreadPoolStl::OnStartUnsafe(void) {
-  auto concurrent = std::thread::hardware_concurrency();
   if (m_outstanding)
     // Do nothing if the pool size was already set by someone else
     return;
@@ -48,7 +47,6 @@ void SystemThreadPoolStl::OnStartUnsafe(void) {
   // TODO:  Set this number according to std::thread::hardware_concurrency.  This can't
   // be done right now due to the fact that DispatchQueue has terrible concurrency
   // performance.
-  (void)concurrent;
   while (m_outstanding < 2)
     AddWorkerThreadUnsafe();
 }


### PR DESCRIPTION
One of our users noticed that the Leap SDK Sample.cpp no longer links on Fedora 16, due to a dependency on std::thread::hardware_concurrency(). This would also affect Ubuntu 12.04 LTS.

This could be replaced with get_nprocs() on Linux, but for now it can be removed.