### PR TITLE
Move spin_lock type from Platform to autowiring

### DIFF
--- a/autowiring/spin_lock.h
+++ b/autowiring/spin_lock.h
@@ -1,3 +1,4 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <atomic>
 

--- a/autowiring/spin_lock.h
+++ b/autowiring/spin_lock.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <atomic>
+
+namespace autowiring {
+
+class spin_lock {
+public:
+  spin_lock(void) {
+    m_lock.clear();
+  }
+
+private:
+  mutable std::atomic_flag m_lock;
+
+public:
+  void lock(void) {
+    // acquire lock
+    while (m_lock.test_and_set(std::memory_order_acquire))
+      // spin
+      ;
+  }
+
+  bool try_lock(void) {
+    // One shot attempt and return
+    return !m_lock.test_and_set(std::memory_order_acquire);
+  }
+
+  void unlock(void) {
+    // release lock
+    m_lock.clear(std::memory_order_release);
+  }
+
+  // Can't be copied, moved, or assigned:
+  spin_lock(spin_lock&&) = delete;
+  spin_lock(const spin_lock&) = delete;
+  void operator=(const spin_lock&) = delete;
+  void operator=(spin_lock&&) = delete;
+};
+
+}

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -155,6 +155,7 @@ set(Autowiring_SRCS
   SatCounter.cpp
   SlotInformation.cpp
   SlotInformation.h
+  spin_lock.h
   sum.h
   SystemThreadPool.cpp
   SystemThreadPool.h

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -55,6 +55,7 @@ set(AutowiringTest_SRCS
   ParallelTest.cpp
   PostConstructTest.cpp
   SelfSelectingFixtureTest.cpp
+  SpinLockTest.cpp
   TeardownNotifierTest.cpp
   TypeRegistryTest.cpp
   SatisfiabilityTest.cpp

--- a/src/autowiring/test/SpinLockTest.cpp
+++ b/src/autowiring/test/SpinLockTest.cpp
@@ -1,0 +1,71 @@
+#include "stdafx.h"
+#include "spin_lock.h"
+#include <gtest/gtest.h>
+#include <mutex>
+#include <thread>
+
+TEST(SpinLockTest, RecursiveAcquireFails) {
+  autowiring::spin_lock lock;
+  ASSERT_TRUE(lock.try_lock()) << "Lock acquisition attempt did not succeed immediately where it should have been uncontended";
+  ASSERT_FALSE(lock.try_lock()) << "Lock attempted succeeded after lock should have already been held";
+  lock.unlock();
+}
+
+TEST(SpinLockTest, SimpleExclusion) {
+  auto pLock = std::make_shared<autowiring::spin_lock>();
+  pLock->lock();
+
+  auto lockSucceeded = std::make_shared<bool>(false);
+  std::thread([lockSucceeded, pLock] {
+    *lockSucceeded = pLock->try_lock();
+  }).join();
+  ASSERT_FALSE(*lockSucceeded) << "A lock attempt made from another thread succeeded while the lock should have been held";
+}
+
+TEST(SpinLockTest, PathologicalExclusion) {
+  auto pLock = std::make_shared<autowiring::spin_lock>();
+  auto value = std::make_shared<std::atomic<int>>(0);
+  auto success = std::make_shared<bool>(true);
+
+  // Four threads, one per core, that loop 100x
+  std::vector<std::thread> threads(4);
+  for (auto& thread : threads)
+    thread = std::thread(
+      [=] {
+        for (size_t i = 1000; i--;) {
+          std::lock_guard<autowiring::spin_lock> lk(*pLock);
+          ++(*value);
+          if (*value != 1)
+            *success = false;
+          --(*value);
+        }
+      }
+    );
+
+  for (auto& thread : threads)
+    thread.join();
+
+  // Verify the lock did everything it was supposed to do:
+  ASSERT_TRUE(*success) << "Lock failed to exclude multi-access under pathological cases";
+}
+
+TEST(SpinLockTest, LockGuardBehavior) {
+  autowiring::spin_lock lock;
+  {
+    std::lock_guard<autowiring::spin_lock> lk(lock);
+    ASSERT_FALSE(lock.try_lock()) << "Mutual exclusion is not correctly assured during lock_guard lock";
+  }
+  ASSERT_TRUE(lock.try_lock()) << "Lock could not be reobtained after it should have been released";
+}
+
+TEST(SpinLockTest, UniqueLockBehavior) {
+  autowiring::spin_lock lock;
+
+  std::unique_lock<autowiring::spin_lock> outer;
+  {
+    std::unique_lock<autowiring::spin_lock> lk(lock);
+    ASSERT_FALSE(lock.try_lock()) << "Mutual exclusion is not correctly assured during lock_guard lock";
+    outer = std::move(lk);
+  }
+  ASSERT_FALSE(lock.try_lock()) << "Lock was incorrectly released during inner scope teardown";
+}

--- a/src/autowiring/test/SpinLockTest.cpp
+++ b/src/autowiring/test/SpinLockTest.cpp
@@ -1,3 +1,4 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "spin_lock.h"
 #include <gtest/gtest.h>


### PR DESCRIPTION
Autowiring is increasingly a concurrency library, this type has a better home here and could actually be used by some concepts that presently use the much more heavyweight `std::mutex`.