### PR TITLE
Add *_i32 and *i64 for fixed sized chrono types

### DIFF
--- a/autowiring/chrono_types.h
+++ b/autowiring/chrono_types.h
@@ -3,6 +3,7 @@
 #include <autowiring/C++11/cpp11.h>
 #include CHRONO_HEADER
 #include <autowiring/basic_timer.h>
+#include <cstdint>
 
 //Common chrono types
 typedef std::chrono::duration<double> seconds_d;
@@ -14,6 +15,16 @@ typedef std::chrono::duration<float> seconds_f;
 typedef std::chrono::duration<float, std::milli> milliseconds_f;
 typedef std::chrono::duration<float, std::micro> microseconds_f;
 typedef std::chrono::duration<float, std::nano> nanoseconds_f;
+
+typedef std::chrono::duration<int32_t> seconds_i32;
+typedef std::chrono::duration<int32_t, std::milli> milliseconds_i32;
+typedef std::chrono::duration<int32_t, std::micro> microseconds_i32;
+typedef std::chrono::duration<int32_t, std::nano> nanoseconds_i32;
+
+typedef std::chrono::duration<int64_t> seconds_i64;
+typedef std::chrono::duration<int64_t, std::milli> milliseconds_i64;
+typedef std::chrono::duration<int64_t, std::micro> microseconds_i64;
+typedef std::chrono::duration<int64_t, std::nano> nanoseconds_i64;
 
 typedef basic_timer<std::chrono::profiling_clock> profiling_timer;
 typedef basic_timer<std::chrono::profiling_clock, seconds_d> profiling_timer_seconds;


### PR DESCRIPTION
Useful if you only want an int, since the default is a long long.