### PR TITLE
Implement AutoPacket::Call

### DIFF
--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -716,7 +716,15 @@ public:
     typedef autowiring::CE<decltype(pfn), t_index> t_call;
     typedef typename t_call::t_ceSetup t_ceSetup;
 
-    t_ceSetup setup(*this);
+    // Completely unnecessary.  Call will avoid making unneeded copies, and this is guaranteed
+    // by a unit test.  Dereference your shared pointers before passing them in.
+    static_assert(
+      !is_any<is_shared_ptr<Outputs>::value...>::value,
+      "Do not use shared pointer arguments as output arguments with Call"
+    );
+
+    auto outputTuple = autowiring::tie(outputs...);
+    t_ceSetup setup(*this, outputTuple);
     t_call::CallWithArgs((void*)pfn, setup);
 
     autowiring::noop(
@@ -732,13 +740,17 @@ public:
     typedef typename make_index_tuple<Decompose<decltype(&Fx::operator())>::N>::type t_index;
     typedef autowiring::CE<decltype(&Fx::operator()), t_index> t_call;
     typedef typename t_call::t_ceSetup t_ceSetup;
-
-    t_ceSetup setup(*this);
-    t_call::template CallWithArgs<&Fx::operator()>(&fx, setup);
-
-    autowiring::noop(
-      (setup.template Extract<Outputs>(outputs), false)...
+    
+    // Completely unnecessary.  Call will avoid making unneeded copies, and this is guaranteed
+    // by a unit test.  Dereference your shared pointers before passing them in.
+    static_assert(
+      !is_any<is_shared_ptr<Outputs>::value...>::value,
+      "Do not use shared pointer arguments as output arguments with Call"
     );
+
+    auto outputTuple = autowiring::tie(outputs...);
+    t_ceSetup setup(*this, outputTuple);
+    t_call::template CallWithArgs<&Fx::operator()>(&fx, setup);
   }
 
   /// <summary>

--- a/autowiring/CallExtractor.h
+++ b/autowiring/CallExtractor.h
@@ -108,6 +108,13 @@ struct CE<RetType (*)(Args...), index_tuple<N...>>:
     );
     autowiring::noop(extractor.template Commit<N>(false)...);
   }
+  
+  static void CallWithArgs(void* pfn, t_ceSetup& pack) {
+    // Extract, call, commit
+    ((t_pfn)pfn)(
+      static_cast<typename auto_arg<Args>::arg_type>(autowiring::get<N>(pack.args))...
+    );
+  }
 };
 
 /// <summary>

--- a/autowiring/auto_tuple.h
+++ b/autowiring/auto_tuple.h
@@ -126,4 +126,9 @@ namespace autowiring {
   tuple<Args&...> tie(Args&... args) {
     return tuple<Args&...>(args...);
   }
+
+  template<class... Args>
+  tuple<Args...> make_tuple(Args&&... args) {
+    return tuple<Args...>(std::forward<Args&&>(args)...);
+  }
 }

--- a/autowiring/auto_tuple.h
+++ b/autowiring/auto_tuple.h
@@ -15,7 +15,10 @@ namespace autowiring {
   /// Finds the specified type T in the argument pack
   /// </remarks>
   template<typename T, typename... Args>
-  struct find;
+  struct find {
+    static const bool value = false;
+    static const size_t index = 0;
+  };
   
   template<typename T, typename Arg, typename... Args>
   struct find<T, Arg, Args...> {
@@ -28,12 +31,6 @@ namespace autowiring {
     // matches are found, holds the sum of all of those values.
     static const size_t index =
       (value ? 1 + find<T, Args...>::index : 0);
-  };
-
-  template<typename T>
-  struct find<T> {
-    static const bool value = false;
-    static const size_t index = 0;
   };
 
   template<int N, class... Args>
@@ -107,6 +104,7 @@ namespace autowiring {
     typedef tuple_value<sizeof...(Args), Arg> t_value;
 
     tuple(void) = default;
+    tuple(const tuple&) = default;
 
     tuple(Arg&& arg, Args&&... args) :
       tuple<Args...>(std::forward<Args>(args)...),

--- a/src/autowiring/test/AutoPacketTest.cpp
+++ b/src/autowiring/test/AutoPacketTest.cpp
@@ -138,3 +138,35 @@ TEST_F(AutoPacketTest, ComplexNetwork) {
   ASSERT_EQ(pPacketB, packet.get()) << "Current packet in second second-level filter call was not equal as expected";
   ASSERT_EQ(pPacketAA, packet.get()) << "Current packet in third-level filter call was not equal as expected";
 }
+
+TEST_F(AutoPacketTest, CallTest) {
+  AutoRequired<AutoPacketFactory> factory;
+  auto packet = factory->NewPacket();
+
+  packet->Decorate(Decoration<0>{101});
+  packet->Decorate(Decoration<1>{102});
+
+  bool called = false;
+  Decoration<0> rd0;
+  Decoration<1> rd1;
+  
+  Decoration<2> rd2;
+  std::shared_ptr<Decoration<2>> shared_rd2;
+
+  packet->Call(
+    [&](const Decoration<0>& d0, Decoration<1> d1, Decoration<2>& d2) {
+      called = true;
+      rd0 = d0;
+      rd1 = d1;
+      d2 = Decoration<2>{ 299 };
+    },
+    rd2,
+    shared_rd2
+  );
+
+  ASSERT_TRUE(called) << "Call-by lambda was not invoked as expected";
+  ASSERT_EQ(101, rd0.i) << "Decoration<0> was not properly copied into a call";
+  ASSERT_EQ(102, rd1.i) << "Decoration<1> was not properly copied into a call";
+  ASSERT_EQ(299, rd2.i) << "Decoration<2> was not extracted from the call filter properly";
+  ASSERT_EQ(299, shared_rd2->i) << "Shared pointer extraction did not recover a correct value";
+}

--- a/src/autowiring/test/AutoPacketTest.cpp
+++ b/src/autowiring/test/AutoPacketTest.cpp
@@ -168,21 +168,30 @@ TEST_F(AutoPacketTest, CallTest) {
   ASSERT_EQ(299, rd2.i) << "Decoration<2> was not extracted from the call filter properly";
 }
 
-static void SimpleCall(const Decoration<0>& d0, Decoration<1>& d1, Decoration<2>& d2) {
-  d1.i = 299;
+static void SimpleCall(std::shared_ptr<const Decoration<4>> d4, const Decoration<0>& d0, Decoration<1>& d1, Decoration<2>& d2, Decoration<3>& unused) {
+  d1.i = d4->i;
   d2.i = d0.i;
+  unused.i = 9999;
 }
+
+static_assert(auto_arg<Decoration<2>&>::is_output, "Output type not correctly detected");
+
+static_assert(
+  autowiring::choice<Decoration<2>&, autowiring::tuple<const Decoration<0>&, Decoration<1>&, Decoration<2>&>>::is_matched,
+  "Failed to match an obvious choice output"
+);
 
 TEST_F(AutoPacketTest, ObjectCallTest) {
   AutoRequired<AutoPacketFactory> factory;
   auto packet = factory->NewPacket();
   packet->Decorate(Decoration<0>{1001});
+  packet->Decorate(Decoration<4>{9001});
 
   Decoration<1> d1;
   Decoration<2> d2;
   packet->Call(SimpleCall, d1, d2);
 
-  ASSERT_EQ(299, d1.i) << "Moore value not assigned correctly";
+  ASSERT_EQ(9001, d1.i) << "Moore value not assigned correctly";
   ASSERT_EQ(1001, d2.i) << "Mealy value not assigned correctly";
 }
 

--- a/src/autowiring/test/AutoPacketTest.cpp
+++ b/src/autowiring/test/AutoPacketTest.cpp
@@ -170,3 +170,21 @@ TEST_F(AutoPacketTest, CallTest) {
   ASSERT_EQ(299, rd2.i) << "Decoration<2> was not extracted from the call filter properly";
   ASSERT_EQ(299, shared_rd2->i) << "Shared pointer extraction did not recover a correct value";
 }
+
+static void SimpleCall(const Decoration<0>& d0, Decoration<1>& d1, Decoration<2>& d2) {
+  d1.i = 299;
+  d2.i = d0.i;
+}
+
+TEST_F(AutoPacketTest, ObjectCallTest) {
+  AutoRequired<AutoPacketFactory> factory;
+  auto packet = factory->NewPacket();
+  packet->Decorate(Decoration<0>{1001});
+
+  Decoration<1> d1;
+  Decoration<2> d2;
+  packet->Call(SimpleCall, d1, d2);
+
+  ASSERT_EQ(299, d1.i) << "Moore value not assigned correctly";
+  ASSERT_EQ(1001, d2.i) << "Mealy value not assigned correctly";
+}


### PR DESCRIPTION
This feature allows a user holding an `AutoPacket` to manually delegate control to another routine using `AutoPacket::Call`.

```C++
void MyClass::AutoFilter(AutoPacket& packet) {
  Decoration<1> myOutputValue;
  packet->Call(
    [&] (const Decoration<0>& in, Decoration<1>& out) {
      assert(&out == &myOutputValue);
      out.i = 100;
    },
    myOutputValue
  );
}
```

Assuming that `p` is decorated with `Decoration<0>`, the above causes the lambda function to be called with the parameters mapped correctly, and the output value is captured and stored in `myOutputValue`.

This process is efficient in that it doesn't create ANY copies of `myOutputValue`.

- [x] Support function object calls
- [x] Support dumb function calls
- [x] Be efficient!  Outputs by value should not be copied