### PR TITLE
Make CoreRunnable lock mutable

### DIFF
--- a/autowiring/CoreRunnable.h
+++ b/autowiring/CoreRunnable.h
@@ -29,7 +29,7 @@ private:
   std::shared_ptr<CoreObject> m_outstanding;
 
 protected:
-  std::mutex m_lock;
+  mutable std::mutex m_lock;
   std::condition_variable m_cv;
 
   /// <returns>


### PR DESCRIPTION
This lock should be usable in `const` accessor methods without requiring any special casting.  Locks, generally speaking, ought to be mutable because they may sometimes need to synchronize access to data that may be read-only in the current context.