### PR TITLE
Pull ThreadSleep into CoreRunnable

### DIFF
--- a/autowiring/BasicThread.h
+++ b/autowiring/BasicThread.h
@@ -192,20 +192,6 @@ protected:
   void PerformStatusUpdate(const std::function<void()>& fn) const;
 
   /// <summary>
-  /// Sleeps this thread for the specified duration.
-  /// </summary>
-  /// <returns>False if the thread was terminated before the timeout elapsed.</returns>
-  /// <remarks>
-  /// Events are dispatched by this method while the sleep is taking place, which makes this
-  /// method similar to an alertable wait on Windows.  Callers are cautioned against holding
-  /// locks while calling this method; if this is done, a deadlock could result.
-  ///
-  /// Callers should not invoke this method outside of this thread's thread context, or an
-  /// interruption exception could result.
-  /// </remarks>
-  bool ThreadSleep(std::chrono::nanoseconds timeout) const;
-
-  /// <summary>
   /// Causes a new thread to be created in which the Run method will be invoked
   /// </summary>
   /// <returns>True to indicate that the thread was started successfully, false if it was already started or cancelled</returns>

--- a/autowiring/CoreRunnable.h
+++ b/autowiring/CoreRunnable.h
@@ -114,6 +114,12 @@ public:
   void Stop(bool graceful = true);
 
   /// <summary>
+  /// Sleeps this thread for the specified duration.
+  /// </summary>
+  /// <returns>False if the thread was terminated before the timeout elapsed.</returns>
+  bool ThreadSleep(std::chrono::nanoseconds timeout);
+
+  /// <summary>
   /// Waits indefinitely. Returns when this runnable stops.
   /// </summary>
   void Wait(void);

--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -119,11 +119,6 @@ void BasicThread::PerformStatusUpdate(const std::function<void()>& fn) const {
   m_state->m_stateCondition.notify_all();
 }
 
-bool BasicThread::ThreadSleep(std::chrono::nanoseconds timeout) const {
-  std::unique_lock<std::mutex> lk(m_state->m_lock);
-  return m_state->m_stateCondition.wait_for(lk, timeout, [this] { return ShouldStop(); });
-}
-
 bool BasicThread::OnStart(void) {
   std::shared_ptr<CoreContext> context = m_context.lock();
   if(!context)

--- a/src/autowiring/CoreRunnable.cpp
+++ b/src/autowiring/CoreRunnable.cpp
@@ -53,6 +53,11 @@ void CoreRunnable::Stop(bool graceful) {
   }
 }
 
+bool CoreRunnable::ThreadSleep(std::chrono::nanoseconds timeout) {
+  std::unique_lock<std::mutex> lk(m_lock);
+  return m_cv.wait_for(lk, timeout, [this] { return ShouldStop(); });
+}
+
 void CoreRunnable::Wait(void) {
   {
     std::unique_lock<std::mutex> lk(m_lock);


### PR DESCRIPTION
Update `ThreadSleep` to use the condition variable in `CoreRunnable`, rather than the state block in `BasicThread`.  Also update the documentation on this method to reflect the method's actual behavior.