### PR TITLE
Provide a default placement ctor

### DIFF
--- a/autowiring/ObjectPool.h
+++ b/autowiring/ObjectPool.h
@@ -19,6 +19,9 @@ void DefaultInitialize(T&){}
 template<typename T>
 void DefaultFinalize(T&){}
 
+template<typename T>
+void DefaultPlacement(T* ptr) { new(ptr) T; }
+
 namespace autowiring {
   struct placement_t {};
   static const placement_t placement{};
@@ -79,7 +82,7 @@ public:
   /// </param>
   ObjectPool(
     const autowiring::placement_t&,
-    const std::function<void(T*)>& placement,
+    const std::function<void(T*)>& placement = &DefaultPlacement<T>,
     const std::function<void(T&)>& initial = &DefaultInitialize<T>,
     const std::function<void(T&)>& final = &DefaultFinalize<T>
   ) :


### PR DESCRIPTION
We expect users to change to this other `ObjectPool` ctor, provide a default version of the placement constructor so they don't have to guess as to what this member is meant to do.