### PR TITLE
Implement ContextMap::clear

### DIFF
--- a/autowiring/ContextMap.h
+++ b/autowiring/ContextMap.h
@@ -50,6 +50,14 @@ public:
   // Accessor methods:
   size_t size(void) const {return m_contexts.size();}
 
+  /// <summary>
+  /// Removes all elements from the map
+  /// </summary>
+  void clear(void) {
+    std::lock_guard<std::mutex> lk(*m_tracker);
+    m_contexts.clear();
+  }
+
   class iterator {
   public:
     iterator(const ContextMap& parent) :

--- a/src/autowiring/test/ContextMapTest.cpp
+++ b/src/autowiring/test/ContextMapTest.cpp
@@ -273,3 +273,18 @@ TEST_F(ContextMapTest, VerifyRangeBasedEnumeration) {
 
   ASSERT_EQ(3UL, ct) << "Context map range-based enumeration did not correctly enumerate all members";
 }
+
+TEST_F(ContextMapTest, Clear) {
+  std::shared_ptr<CoreContext> ctxt1 = AutoCreateContext();
+  std::shared_ptr<CoreContext> ctxt2 = AutoCreateContext();
+  std::shared_ptr<CoreContext> ctxt3 = AutoCreateContext();
+
+  ContextMap<string> mp;
+  mp.Add("a", ctxt1);
+  mp.Add("b", ctxt2);
+  mp.Add("c", ctxt3);
+
+  ASSERT_EQ(3UL, mp.size()) << "Map did not have the correct number of entries after setup";
+  mp.clear();
+  ASSERT_EQ(0UL, mp.size()) << "Map clear operation did not clear the map itself as expected";
+}


### PR DESCRIPTION
This feature removes all elements from the `ContextMap` in a thread-safe way

Fixes #719 