### PR TITLE
Add and implement "once" concept

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -7,9 +7,10 @@
 #include "AutowiringEvents.h"
 #include "autowiring_error.h"
 #include "Bolt.h"
+#include "CallExtractor.h"
 #include "CoreRunnable.h"
 #include "ContextMember.h"
-#include "CallExtractor.h"
+#include "CoreObjectDescriptor.h"
 #include "CreationRules.h"
 #include "CurrentContextPusher.h"
 #include "ExceptionFilter.h"
@@ -19,7 +20,7 @@
 #include "JunctionBoxManager.h"
 #include "member_new_type.h"
 #include "MemoEntry.h"
-#include "CoreObjectDescriptor.h"
+#include "once.h"
 #include "result_or_default.h"
 #include "ThreadPool.h"
 #include "TypeRegistry.h"
@@ -151,13 +152,13 @@ protected:
 
 public:
   // Asserted when the context is initiated
-  autowiring::signal<void()> onInitiated;
+  autowiring::once_signal<CoreContext> onInitiated;
 
   // Asserted when the context is actually running
-  autowiring::signal<void()> onRunning;
+  autowiring::once_signal<CoreContext> onRunning;
 
   // Asserted when the context is being shut down
-  autowiring::signal<void()> onShutdown;
+  autowiring::once_signal<CoreContext> onShutdown;
 
   // Asserted when the context is tearing down but before members objects are destroyed or
   // any contained AutoWired fields are unlinked

--- a/autowiring/once.h
+++ b/autowiring/once.h
@@ -1,0 +1,114 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "auto_signal.h"
+#include "spin_lock.h"
+#include <vector>
+
+namespace autowiring {
+  namespace detail {
+    struct once_fn {
+      virtual ~once_fn(void) {}
+      virtual void operator()() = 0;
+    };
+
+    template<typename Fn>
+    struct once_fn_t :
+      once_fn
+    {
+      once_fn_t(Fn&& fn) :
+        fn(std::forward<Fn&&>(fn))
+      {}
+
+      const Fn fn;
+
+      void operator()() override final { fn(); }
+    };
+  }
+
+  /// <summary>
+  /// Implements an observable boolean variable that can only be set to true once
+  /// </summary>
+  /// <remarks>
+  /// There are many one-way state transitions in Autowiring which may require that
+  /// specific 
+  /// </remarks>
+  struct once
+  {
+  protected:
+    bool flag = false;
+    autowiring::spin_lock m_spin;
+    std::vector<std::unique_ptr<detail::once_fn>> m_fns;
+
+  public:
+    template<typename Fn>
+    void operator+=(Fn&& rhs) {
+      // Initial check of the flag, we don't even want to bother with the rest
+      // of this function if the flag is already set
+      if (flag) {
+        rhs();
+        return;
+      }
+
+      // Move the lambda into our unique pointer outside of the lock to reduce
+      // total contention time
+      std::unique_ptr<detail::once_fn_t<Fn>> fn{
+        new detail::once_fn_t<Fn>{ std::forward<Fn&&>(rhs) }
+      };
+
+      // Double-check the flag under lock:
+      {
+        std::lock_guard<autowiring::spin_lock> lk(m_spin);
+        if (!flag) {
+          m_fns.push_back(std::move(fn));
+          return;
+        }
+      }
+
+      // We got here, the flag was set in the double-check.  We need to call
+      // the lambda function, but unfortunately we've already moved it, so we
+      // need to call the pointer version of the lambda.
+      (*fn)();
+    }
+
+    /// <summary>
+    /// Sets the control flag
+    /// </summary>
+    /// <remarks>
+    /// This method is idempotent
+    /// </remarks>
+    void signal(void);
+
+    /// <summary>
+    /// Sets the control flag
+    /// </summary>
+    /// <remarks>
+    /// It is an error to assign the once field to any value other than zero
+    /// This method is identical to signal
+    /// </remarks>
+    void operator=(bool rhs);
+
+    /// <summary>
+    /// Sets the control flag
+    /// </summary>
+    /// <remarks>
+    /// This method is identical to signal
+    /// </remarks>
+    void operator()() { signal(); }
+  };
+
+  /// <summary>
+  /// Implements the observable portion of a once flag
+  /// </summary>
+  template<typename T>
+  struct once_signal:
+    private once
+  {
+  public:
+    friend T;
+
+    template<typename Fn>
+    void operator+=(Fn&& fn) {
+      return once::operator+=<Fn>(std::forward<Fn&&>(fn));
+    }
+  };
+}

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -148,6 +148,8 @@ set(Autowiring_SRCS
   ObjectPool.h
   ObjectPoolMonitor.cpp
   ObjectPoolMonitor.h
+  once.h
+  once.cpp
   Parallel.h
   Parallel.cpp
   CoreObjectDescriptor.h

--- a/src/autowiring/once.cpp
+++ b/src/autowiring/once.cpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "once.h"
+
+using namespace autowiring;
+
+void once::signal(void) {
+  // Standard lock double-check
+  if (flag)
+    return;
+
+  std::vector<std::unique_ptr<detail::once_fn>> fns;
+  {
+    std::lock_guard<autowiring::spin_lock> lk(m_spin);
+    if (flag)
+      return;
+    flag = true;
+    fns = std::move(m_fns);
+    m_fns.clear();
+  }
+
+  // Invoke all registered handlers outside of the lock:
+  for (auto& cur : fns)
+    (*cur)();
+}
+
+void once::operator=(bool rhs) {
+  if (!rhs)
+    throw std::runtime_error("Cannot set a once flag to any value other than true");
+  signal();
+}

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -52,6 +52,7 @@ set(AutowiringTest_SRCS
   MultiInheritTest.cpp
   ObjectPoolTest.cpp
   ObservableTest.cpp
+  OnceTest.cpp
   ParallelTest.cpp
   PostConstructTest.cpp
   SelfSelectingFixtureTest.cpp

--- a/src/autowiring/test/OnceTest.cpp
+++ b/src/autowiring/test/OnceTest.cpp
@@ -49,7 +49,7 @@ TEST(OnceTest, MultiLambdaPending) {
   autowiring::once o;
   std::atomic<int> x{ 0 };
   std::atomic<int> y{ 0 };
-  bool go = false;
+  bool go = true;
 
   std::thread v([&] {
     while(go) {
@@ -64,6 +64,7 @@ TEST(OnceTest, MultiLambdaPending) {
   std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
   // Finally we verify that everything got hit as we expected:
+  go = false;
   v.join();
   ASSERT_EQ(y, x) << "Not all pended lambdas were executed as expected";
 }

--- a/src/autowiring/test/OnceTest.cpp
+++ b/src/autowiring/test/OnceTest.cpp
@@ -1,0 +1,87 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "TestFixtures/SimpleObject.hpp"
+#include "TestFixtures/SimpleThreaded.hpp"
+#include <autowiring/Autowired.h>
+#include <autowiring/CoreContext.h>
+#include <autowiring/once.h>
+#include THREAD_HEADER
+
+TEST(OnceTest, NoRepeatedCall) {
+  autowiring::once o;
+
+  int val = 0;
+  o += [&] { val++; };
+
+  o = true;
+  ASSERT_EQ(1, val) << "Lambda not executed when flag was set";
+  o = true;
+  ASSERT_EQ(1, val) << "Lambda was executed too many times, once flag did not properly implement idempotence";
+}
+
+TEST(OnceTest, CallAfterSet) {
+  autowiring::once o;
+
+  int val1 = 0;
+  o += [&] { val1++; };
+
+  o = true;
+  ASSERT_EQ(1, val1) << "Lambda not executed when a flag was set";
+
+  int val2 = 0;
+  o += [&] { val2++; };
+  ASSERT_EQ(1, val2) << "Lambda not executed on assignment as expected";
+}
+
+TEST(OnceTest, NoLeaks) {
+  autowiring::once o;
+  auto v = std::make_shared<bool>(false);
+  o += [v] {};
+  ASSERT_EQ(2UL, v.use_count()) << "Shared pointer not properly captured by once flag";
+
+  o = true;
+  ASSERT_TRUE(v.unique()) << "Shared pointer leaked by once flag after execution";
+  o += [v] {};
+  ASSERT_TRUE(v.unique()) << "Shared pointer leaked by once flag after post-set attachment";
+}
+
+TEST(OnceTest, MultiLambdaPending) {
+  autowiring::once o;
+  std::atomic<int> x{ 0 };
+  std::atomic<int> y{ 0 };
+  bool go = false;
+
+  std::thread v([&] {
+    while(go) {
+      o += [&] { x++; };
+      y++;
+    }
+  });
+
+  // Let the other thread zip around for awhile in both modes:
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  o = true;
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+  // Finally we verify that everything got hit as we expected:
+  v.join();
+  ASSERT_EQ(y, x) << "Not all pended lambdas were executed as expected";
+}
+
+class PrivateSignal {
+public:
+  autowiring::once_signal<PrivateSignal> sig;
+
+  void signal(void) {
+    sig.signal();
+  }
+};
+
+TEST(OnceTest, OwnedSignal) {
+  PrivateSignal priv;
+
+  bool hit = false;
+  priv.sig += [&hit] { hit = true; };
+  priv.signal();
+  ASSERT_TRUE(hit) << "Private signal did not get set as expected";
+}


### PR DESCRIPTION
There are lots of one-way transitions in the code that need to trigger other behavior, a "once" flag is a well overdue support concept to implement such transitions.