### PR TITLE
Allow pass by value support to NotifyWhenAutowired

### DIFF
--- a/autowiring/AutowirableSlot.h
+++ b/autowiring/AutowirableSlot.h
@@ -247,6 +247,8 @@ class AutowirableSlotFn:
   static_assert(!std::is_same<GlobalCoreContext, T>::value, "Do not attempt to autowire GlobalCoreContext.  Instead, use AutoGlobalContext");
 
 public:
+  typedef typename std::decay<Fn>::type FnActual;
+
   AutowirableSlotFn(const std::shared_ptr<CoreContext>& ctxt, Fn&& fn) :
     AutowirableSlot<T>(ctxt),
     fn(std::move(fn))
@@ -258,14 +260,14 @@ public:
   }
 
   // Underlying lambda that we will call:
-  const Fn fn;
+  const FnActual fn;
 
   /// <summary>
   /// Finalization routine, called by our strategy
   /// </summary>
   void Finalize(void) override {
     // Let the lambda execute as it sees fit:
-    CallThroughObj(fn, &Fn::operator());
+    CallThroughObj(fn, &FnActual::operator());
 
     // Call the lambda, remove all accountability to the context, self-destruct, and return:
     this->m_context.reset();
@@ -273,7 +275,7 @@ public:
   }
 
   template<class L, class Ret, class... Args>
-  void CallThroughObj(const Fn& fn, Ret(L::*pfn)(Args...) const) {
+  void CallThroughObj(const FnActual& fn, Ret(L::*pfn)(Args...) const) {
     (fn.*pfn)(
       (Args) *this...
     );

--- a/src/autowiring/test/PostConstructTest.cpp
+++ b/src/autowiring/test/PostConstructTest.cpp
@@ -385,3 +385,20 @@ TEST_F(PostConstructTest, PostConstructCanSafelyThrow) {
   Autowired<PostConstructThrowsException> pcte;
   ASSERT_FALSE(pcte.IsAutowired()) << "A context member which threw an exception post-construction was incorrectly introduced into a context";
 }
+
+TEST_F(PostConstructTest, CallbackCanBeCopied) {
+  auto callCount = std::make_shared<int>(0);
+  auto fn = [callCount] {
+    (*callCount)++;
+  };
+
+  Autowired<SimpleObject> sobj;
+  sobj.NotifyWhenAutowired(fn);
+
+  AutoCurrentContext ctxt;
+  ctxt->NotifyWhenAutowired<SimpleObject>(fn);
+
+  AutoRequired<SimpleObject>();
+
+  ASSERT_EQ(2UL, *callCount) << "Twice-bound autowiring listener was not called twice as expected";
+}


### PR DESCRIPTION
Users shouldn't be compelled to pass lambdas by rvalue reference to `CoreContext::NotifyWhenAutowired`, fix this routine to allow them the freedom to pass by value if they want.