### PR TITLE
Correct bad collapse of shared pointer type

### DIFF
--- a/autowiring/auto_arg.h
+++ b/autowiring/auto_arg.h
@@ -103,6 +103,14 @@ public:
 };
 
 /// <summary>
+/// Specialization for "const std::shared_ptr<const T>&" ~ auto_in<T>
+/// </summary>
+template<class T>
+class auto_arg<const std::shared_ptr<const T>&>:
+  public auto_arg<std::shared_ptr<const T>>
+{};
+
+/// <summary>
 /// Specialization for "T*" ~ auto_in<T*>.  T must be const-qualified in order to be an input parameter.
 /// </summary>
 template<class T>

--- a/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
+++ b/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
@@ -221,13 +221,14 @@ TEST_F(AutoFilterCollapseRulesTest, CoreContextArg) {
 TEST_F(AutoFilterCollapseRulesTest, MultiConstCollapse) {
   AutoRequired<AutoPacketFactory> factory;
 
-  auto shared_ptr_called = std::make_shared<bool>(false);
-  *factory += [shared_ptr_called](const std::shared_ptr<Decoration<0> const>& in) {
-    *shared_ptr_called = true;
+  auto called = std::make_shared<bool>(false);
+  *factory += [called] (const std::shared_ptr<Decoration<0> const>&) {
+    *called = true;
   };
 
   auto packet = factory->NewPacket();
-  packet->Decorate(Decoration<0>{101});
 
-  ASSERT_TRUE(*shared_ptr_called) << "Const shared pointer const reference variant not invoked";
+  ASSERT_FALSE(*called) << "Const shared pointer const reference variant invoked prematurely";
+  packet->Decorate(Decoration<0>{});
+  ASSERT_TRUE(*called) << "Const shared pointer const reference variant not invoked";
 }

--- a/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
+++ b/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
@@ -218,6 +218,22 @@ TEST_F(AutoFilterCollapseRulesTest, CoreContextArg) {
   ASSERT_TRUE(match2) << "Shared pointer input argument did not match expectation";
 }
 
+static_assert(
+  std::is_same<
+    auto_arg<Decoration<0>>::id_type,
+    auto_arg<std::shared_ptr<const Decoration<0>>>::id_type
+  >::value,
+  "ID type of a const shared_ptr did not match the fundamental type"
+);
+
+static_assert(
+  std::is_same<
+    auto_arg<Decoration<0>>::id_type,
+    auto_arg<const std::shared_ptr<Decoration<0> const>&>::id_type
+  >::value,
+  "ID type of a const shared_ptr const reference did not match the fundamental type"
+);
+
 TEST_F(AutoFilterCollapseRulesTest, MultiConstCollapse) {
   AutoRequired<AutoPacketFactory> factory;
 

--- a/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
+++ b/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
@@ -217,3 +217,17 @@ TEST_F(AutoFilterCollapseRulesTest, CoreContextArg) {
   ASSERT_TRUE(match1) << "Reference input argument did not match expected";
   ASSERT_TRUE(match2) << "Shared pointer input argument did not match expectation";
 }
+
+TEST_F(AutoFilterCollapseRulesTest, MultiConstCollapse) {
+  AutoRequired<AutoPacketFactory> factory;
+
+  auto shared_ptr_called = std::make_shared<bool>(false);
+  *factory += [shared_ptr_called](const std::shared_ptr<Decoration<0> const>& in) {
+    *shared_ptr_called = true;
+  };
+
+  auto packet = factory->NewPacket();
+  packet->Decorate(Decoration<0>{101});
+
+  ASSERT_TRUE(*shared_ptr_called) << "Const shared pointer const reference variant not invoked";
+}

--- a/src/autowiring/test/AutoFilterConstructRulesTest.cpp
+++ b/src/autowiring/test/AutoFilterConstructRulesTest.cpp
@@ -175,32 +175,3 @@ TEST_F(AutoFilterConstructRulesTest, NonCopyableDecorationOut) {
   ASSERT_NE(nullptr, val) << "Non-copyable decoration was claimed to be present on the packet but, when inspected, was absent";
   ASSERT_EQ(101, (**val).i) << "Decoration was not properly extracted";
 }
-
-TEST_F(AutoFilterConstructRulesTest, NonCopyableDecorationWithSharedPtr) {
-  AutoRequired<AutoPacketFactory> factory;
-
-  auto called = std::make_shared<bool>(false);
-  auto shared_ptr_called = std::make_shared<bool>(false);
-
-  *factory += [called](DecorationThatCannotBeCopied& out) {
-    out.i = 101;
-  };
-
-  *factory += [shared_ptr_called](const std::shared_ptr<DecorationThatCannotBeCopied const>& in) {
-    *shared_ptr_called = true;
-  };
-
-  *factory += [called](const DecorationThatCannotBeCopied& in) {
-    *called = true;
-  };
-
-  auto packet = factory->NewPacket();
-  ASSERT_TRUE(packet->Has<DecorationThatCannotBeCopied>()) << "Non-copyable decoration was not present on the packet";
-
-  auto val = packet->GetShared<DecorationThatCannotBeCopied>();
-  ASSERT_NE(nullptr, val) << "Non-copyable decoration was claimed to be present on the packet but, when inspected, was absent";
-  ASSERT_EQ(101, (**val).i) << "Decoration was not properly extracted";
-
-  ASSERT_TRUE(*called) << "Filter accepting a non-copyable decoration was not called as expected";
-  ASSERT_TRUE(*shared_ptr_called) << "Filter accepting a shared-pointer of a non-copyable decoration was not called as expected";
-}

--- a/src/autowiring/test/AutoFilterConstructRulesTest.cpp
+++ b/src/autowiring/test/AutoFilterConstructRulesTest.cpp
@@ -175,3 +175,32 @@ TEST_F(AutoFilterConstructRulesTest, NonCopyableDecorationOut) {
   ASSERT_NE(nullptr, val) << "Non-copyable decoration was claimed to be present on the packet but, when inspected, was absent";
   ASSERT_EQ(101, (**val).i) << "Decoration was not properly extracted";
 }
+
+TEST_F(AutoFilterConstructRulesTest, NonCopyableDecorationWithSharedPtr) {
+  AutoRequired<AutoPacketFactory> factory;
+
+  auto called = std::make_shared<bool>(false);
+  auto shared_ptr_called = std::make_shared<bool>(false);
+
+  *factory += [called](DecorationThatCannotBeCopied& out) {
+    out.i = 101;
+  };
+
+  *factory += [shared_ptr_called](const std::shared_ptr<DecorationThatCannotBeCopied const>& in) {
+    *shared_ptr_called = true;
+  };
+
+  *factory += [called](const DecorationThatCannotBeCopied& in) {
+    *called = true;
+  };
+
+  auto packet = factory->NewPacket();
+  ASSERT_TRUE(packet->Has<DecorationThatCannotBeCopied>()) << "Non-copyable decoration was not present on the packet";
+
+  auto val = packet->GetShared<DecorationThatCannotBeCopied>();
+  ASSERT_NE(nullptr, val) << "Non-copyable decoration was claimed to be present on the packet but, when inspected, was absent";
+  ASSERT_EQ(101, (**val).i) << "Decoration was not properly extracted";
+
+  ASSERT_TRUE(*called) << "Filter accepting a non-copyable decoration was not called as expected";
+  ASSERT_TRUE(*shared_ptr_called) << "Filter accepting a shared-pointer of a non-copyable decoration was not called as expected";
+}


### PR DESCRIPTION
This fixes an issue where `const shared_ptr<const T>&` was not being properly collapsed.  The cause is that the `auto_arg<const T&>` specialization incorrectly matches the above case and the specialization does not delegate back to `auto_arg` for further handling.

This break was introduced by 0dede365287d2f5faa3380a8d3ea5eb136e6202f, and the reason the change was made was to allow certain `AutoFilter`s to be declared even if some of their byref input arguments were incomplete.

Fixes #722 