### PR TITLE
Fix null function call

### DIFF
--- a/autowiring/AutoCurrentPacketPusher.h
+++ b/autowiring/AutoCurrentPacketPusher.h
@@ -2,18 +2,24 @@
 #pragma once
 #include "AutoPacket.h"
 
+namespace autowiring {
+
 /// <summary>
 /// RAII for AutoPacket::SetCurrent
 /// </summary>
-namespace autowiring {
-    class AutoCurrentPacketPusher
-    {
-    public:
-        AutoCurrentPacketPusher(AutoPacket& apkt) {
-            AutoPacket::SetCurrent(apkt.shared_from_this());
-        };
-        ~AutoCurrentPacketPusher(void) {
-            AutoPacket::SetCurrent(nullptr);
-        };
-    };
+class AutoCurrentPacketPusher
+{
+public:
+  AutoCurrentPacketPusher(AutoPacket& apkt):
+    prior(AutoPacket::SetCurrent(&apkt))
+  {}
+
+  ~AutoCurrentPacketPusher(void) {
+    AutoPacket::SetCurrent(prior);
+  };
+
+private:
+  AutoPacket* const prior;
+};
+
 }

--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -701,7 +701,18 @@ public:
   /// </remarks>
   static AutoPacket& CurrentPacket(void);
 
-  static void SetCurrent(const std::shared_ptr<AutoPacket>& apkt);
+  /// <summary>
+  /// Sets the current AutoPacket pointer
+  /// </summary>
+  static AutoPacket* SetCurrent(AutoPacket* apkt);
+
+  /// <summary>
+  /// Clears the current AutoPacket pointer
+  /// </summary>
+  /// <remarks>
+  /// Identical to SetCurrent(nullptr)
+  /// </remarks>
+  static AutoPacket* ClearCurrent(void) { return SetCurrent(nullptr); }
 
   /// Get the context of this packet (The context of the AutoPacketFactory that created this context)
   std::shared_ptr<CoreContext> GetContext(void) const;

--- a/autowiring/thread_specific_ptr_win.h
+++ b/autowiring/thread_specific_ptr_win.h
@@ -16,6 +16,7 @@ void thread_specific_ptr<T>::set(T* value) {
 template<typename T>
 void thread_specific_ptr<T>::init() {
   m_key = TlsAlloc();
+  set(nullptr);
 }
 
 template<typename T>

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -18,7 +18,7 @@ using namespace autowiring;
 /// <summary>
 /// A pointer to the current AutoPacket, specific to the current thread.
 /// </summary>
-static thread_specific_ptr<AutoPacket> autoCurrentPacket = nullptr;
+static thread_specific_ptr<AutoPacket> autoCurrentPacket{ nullptr };
 
 AutoPacket::AutoPacket(AutoPacketFactory& factory, std::shared_ptr<void>&& outstanding):
   m_parentFactory(std::static_pointer_cast<AutoPacketFactory>(factory.shared_from_this())),
@@ -498,11 +498,13 @@ std::shared_ptr<AutoPacket> AutoPacket::SuccessorUnsafe(void) {
   return m_successor;
 }
 
-void AutoPacket::SetCurrent(const std::shared_ptr<AutoPacket>& apkt) {
-  if (apkt)
-    autoCurrentPacket.reset(apkt.get());
+AutoPacket* AutoPacket::SetCurrent(AutoPacket* apkt) {
+  AutoPacket* prior = autoCurrentPacket.get();
+  if(apkt)
+    autoCurrentPacket.reset(apkt);
   else
     autoCurrentPacket.release();
+  return prior;
 }
 
 AutoPacket& AutoPacket::CurrentPacket(void) {


### PR DESCRIPTION
Caused by issues with the `AutoCurrentPacket` context pusher feature.  There are lots of weird shared pointers getting carried around and insufficient guards against null pointer dereferences.  Clean this up and fix the defects.  Add tests to prevent regressions, and ensure that `AutoCurrentPacketPusher` restores the prior packet on destruction rather than simply clearing it.