### PR TITLE
Add not-equals operator to auto_id

### DIFF
--- a/autowiring/auto_id.h
+++ b/autowiring/auto_id.h
@@ -96,6 +96,10 @@ struct auto_id {
     return block == rhs.block;
   }
 
+  bool operator!=(auto_id rhs) const {
+    return block != rhs.block;
+  }
+
   explicit operator bool(void) const {
     return block && block->index;
   }


### PR DESCRIPTION
Needed for parallelism with `auto_id::operator==`