### PR TITLE
Add get-by-type support for autowiring tuple

### DIFF
--- a/autowiring/sum.h
+++ b/autowiring/sum.h
@@ -1,0 +1,20 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+
+namespace autowiring {
+  template<int... Ns>
+  struct sum;
+
+  template<int N, int... Ns>
+  struct sum<N, Ns...> :
+    sum<Ns...>
+  {
+    static const size_t value = N + sum<Ns...>::value;
+  };
+
+  template<>
+  struct sum<>
+  {
+    static const size_t value = 0;
+  };
+}

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -154,6 +154,7 @@ set(Autowiring_SRCS
   SatCounter.cpp
   SlotInformation.cpp
   SlotInformation.h
+  sum.h
   SystemThreadPool.cpp
   SystemThreadPool.h
   SystemThreadPoolStl.cpp

--- a/src/autowiring/test/TupleTest.cpp
+++ b/src/autowiring/test/TupleTest.cpp
@@ -3,9 +3,31 @@
 #include <autowiring/auto_tuple.h>
 #include <string>
 
+static_assert(10 == autowiring::sum<1, 2, 7>::value, "Sum template function did not evaluate a sum correctly");
+
 class TupleTest:
   public testing::Test
 {};
+
+static_assert(
+  autowiring::find<long, int, long, float>::value,
+  "Value known to be present in a tuple was not found as expected"
+);
+
+static_assert(
+  3 == autowiring::find<float, int, long, float>::index,
+  "Known-present value was found at the wrong index"
+);
+
+static_assert(
+  1 == autowiring::find<int, int, long, float>::index,
+  "Known-present value was found at the wrong index"
+);
+
+static_assert(
+  0 == autowiring::find<double, int, long, float>::index,
+  "Known-absent value was incorrectly reported as being present"
+);
 
 TEST_F(TupleTest, CallTest) {
   autowiring::tuple<int, int, std::string> t(101, 102, "Hello world!");
@@ -26,4 +48,15 @@ TEST_F(TupleTest, AddressTest) {
   std::unique_ptr<int>& v = autowiring::get<0>(tup);
 
   ASSERT_EQ(&tup.value, &v) << "Get operation did not provide a correct reference to the underlying tuple value";
+}
+
+TEST_F(TupleTest, GetByTypeTest) {
+  autowiring::tuple<int, long, float> tup{ 1, 2, 1.9f };
+  int& iVal = autowiring::get<int>(tup);
+  long& lVal = autowiring::get<long>(tup);
+  float& fVal = autowiring::get<float>(tup);
+
+  ASSERT_EQ(1, iVal) << "Integer value type mismatch";
+  ASSERT_EQ(2, lVal) << "Long value type mismatch";
+  ASSERT_EQ(1.9f, fVal) << "Float value type mismatch";
 }


### PR DESCRIPTION
Necessary for `AutoPacket::Call` to work as expected