### PR TITLE
Render `CreateInternal` exceptions harmless

### DIFF
--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -131,8 +131,8 @@ CoreContext::~CoreContext(void) {
 std::shared_ptr<CoreContext> CoreContext::CreateInternal(t_pfnCreate pfnCreate)
 {
   // don't allow new children if shutting down
-  if(IsShutdown())
-    throw autowiring_error("Cannot create a child context; this context is already shut down");
+  if (IsShutdown())
+    throw dispatch_aborted_exception("Cannot create a child context; this context is already shut down");
     
   t_childList::iterator childIterator;
   {


### PR DESCRIPTION
Context creation in an already terminated context should be harmless.  If a `CoreThread` attempts to create a subcontext and this causes an exception to be thrown, then we want the root dispatcher to quietly handle this error without treating it as a more serious problem.