### PR TITLE
Refactor CallExtractor::Call to accept a const void*

### DIFF
--- a/src/autowiring/AutoPacketInternal.cpp
+++ b/src/autowiring/AutoPacketInternal.cpp
@@ -47,7 +47,7 @@ void AutoPacketInternal::Initialize(bool isFirstPacket) {
   {
     autowiring::AutoCurrentPacketPusher pkt(*this);
     for (SatCounter* call : callCounters)
-      call->GetCall()(call->GetAutoFilter(), *this);
+      call->GetCall()(call->GetAutoFilter().ptr(), *this);
   }
 }
 


### PR DESCRIPTION
`CallExtractor::Call` only uses the underlying pointer in all cases, anyway, there's no reason to need the broader type.