### PR TITLE
Fix glaring mistake with autowiring::parallel void lambdas

### DIFF
--- a/autowiring/Parallel.h
+++ b/autowiring/Parallel.h
@@ -137,6 +137,8 @@ public:
     (std::lock_guard<std::mutex>)m_queueMutex, ++m_outstandingCount;
 
     *m_ctxt += [this, fx] {
+      fx();
+
       std::lock_guard<std::mutex> lk(m_queueMutex);
       m_nVoidEntries++;
       m_queueUpdated.notify_all();

--- a/src/autowiring/test/ParallelTest.cpp
+++ b/src/autowiring/test/ParallelTest.cpp
@@ -82,4 +82,5 @@ TEST_F(ParallelTest, VoidReturnAll) {
   for (auto entry : p.all<void>())
     i++;
   ASSERT_EQ(100UL, i) << "A sufficient number of empty lambdas were not encountered";
+  ASSERT_EQ(100, *val) << "Not all pended lambda functions were called as expected";
 }


### PR DESCRIPTION
We correctly track the completion of these lambdas, but critically, _we don't actually call them_.  Fix this and add a test to ensure we don't make this mistake again.