### PR TITLE
Fix XCode 7.0 Warnings as Errors

### DIFF
--- a/autowiring/AnySharedPointer.h
+++ b/autowiring/AnySharedPointer.h
@@ -48,7 +48,7 @@ public:
   /// <returns>True if the assignment succeeds</returns>
   bool try_assign(const std::shared_ptr<CoreObject>& rhs) {
     if (!m_ti.block->pFromObj)
-      return nullptr;
+      return false;
     auto ptr = m_ti.block->pFromObj(rhs);
     if (!ptr)
       return false;

--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -721,8 +721,6 @@ public:
   template<typename... InArgs, typename... Outputs>
   void Call(void(*pfn)(InArgs...), Outputs&... outputs) {
     typedef typename make_index_tuple<sizeof...(InArgs)>::type t_index;
-    typedef autowiring::CE<decltype(pfn), t_index> t_call;
-    typedef typename t_call::t_ceSetup t_ceSetup;
 
     // Completely unnecessary.  Call will avoid making unneeded copies, and this is guaranteed
     // by a unit test.  Dereference your shared pointers before passing them in.
@@ -749,8 +747,6 @@ public:
   template<typename Fx, typename... InArgs, typename... Outputs>
   void Call(Fx&& fx, void (Fx::*memfn)(InArgs...) const, Outputs&... outputs) {
     typedef typename make_index_tuple<Decompose<decltype(&Fx::operator())>::N>::type t_index;
-    typedef autowiring::CE<decltype(&Fx::operator()), t_index> t_call;
-    typedef typename t_call::t_ceSetup t_ceSetup;
     
     // Completely unnecessary.  Call will avoid making unneeded copies, and this is guaranteed
     // by a unit test.  Dereference your shared pointers before passing them in.


### PR DESCRIPTION
Accidentally upgraded my xcode so I may as well fix these warnings as errors