### PR TITLE
move cmake finder config files to root dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,7 @@ if(NOT AUTOWIRING_IS_EMBEDDED)
   install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/autowiring-config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/autowiring-configVersion.cmake"
-    DESTINATION "cmake"
+    DESTINATION ${CMAKE_INSTALL_PREFIX}
     COMPONENT autowiring
   )
 

--- a/autowiring-config.cmake.in
+++ b/autowiring-config.cmake.in
@@ -7,8 +7,8 @@
 if ("@CMAKE_CURRENT_BINARY_DIR@" STREQUAL CMAKE_CURRENT_LIST_DIR)
   set(autowiring_INCLUDE_DIR "@PROJECT_SOURCE_DIR@")
 else()
-  set(autowiring_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/../include")
+  set(autowiring_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/include")
 endif()
 
-include("${CMAKE_CURRENT_LIST_DIR}/AutowiringTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/AutowiringTargets.cmake")
 set(autowiring_FOUND TRUE)


### PR DESCRIPTION
Fixes https://github.com/leapmotion/autowiring/issues/525

- [ ] only tested on Mac OSX, need to test on other platforms