### PR TITLE
Add test to verify correct behavior on constructive injection

### DIFF
--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -252,9 +252,9 @@ void CoreContext::AddInternal(const CoreObjectDescriptor& traits) {
 
       if (v.m_local) {
         if (traits.pCoreObject && *v.m_value == traits.pCoreObject)
-          throw std::runtime_error("An attempt was made to add the same value to the same context more than once");
+          throw autowiring_error("An attempt was made to add the same value to the same context more than once");
         if (*v.m_value)
-          throw std::runtime_error("An attempt was made to add the same type to the same context more than once");
+          throw autowiring_error("An attempt was made to add the same type to the same context more than once");
       }
       else {
         v.m_value = traits.value;

--- a/src/autowiring/test/AutowiringTest.cpp
+++ b/src/autowiring/test/AutowiringTest.cpp
@@ -211,3 +211,20 @@ TEST_F(AutowiringTest, FastNullDereferenceAttempt) {
   ASSERT_ANY_THROW(*co) << "A dereference attempt on a CoreObject did not throw an exception as expected";
   ASSERT_ANY_THROW((void)co->one) << "A dereference attempt on a CoreObject did not throw an exception as expected";
 }
+
+namespace {
+  class InjectsItself:
+    public CoreObject
+  {
+  public:
+    InjectsItself(bool recurse) {
+      if(recurse)
+        AutoConstruct<InjectsItself>{false};
+    }
+  };
+}
+
+TEST_F(AutowiringTest, AutowiresItself) {
+  // Try to overtake:
+  ASSERT_NO_THROW(AutoConstruct<InjectsItself> bii(true)) << "An overtaken constructor incorrectly caused an exception to be thrown";
+}


### PR DESCRIPTION
Suspect that there is some misbehavior, here, when the same type is injected from multiple threads.  Add a test to uncover the issue, and then fix the problem.