### PR TITLE
Fix and test NotifyWhenAutowired call order

### DIFF
--- a/autowiring/AutowirableSlot.h
+++ b/autowiring/AutowirableSlot.h
@@ -68,9 +68,9 @@ protected:
   /// </remarks>
   std::weak_ptr<CoreContext> m_context;
 
-  /// The unique ptr to the registration of the singal handler which is used to finish
-  /// the autowiring. The registration can be used to cancel the signal handler.
-  std::unique_ptr<autowiring::registration_t> m_deferred_registration;
+  /// The registration of the singal handler which is used to finish the autowiring.
+  /// It can be used to cancel the signal handler.
+  autowiring::registration_t m_deferred_registration;
 
   /// Cancel the signal handler regsitered in m_deferred_regsitration. This is used when this
   /// is already autowired or to cancel autowiring.

--- a/autowiring/AutowirableSlot.h
+++ b/autowiring/AutowirableSlot.h
@@ -70,11 +70,11 @@ protected:
 
   /// The unique ptr to the registration of the singal handler which is used to finish
   /// the autowiring. The registration can be used to cancel the signal handler.
-  std::unique_ptr<autowiring::registration_t> m_deferred_autowire;
+  std::unique_ptr<autowiring::registration_t> m_deferred_registration;
 
-  /// Cancel the signal handler regsitered in m_deferred_autowire. This is used when this
+  /// Cancel the signal handler regsitered in m_deferred_regsitration. This is used when this
   /// is already autowired or to cancel autowiring.
-  void UnRegisterDeferredAutowire(void);
+  void UnregisterDeferredAutowire(void);
 
   /// <summary>
   /// Causes this deferrable to unregister itself with the enclosing context

--- a/autowiring/AutowirableSlot.h
+++ b/autowiring/AutowirableSlot.h
@@ -68,6 +68,9 @@ protected:
   /// </remarks>
   std::weak_ptr<CoreContext> m_context;
 
+  /// This is used to cancel autowiring
+  std::unique_ptr<autowiring::registration_t> m_deferred_autowire;
+
   /// <summary>
   /// Causes this deferrable to unregister itself with the enclosing context
   /// </summary>
@@ -113,6 +116,12 @@ public:
   /// Satisfies autowiring with a so-called "witness slot" which is guaranteed to be satisfied on the same type
   /// </summary>
   void SatisfyAutowiring(const AnySharedPointer& ptr);
+
+  /// <summary>
+  /// Remember the registration for the singal handler which is used to finish the autowiring
+  /// The registration can be used later to cancel autowiring
+  /// </summary>
+  void RegisterDeferredAutowire(autowiring::registration_t&& reg);
 
   bool operator!=(const AnySharedPointer& rhs) const { return m_ptr != rhs; }
   bool operator==(const AnySharedPointer& rhs) const { return m_ptr == rhs; }

--- a/autowiring/AutowirableSlot.h
+++ b/autowiring/AutowirableSlot.h
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AnySharedPointer.h"
+#include "auto_signal.h"
 #include "autowiring_error.h"
 #include "fast_pointer_cast.h"
 #include "SlotInformation.h"
@@ -16,8 +17,7 @@ class CoreObject;
 /// </summary>
 /// <remarks>
 /// The DeferrableAutowiring base class' SatisfyAutowiring routine is  guaranteed to be run in a
-/// synchronized context--IE, a call to CancelAutowiringNotification will block until the above
-/// routine returns.  Unfortunately, this lock also excludes many other types of operations, such
+/// synchronized context.  Unfortunately, this lock also excludes many other types of operations, such
 /// as CoreContext::Inject and CoreContext::FindByType, which means that handing control to a user
 /// specified callback is unsafe.
 ///
@@ -68,23 +68,14 @@ protected:
   /// </remarks>
   std::weak_ptr<CoreContext> m_context;
 
-  // The next entry to be autowired in this sequence
-  DeferrableAutowiring* m_pFlink = nullptr;
-
   /// <summary>
   /// Causes this deferrable to unregister itself with the enclosing context
   /// </summary>
   void CancelAutowiring(void);
 
 public:
-  // Accessor methods:
-  DeferrableAutowiring* GetFlink(void) { return m_pFlink; }
+  // Accessor method:
   const AnySharedPointer& GetSharedPointer(void) const { return m_ptr; }
-
-  // Mutator methods:
-  void SetFlink(DeferrableAutowiring* pFlink) {
-    m_pFlink = pFlink;
-  }
 
   /// <returns>
   /// True if the underlying field is autowired
@@ -117,17 +108,6 @@ public:
   /// If no custom strategy is required, this method may return null
   /// </remarks>
   virtual DeferrableUnsynchronizedStrategy* GetStrategy(void) { return nullptr; }
-
-  /// <summary>
-  /// Releases autowiring objects that are associated with the current slot
-  /// </summary>
-  /// <remarks>
-  /// These objects are generally all objects that have been registered on this slot to receive notifications of
-  /// some kind when the slot itself is satisfied.  When the context is tearing down, there is potentially an
-  /// ownership and responsibility race on this datatype--should the dependant chain be executed on the objects
-  /// that have been satisfied, or should it be destroyed?
-  /// </remarks>
-  virtual DeferrableAutowiring* ReleaseDependentChain(void) { return nullptr; }
 
   /// <summary>
   /// Satisfies autowiring with a so-called "witness slot" which is guaranteed to be satisfied on the same type

--- a/autowiring/AutowirableSlot.h
+++ b/autowiring/AutowirableSlot.h
@@ -109,14 +109,6 @@ public:
   /// </remarks>
   virtual void reset(void);
 
-  /// <returns>
-  /// The strategy that should be used to satisfy this slot
-  /// </returns>
-  /// <remarks>
-  /// If no custom strategy is required, this method may return null
-  /// </remarks>
-  virtual DeferrableUnsynchronizedStrategy* GetStrategy(void) { return nullptr; }
-
   /// <summary>
   /// Satisfies autowiring with a so-called "witness slot" which is guaranteed to be satisfied on the same type
   /// </summary>
@@ -271,7 +263,5 @@ public:
       (Args) *this...
     );
   }
-
-  DeferrableUnsynchronizedStrategy* GetStrategy(void) override { return this; }
 };
 

--- a/autowiring/AutowirableSlot.h
+++ b/autowiring/AutowirableSlot.h
@@ -68,8 +68,13 @@ protected:
   /// </remarks>
   std::weak_ptr<CoreContext> m_context;
 
-  /// This is used to cancel autowiring
+  /// The unique ptr to the registration of the singal handler which is used to finish
+  /// the autowiring. The registration can be used to cancel the signal handler.
   std::unique_ptr<autowiring::registration_t> m_deferred_autowire;
+
+  /// Cancel the signal handler regsitered in m_deferred_autowire. This is used when this
+  /// is already autowired or to cancel autowiring.
+  void UnRegisterDeferredAutowire(void);
 
   /// <summary>
   /// Causes this deferrable to unregister itself with the enclosing context
@@ -118,8 +123,7 @@ public:
   void SatisfyAutowiring(const AnySharedPointer& ptr);
 
   /// <summary>
-  /// Remember the registration for the singal handler which is used to finish the autowiring
-  /// The registration can be used later to cancel autowiring
+  /// Register the singal handler which is used to finish the autowiring
   /// </summary>
   void RegisterDeferredAutowire(autowiring::registration_t&& reg);
 

--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -200,8 +200,9 @@ public:
     }
 
     if (std::shared_ptr<CoreContext> context = DeferrableAutowiring::m_context.lock()) {
-      auto reg = context->NotifyWhenAutowired<T>(std::forward<Fn>(fn));
-      m_autowired_notifications.push_back(std::move(reg));
+      auto ptr = context->NotifyWhenAutowired<T>(std::forward<Fn>(fn));
+      if (ptr)
+        m_autowired_notifications.push_back(std::move(*ptr));
     }
   }
 };

--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -192,7 +192,7 @@ public:
   /// \include snippets/Autowired_Notify.txt
   /// </remarks>
   template<class Fn>
-  void NotifyWhenAutowired(Fn fn) {
+  void NotifyWhenAutowired(Fn&& fn) {
     // Trivial initial check:
     if(*this) {
       fn();
@@ -200,7 +200,7 @@ public:
     }
 
     if (std::shared_ptr<CoreContext> context = DeferrableAutowiring::m_context.lock()) {
-      auto reg = context->NotifyWhenAutowired<T>(std::forward<Fn&&>(fn));
+      auto reg = context->NotifyWhenAutowired<T>(std::forward<Fn>(fn));
       m_autowired_notifications.push_back(std::move(reg));
     }
   }

--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -206,9 +206,12 @@ public:
       autowiring::registration_t reg =
         entry->m_sig += [this, fn] (autowiring::registration_t registration){
           fn();
-          m_autowired_notifications.erase(
-            std::remove(m_autowired_notifications.begin(), m_autowired_notifications.end(), registration),
-            m_autowired_notifications.end());
+          for(auto iter = m_autowired_notifications.begin(); iter != m_autowired_notifications.end(); ++iter) {
+            if( *iter == registration) {
+              m_autowired_notifications.erase(iter);
+              break;
+            }
+          }
           *registration.owner -= registration;
         };
       m_autowired_notifications.push_back(std::move(reg));

--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -438,7 +438,7 @@ protected:
   /// Adds a notification handler which will be called when the type matching reference is inserted
   /// </summary>
   template<typename Fn>
-  autowiring::registration_t AddNotificationHandlerUnsafe(AnySharedPointer& reference, Fn& handler) {
+  autowiring::registration_t AddNotificationHandlerUnsafe(AnySharedPointer& reference, Fn&& handler) {
     size_t found = m_typeMemos.count(reference.type());
 
     if(!found) {
@@ -1257,7 +1257,7 @@ public:
       listener();
       return autowiring::registration_t(nullptr, nullptr);
     }
-    return this->AddNotificationHandlerUnsafe<Fn>(reference, listener);
+    return this->AddNotificationHandlerUnsafe<Fn>(reference, std::forward<Fn>(listener));
   }
 
   /// <summary>

--- a/autowiring/MemoEntry.h
+++ b/autowiring/MemoEntry.h
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AnySharedPointer.h"
+#include "auto_signal.h"
 
 struct CoreObjectDescriptor;
 class DeferrableAutowiring;

--- a/autowiring/MemoEntry.h
+++ b/autowiring/MemoEntry.h
@@ -7,13 +7,13 @@ class DeferrableAutowiring;
 
 /// \internal
 /// <summary>
-/// Represents a single entry, together with any deferred elements waiting on the satisfaction of this entry
+/// Represents a single entry, together with a signal which would be fired on the satisfaction of this entry
 /// </summary>
 struct MemoEntry {
   MemoEntry(void);
 
-  // The first deferrable autowiring which requires this type, if one exists:
-  DeferrableAutowiring* pFirst = nullptr;
+  // A signal which would be fired on the satisfaction of this entry
+  autowiring::signal<void()> m_sig;
 
   // A back reference to the concrete type from which this memo was generated.  This field may be null
   // if there is no corresponding concrete type.

--- a/src/autowiring/AutowirableSlot.cpp
+++ b/src/autowiring/AutowirableSlot.cpp
@@ -37,16 +37,23 @@ void DeferrableAutowiring::CancelAutowiring(void) {
   if(strategy)
     strategy->Finalize();
 
-  if (m_deferred_autowire) {
-   *m_deferred_autowire->owner -= *m_deferred_autowire;
-   m_deferred_autowire = nullptr;
-  }
+  UnRegisterDeferredAutowire();
 }
 
 void DeferrableAutowiring::SatisfyAutowiring(const AnySharedPointer& ptr) {
   m_ptr = ptr;
+  UnRegisterDeferredAutowire();
 }
 
 void DeferrableAutowiring::RegisterDeferredAutowire(autowiring::registration_t&& reg) {
   m_deferred_autowire = std::make_unique<autowiring::registration_t>(std::move(reg));
 }
+
+
+void DeferrableAutowiring::UnRegisterDeferredAutowire(void) {
+  if (m_deferred_autowire) {
+    *m_deferred_autowire->owner -= *m_deferred_autowire;
+    m_deferred_autowire = nullptr;
+  }
+}
+

--- a/src/autowiring/AutowirableSlot.cpp
+++ b/src/autowiring/AutowirableSlot.cpp
@@ -32,11 +32,6 @@ void DeferrableAutowiring::CancelAutowiring(void) {
 
   m_context.reset();
 
-  // Always finalize this entry:
-  auto strategy = GetStrategy();
-  if(strategy)
-    strategy->Finalize();
-
   UnregisterDeferredAutowire();
 }
 

--- a/src/autowiring/AutowirableSlot.cpp
+++ b/src/autowiring/AutowirableSlot.cpp
@@ -49,11 +49,9 @@ void DeferrableAutowiring::RegisterDeferredAutowire(autowiring::registration_t&&
   m_deferred_autowire = std::make_unique<autowiring::registration_t>(std::move(reg));
 }
 
-
 void DeferrableAutowiring::UnRegisterDeferredAutowire(void) {
   if (m_deferred_autowire) {
     *m_deferred_autowire->owner -= *m_deferred_autowire;
     m_deferred_autowire = nullptr;
   }
 }
-

--- a/src/autowiring/AutowirableSlot.cpp
+++ b/src/autowiring/AutowirableSlot.cpp
@@ -34,8 +34,10 @@ void DeferrableAutowiring::CancelAutowiring(void) {
   // Reset our hold on the weak pointer to prevent repeated cancellation:
   m_context.reset();
 
-  // Tell our context we are going away:
-  context->CancelAutowiringNotification(this);
+  // Always finalize this entry:
+  auto strategy = GetStrategy();
+  if(strategy)
+    strategy->Finalize();
 }
 
 void DeferrableAutowiring::SatisfyAutowiring(const AnySharedPointer& ptr) {

--- a/src/autowiring/AutowirableSlot.cpp
+++ b/src/autowiring/AutowirableSlot.cpp
@@ -10,7 +10,8 @@ using namespace std;
 
 DeferrableAutowiring::DeferrableAutowiring(AnySharedPointer&& witness, const std::shared_ptr<CoreContext>& context) :
   m_ptr(std::move(witness)),
-  m_context(context)
+  m_context(context),
+  m_deferred_registration(autowiring::registration_t(nullptr, nullptr))
 {}
 
 DeferrableAutowiring::~DeferrableAutowiring(void) {
@@ -41,12 +42,11 @@ void DeferrableAutowiring::SatisfyAutowiring(const AnySharedPointer& ptr) {
 }
 
 void DeferrableAutowiring::RegisterDeferredAutowire(autowiring::registration_t&& reg) {
-  m_deferred_registration = std::make_unique<autowiring::registration_t>(std::move(reg));
+  m_deferred_registration = std::move(reg);
 }
 
-void DeferrableAutowiring::UnregisterDeferredAutowire(void) {
+void DeferrableAutowiring::UnregisterDeferredAutowire() {
   if (m_deferred_registration) {
-    *m_deferred_registration->owner -= *m_deferred_registration;
-    m_deferred_registration = nullptr;
+    *m_deferred_registration.owner -= m_deferred_registration;
   }
 }

--- a/src/autowiring/AutowirableSlot.cpp
+++ b/src/autowiring/AutowirableSlot.cpp
@@ -37,21 +37,21 @@ void DeferrableAutowiring::CancelAutowiring(void) {
   if(strategy)
     strategy->Finalize();
 
-  UnRegisterDeferredAutowire();
+  UnregisterDeferredAutowire();
 }
 
 void DeferrableAutowiring::SatisfyAutowiring(const AnySharedPointer& ptr) {
   m_ptr = ptr;
-  UnRegisterDeferredAutowire();
+  UnregisterDeferredAutowire();
 }
 
 void DeferrableAutowiring::RegisterDeferredAutowire(autowiring::registration_t&& reg) {
-  m_deferred_autowire = std::make_unique<autowiring::registration_t>(std::move(reg));
+  m_deferred_registration = std::make_unique<autowiring::registration_t>(std::move(reg));
 }
 
-void DeferrableAutowiring::UnRegisterDeferredAutowire(void) {
-  if (m_deferred_autowire) {
-    *m_deferred_autowire->owner -= *m_deferred_autowire;
-    m_deferred_autowire = nullptr;
+void DeferrableAutowiring::UnregisterDeferredAutowire(void) {
+  if (m_deferred_registration) {
+    *m_deferred_registration->owner -= *m_deferred_registration;
+    m_deferred_registration = nullptr;
   }
 }

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -1047,13 +1047,14 @@ void CoreContext::AddDeferredAutowireUnsafe(DeferrableAutowiring* deferrable) {
   // Obtain the entry (potentially a second time):
   MemoEntry& entry = m_typeMemos[deferrable->GetType()];
 
-  entry.m_sig += [deferrable, &entry] {
+  autowiring::registration_t reg = entry.m_sig += [deferrable, &entry] {
     deferrable->SatisfyAutowiring(entry.m_value);
     auto strategy = deferrable->GetStrategy();
     if (strategy) {
       strategy->Finalize();
     }
   };
+  deferrable->RegisterDeferredAutowire(std::move(reg));
 }
 
 void CoreContext::InsertSnooper(const AnySharedPointer& snooper) {

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -1061,10 +1061,6 @@ void CoreContext::AddDeferredAutowireUnsafe(DeferrableAutowiring* deferrable) {
 
   autowiring::registration_t reg = entry.m_sig += [deferrable, &entry] {
     deferrable->SatisfyAutowiring(entry.m_value);
-    auto strategy = deferrable->GetStrategy();
-    if (strategy) {
-      strategy->Finalize();
-    }
   };
   deferrable->RegisterDeferredAutowire(std::move(reg));
 }

--- a/src/autowiring/test/PostConstructTest.cpp
+++ b/src/autowiring/test/PostConstructTest.cpp
@@ -11,19 +11,6 @@ class PostConstructTest:
 
 using namespace std;
 
-class ContextExposer:
-  public CoreContext
-{
-public:
-  size_t DeferredCount(void) const {
-    size_t ct = 0;
-    for(const auto& entry : CoreContext::m_typeMemos)
-      for(auto cur = entry.second.pFirst; cur; cur = cur->GetFlink())
-        ct++;
-    return ct;
-  }
-};
-
 // Two classes to make up the cyclic dependency:
 class A:
   public ContextMember
@@ -97,19 +84,6 @@ TEST_F(PostConstructTest, VerifyNaiveBehavior) {
   // Create a context and add just the naive class, to verify the problematic behavior:
   AutoCurrentContext ctxt;
   ASSERT_THROW(ctxt->Inject<Naive>(), std::exception) << "Naive class didn't throw an exception as expected";
-}
-
-TEST_F(PostConstructTest, VerifyExpectedDeferrmentCount) {
-  AutoCurrentContext ctxt;
-
-  // Add the smart class, which should introduce a single deferred count:
-  ctxt->Inject<Smarter>();
-
-  // Now test the count:
-  ASSERT_EQ(
-    1UL,
-    ((ContextExposer&)*ctxt).DeferredCount()
-  ) << "Unexpected number of deferred initializers";
 }
 
 TEST_F(PostConstructTest, VerifySmartBehavior) {

--- a/src/autowiring/test/PostConstructTest.cpp
+++ b/src/autowiring/test/PostConstructTest.cpp
@@ -391,16 +391,36 @@ namespace {
 }
 
 TEST_F(PostConstructTest, StrictNotificationArrangement) {
-  size_t call[3] = {0, 0, 0};
-  size_t callIdx = 1;
+  int call[7] = {-1, -1, -1, -1, -1, -1, -1};
+  int callIdx = 1;
 
   AutoCurrentContext ctxt;
-  Autowired<EmptyType> obj;
-  obj.NotifyWhenAutowired([&] { call[0] = callIdx++; });
-  ctxt->NotifyWhenAutowired<EmptyType>([&] { call[1] = callIdx++; });
-  obj.NotifyWhenAutowired([&] { call[2] = callIdx++; });
+  Autowired<EmptyType> obj1;
+  obj1.NotifyWhenAutowired([&] {
+    call[0] = callIdx++;
+  });
+  ctxt->NotifyWhenAutowired<EmptyType>([&] {
+    call[1] = callIdx++;
+  });
+  obj1.NotifyWhenAutowired([&] {
+    call[2] = callIdx++;
+  });
+  ctxt->NotifyWhenAutowired<EmptyType>([&] {
+    call[3] = callIdx++;
+  });
+  Autowired<EmptyType> obj2;
+  obj2.NotifyWhenAutowired([&] {
+    call[4] = callIdx++;
+  });
+  obj1.NotifyWhenAutowired([&] {
+    call[5] = callIdx++;
+  });
+  obj2.NotifyWhenAutowired([&] {
+    call[6] = callIdx++;
+  });
+
   ctxt->Inject<EmptyType>();
 
-  for (size_t i = 0; i < 3; i++)
+  for (int i = 0; i < 7; i++)
     ASSERT_EQ(i + 1, call[i]) << "Registered autowired handler was not called in the correct order";
 }

--- a/src/autowiring/test/PostConstructTest.cpp
+++ b/src/autowiring/test/PostConstructTest.cpp
@@ -391,7 +391,7 @@ namespace {
 }
 
 TEST_F(PostConstructTest, StrictNotificationArrangement) {
-  size_t call[3] = {-1, -1, -1};
+  size_t call[3] = {0, 0, 0};
   size_t callIdx = 1;
 
   AutoCurrentContext ctxt;


### PR DESCRIPTION
`NotifyWhenAutowired` is meant to carry an outer total order guarantee which states that notifications pertaining to the injection of a particular type into a context must be processed strictly in the order they are received.

- [ ] Fixes #738