### PR TITLE
Enhance autowiring::signal and provide strong sequentiality guarantees

### DIFF
--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -156,9 +156,9 @@ public:
       Autowired<T>* l_field = field; //lambda capture of references doesn't work right.
       autowiring::signal<void(Args...)> U::* l_member = member;
 
-      field->NotifyWhenAutowired([l_field, l_member, rhs](){
-        auto reg = static_cast<U*>(l_field->get())->*l_member += rhs;
-        l_field->m_events.push_back(reg);
+      field->NotifyWhenAutowired([l_field, l_member, rhs] {
+        auto& sig = static_cast<U*>(l_field->get())->*l_member;
+        l_field->m_events.push_back(sig += rhs);
       });
     }
   };
@@ -173,8 +173,8 @@ public:
   void reset(void) override {
     // And remove any events that were added to the object by this autowired field
     auto localEvents = std::move(m_events);
-    for (auto& registration : localEvents)
-      registration.reset();
+    for (auto& localEvent : localEvents)
+      *localEvent.owner -= localEvent;
 
     // Linked list unwind deletion:
     for (

--- a/autowiring/auto_signal.h
+++ b/autowiring/auto_signal.h
@@ -1,16 +1,18 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include "auto_tuple.h"
+#include "autowiring_error.h"
 #include "Decompose.h"
 #include "index_tuple.h"
 #include "noop.h"
 #include "spin_lock.h"
-#include "auto_tuple.h"
 #include <atomic>
 #include <functional>
 #include <list>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
+#include TYPE_TRAITS_HEADER
 
 /// <summary>
 /// Implements an asynchronous signal concept as an AutoFired alternative
@@ -141,7 +143,8 @@ namespace autowiring {
     signal_base
   {
   public:
-    signal(void) = default;
+    signal(void) {}
+    signal(const signal&) = delete;
 
     signal(signal&& rhs) :
       m_pFirstListener(rhs.m_pFirstListener),
@@ -324,7 +327,7 @@ namespace autowiring {
       }
 
       void operator()() override {
-        call(make_index_tuple<sizeof...(FnArgs)>::type{});
+        call(typename make_index_tuple<sizeof...(FnArgs)>::type{});
       }
     };
 

--- a/autowiring/auto_tuple.h
+++ b/autowiring/auto_tuple.h
@@ -3,6 +3,7 @@
 #include "is_any.h"
 #include "index_tuple.h"
 #include "sum.h"
+#include <memory>
 
 namespace autowiring {
   /// <summary>

--- a/autowiring/noop.h
+++ b/autowiring/noop.h
@@ -4,4 +4,9 @@
 namespace autowiring {
   template<class... Args>
   void noop(Args...) {}
+
+  template<class... Args>
+  struct noop_t {
+    void operator()(Args...) const {}
+  };
 }

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -19,7 +19,7 @@
 
 using namespace autowiring;
 
-static_assert(!std::has_copy_constructor<CoreContext>::value, "Copy constructor incorrectly inferred on CoreContext");
+static_assert(!std::is_copy_constructible<CoreContext>::value, "Copy constructor incorrectly inferred on CoreContext");
 
 class DelayedContextHold:
   public CoreRunnable

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -19,6 +19,8 @@
 
 using namespace autowiring;
 
+static_assert(!std::has_copy_constructor<CoreContext>::value, "Copy constructor incorrectly inferred on CoreContext");
+
 class DelayedContextHold:
   public CoreRunnable
 {

--- a/src/autowiring/auto_signal.cpp
+++ b/src/autowiring/auto_signal.cpp
@@ -4,8 +4,4 @@
 #include "SlotInformation.h"
 
 using namespace autowiring;
-using namespace autowiring::detail;
 
-void signal_base::operator-=(const registration_t& reg) {
-  *this -= reg.entry;
-}

--- a/src/autowiring/test/AutoSignalTest.cpp
+++ b/src/autowiring/test/AutoSignalTest.cpp
@@ -322,7 +322,7 @@ TEST_F(AutoSignalTest, SelfModifyingCall) {
   int magic_number = 123;
   
   registration_t registration1 =
-    signal1 += [&](registration_t& reg, int magic) {
+    signal1 += [&](registration_t reg, int magic) {
       ASSERT_EQ(magic, magic_number);
       ASSERT_EQ(registration1, reg);
       ++handler_called1;
@@ -334,7 +334,7 @@ TEST_F(AutoSignalTest, SelfModifyingCall) {
   };
 
   registration_t registration2 =
-    signal1 += [&](registration_t& reg, int magic) {
+    signal1 += [&](registration_t reg, int magic) {
       ASSERT_EQ(magic, magic_number);
       ASSERT_EQ(registration2, reg);
       ++handler_called2;


### PR DESCRIPTION
We need a major refactor to the internals of `autowiring::signal` to allow it to behave more predictably when clients use handlers that either invoke other signals or register/unregister other signal handlers.  The newly refactored `autowiring::signal` should have the following improvements and design choices:

* Make use of a lock-free dispatch queue concept to allow us to relax the constraint that all locks are released before handing controls to clients.
* Introduce an image guarantee which ensures that all signal handlers registered at the time of a call are actually invoked, even if some of them are unregistered.
* Improve efficiency by only taking copies of input arguments when it is absolutely necessary for concurrency reasons
* If a user passes an argument as an rvalue reference or by value, move that argument into the dispatch queue rather than taking a copy--but only do so if it is necessary