### PR TITLE
CoreContext must not be abstract

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -147,7 +147,7 @@ class CoreContext:
 {
 protected:
   typedef std::list<std::weak_ptr<CoreContext>> t_childList;
-  CoreContext(const std::shared_ptr<CoreContext>& pParent, t_childList::iterator backReference);
+  CoreContext(const std::shared_ptr<CoreContext>& pParent, t_childList::iterator backReference, const std::type_info& sigilType);
 
 public:
   // Asserted when the context is initiated
@@ -177,6 +177,9 @@ protected:
 
   // Back-referencing iterator which refers to ourselves in our parent's child list:
   const t_childList::iterator m_backReference;
+
+  // Sigil type, used during bolting
+  const std::type_info& m_sigilType;
 
   // State block for this context:
   std::shared_ptr<CoreContextStateBlock> m_stateBlock;
@@ -528,7 +531,7 @@ public:
   /// The number of child contexts of this context.
   size_t GetChildCount(void) const;
   /// The type used as a sigil when creating this class, if any.
-  virtual const std::type_info& GetSigilType(void) const = 0;
+  const std::type_info& GetSigilType(void) const { return m_sigilType; }
   /// The Context iterator for the parent context's children, pointing to this context.
   t_childList::iterator GetBackReference(void) const { return m_backReference; }
   /// A shared reference to the parent context of this context.
@@ -545,7 +548,7 @@ public:
 
   /// True if the sigil type of this CoreContext matches the specified sigil type.
   template<class Sigil>
-  bool Is(void) const { return GetSigilType() == typeid(Sigil); }
+  bool Is(void) const { return m_sigilType == typeid(Sigil); }
 
   /// <summary>
   /// The first child in the set of this context's children.
@@ -1327,17 +1330,10 @@ class CoreContextT:
   public CoreContext
 {
 public:
-  static const std::type_info& sc_type;
-
   CoreContextT(const std::shared_ptr<CoreContext>& pParent, t_childList::iterator backReference) :
-    CoreContext(pParent, backReference)
+    CoreContext(pParent, backReference, typeid(T))
   {}
-
-  const std::type_info& GetSigilType(void) const override { return sc_type; }
 };
-
-template<class T>
-const std::type_info& CoreContextT<T>::sc_type = typeid(T);
 
 std::ostream& operator<<(std::ostream& os, const CoreContext& context);
 

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -52,9 +52,10 @@ public:
 static thread_specific_ptr<std::shared_ptr<CoreContext>> autoCurrentContext;
 
 // Peer Context Constructor. Called interally by CreatePeer
-CoreContext::CoreContext(const std::shared_ptr<CoreContext>& pParent, t_childList::iterator backReference) :
+CoreContext::CoreContext(const std::shared_ptr<CoreContext>& pParent, t_childList::iterator backReference, const std::type_info& sigilType) :
   m_pParent(pParent),
   m_backReference(backReference),
+  m_sigilType(sigilType),
   m_stateBlock(std::make_shared<CoreContextStateBlock>(pParent ? pParent->m_stateBlock : nullptr)),
   m_junctionBoxManager(new JunctionBoxManager),
   m_threadPool(std::make_shared<NullPool>())

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -8,6 +8,12 @@
 #include THREAD_HEADER
 #include FUTURE_HEADER
 
+// A lot of clients invoke arbitrary CoreContext members during teardown of this type.  If any of those members are
+// potentially abstract, the result could be a disastrous pure virtual function call.  Broadly speaking, while there
+// are not guarantees that calls to the base versions of CoreContext virtual functions will perform the desired
+// operation, there should never be a circumstance where such calls trigger a crash.
+static_assert(!std::is_abstract<CoreContext>::value, "CoreContext cannot be abstract");
+
 class CoreContextTest:
   public testing::Test
 {};


### PR DESCRIPTION
There are cases where `CoreContext` methods are invoked on instances of this type while `CoreContext` is in teardown.  Generally this safe from a state standpoint, but we must be sure that none of those methods are pure virtual or invoke any pure virtual methods.

Make `CoreContext` a concrete type, and add a static assertion in the `CoreContext` unit test to ensure that the type does not become abstract again in the future.