### PR TITLE
Nobody cares about the output to `make install`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
   - $CMAKE_DIRNAME/bin/cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX:PATH=~/autowiring/
   - make -j 4 || make
   - ctest --output-on-failure
-  - make install
+  - make install > logfile || cat logfile
   - cpack || (cat _CPack_Packages/Linux/TGZ/InstallOutput.log; exit 3)
   - cd examples
   - ../$CMAKE_DIRNAME/bin/cmake . -DCMAKE_PREFIX_PATH:PATH=~


### PR DESCRIPTION
This just makes build logs more chatty, don't print any output unless something goes wrong.