### PR TITLE
CoreContext should not define a copy ctor

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -148,6 +148,7 @@ class CoreContext:
 {
 protected:
   typedef std::list<std::weak_ptr<CoreContext>> t_childList;
+  CoreContext(const CoreContext&) = delete;
   CoreContext(const std::shared_ptr<CoreContext>& pParent, t_childList::iterator backReference, const std::type_info& sigilType);
 
 public:


### PR DESCRIPTION
It would be an error for a CoreContext to be copied, and this should not be used anywhere by anyone.  Explicitly disallow it.