### PR TITLE
Add dereference operator to observable

### DIFF
--- a/autowiring/observable.h
+++ b/autowiring/observable.h
@@ -37,6 +37,7 @@ private:
 
 public:
   operator const T&(void) const { return val; }
+  const T& operator*(void) const { return val; }
 
   observable& operator=(const T& rhs) {
     onBeforeChanged(val, rhs);

--- a/src/autowiring/test/ObservableTest.cpp
+++ b/src/autowiring/test/ObservableTest.cpp
@@ -13,6 +13,7 @@ TEST_F(ObservableTest, SimpleAssignmentCheck) {
   ob.onChanged += [&hit] { hit = true; };
   ob = 2;
   ASSERT_TRUE(hit) << "OnChanged handler not hit when the observable value was modified";
+  ASSERT_EQ(2, *ob) << "operator * gives an incorrect value";
 }
 
 TEST_F(ObservableTest, BeforeAndAfter) {


### PR DESCRIPTION
Simple low-risk extension that should make this type more useful.