### PR TITLE
Fix issue with unlink teardown behavior

### DIFF
--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -140,6 +140,23 @@ public:
     return this->operator const std::shared_ptr<T>&().get();
   }
 
+  template<typename Fn, typename... Args>
+  struct wrapper {
+    wrapper(Autowired<T>* field, Fn&& fn) :
+      field(field),
+      fn(std::forward<Fn&&>(fn))
+    {}
+
+    Autowired<T>* field;
+    Fn fn;
+
+    void operator()(const Args&... args) {
+      if (field->IsAutowired()) {
+        fn(args...);
+      }
+    }
+  };
+
   //A small temporary structure for the info required to register an event
   //with a member signal on an autowired field.
   template<typename U, typename... Args>
@@ -155,10 +172,11 @@ public:
     void operator+=(Fn&& rhs) {
       Autowired<T>* l_field = field; //lambda capture of references doesn't work right.
       autowiring::signal<void(Args...)> U::* l_member = member;
+      auto wrapped = wrapper<Fn, Args...>(l_field, std::forward<Fn&&>(rhs));
 
-      field->NotifyWhenAutowired([l_field, l_member, rhs] {
+      field->NotifyWhenAutowired([l_field, l_member, wrapped] {
         auto& sig = static_cast<U*>(l_field->get())->*l_member;
-        l_field->m_events.push_back(sig += rhs);
+        l_field->m_events.push_back(sig += wrapped);
       });
     }
   };
@@ -174,7 +192,7 @@ public:
     // And remove any events that were added to the object by this autowired field
     auto localEvents = std::move(m_events);
     for (auto& localEvent : localEvents) {
-      localEvent.owner->unlink(localEvent, true);
+      *localEvent.owner-=localEvent;
     }
 
     // Linked list unwind deletion:

--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -173,8 +173,9 @@ public:
   void reset(void) override {
     // And remove any events that were added to the object by this autowired field
     auto localEvents = std::move(m_events);
-    for (auto& localEvent : localEvents)
-      *localEvent.owner -= localEvent;
+    for (auto& localEvent : localEvents) {
+      localEvent.owner->unlink(localEvent, true);
+    }
 
     // Linked list unwind deletion:
     for (

--- a/autowiring/auto_signal.h
+++ b/autowiring/auto_signal.h
@@ -481,8 +481,10 @@ namespace autowiring {
           // Spurious failure, or insertion.
           // We cannot delegate control to insertion, and spurious failure should be retried.
           continue;
-        default:
-          // Asserting or deferred for awhile, we need to take another option
+          case SignalState::Asserting:
+          case SignalState::Deferred:
+          // Some other thread is already asserting this signal, doing work, we need to ensure
+          // that thread takes responsibility for this call.
           break;
         }
 

--- a/autowiring/auto_signal.h
+++ b/autowiring/auto_signal.h
@@ -479,7 +479,7 @@ namespace autowiring {
         case SignalState::Free:
         case SignalState::Updating:
           // Spurious failure, or insertion.
-          // We cannot delegate control to insertion, and spurious failure shoudl be retried.
+          // We cannot delegate control to insertion, and spurious failure should be retried.
           continue;
         default:
           // Asserting or deferred for awhile, we need to take another option

--- a/autowiring/auto_signal.h
+++ b/autowiring/auto_signal.h
@@ -507,14 +507,14 @@ namespace autowiring {
           state = SignalState::Free;
         } while (!m_state.compare_exchange_weak(state, SignalState::Asserting));
 
-        // Great.  If we got here it's because everyone got away and we're left holding the bag.
-        // We thought we were going to need to pend a callable signal but instead we're still going
-        // to need to invoke it ourselves.
         break;
       }
 
       if (m_state == SignalState::Free) return;
 
+      // Great.  If we got here it's because everyone got away and we're left holding the bag.
+      // We thought we were going to need to pend a callable signal but instead we're still going
+      // to need to invoke it ourselves.
       // Try to get out of the asserting state and into the free state
       for(
         SignalState state = SignalState::Asserting;

--- a/autowiring/auto_signal.h
+++ b/autowiring/auto_signal.h
@@ -196,12 +196,15 @@ namespace autowiring {
 
     // Base type for listeners attached to this signal
     struct entry_base {
+      entry_base(void) {}
+      entry_base(const entry_base& rhs) = delete;
+
       virtual ~entry_base(void) {}
       virtual void operator()(const Args&... args) = 0;
 
       entry_base* pFlink = nullptr;
       entry_base* pBlink = nullptr;
-      std::atomic<bool> unlinkImmediately{false};
+      std::atomic<bool> unlinkImmediately{ false };
     };
 
     template<typename Fn>

--- a/autowiring/auto_signal.h
+++ b/autowiring/auto_signal.h
@@ -513,6 +513,8 @@ namespace autowiring {
         break;
       }
 
+      if (m_state == SignalState::Free) return;
+
       // Try to get out of the asserting state and into the free state
       for(
         SignalState state = SignalState::Asserting;


### PR DESCRIPTION
This pull request highlights a problem with the way that unlink teardown occurs, specifically during signal unregistration.  Fix this problem.

- [ ] Fixes #762