### PR TITLE
Fix broken Unlink function

### DIFF
--- a/autowiring/auto_signal.h
+++ b/autowiring/auto_signal.h
@@ -317,6 +317,12 @@ namespace autowiring {
         if (m_pLastListener)
           m_pLastListener->pFlink = nullptr;
       }
+
+      // Neighbor unlink:
+      if (entry.pFlink)
+        entry.pFlink->pBlink = entry.pBlink;
+      if (entry.pBlink)
+        entry.pBlink->pFlink = entry.pFlink;
     }
 
     struct callable_unlink :

--- a/src/autowiring/test/AutoSignalTest.cpp
+++ b/src/autowiring/test/AutoSignalTest.cpp
@@ -438,6 +438,24 @@ TEST_F(AutoSignalTest, OneRemovesAll) {
   ASSERT_EQ(2, nRun) << "Should have executed all signals even if all signals were unlinked under a callback";
 }
 
+TEST_F(AutoSignalTest, SingleUnregisterFromMany) {
+  autowiring::signal<void()> sig;
+
+  size_t ct = 0;
+  auto l = [&] { ct++; };
+
+  sig += l;
+  sig += l;
+  auto r = sig += l;
+  sig += l;
+  sig += l;
+  sig += l;
+  sig -= r;
+
+  sig();
+  ASSERT_EQ(5UL, ct) << "Incorrect number of signals asserted";
+}
+
 namespace {
   class ObjectA;
   class ObjectB;


### PR DESCRIPTION
Unlink wasn't actually removing the specified entry from the list.  What a dopy oversight.  Add a test so we don't make this error again.