### PR TITLE
Eliminate embedded build concept

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,12 +31,6 @@ else()
 endif()
 message(STATUS "Using architecture: ${autowiring_BUILD_ARCHITECTURES}")
 
-# If there's an external libraries directory path, use it as a search prefix
-if(EXTERNAL_LIBRARY_DIR)
-  list(APPEND CMAKE_PREFIX_PATH ${EXTERNAL_LIBRARY_DIR})
-  list(APPEND CMAKE_INCLUDE_PATH ${EXTERNAL_LIBRARY_DIR})
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCC)
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.8")
     message(FATAL_ERROR "GCC version 4.8 minimum is required to build Autowiring")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,13 +31,6 @@ else()
 endif()
 message(STATUS "Using architecture: ${autowiring_BUILD_ARCHITECTURES}")
 
-# Determine whether Autowiring has been embedded in another project
-if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-  set(AUTOWIRING_IS_EMBEDDED OFF)
-else()
-  set(AUTOWIRING_IS_EMBEDDED ON)
-endif()
-
 # If there's an external libraries directory path, use it as a search prefix
 if(EXTERNAL_LIBRARY_DIR)
   list(APPEND CMAKE_PREFIX_PATH ${EXTERNAL_LIBRARY_DIR})
@@ -83,31 +76,22 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake-modules")
 include(AddPCH)
 include(ConditionalSources)
 
-# We don't build tests unless we're being built by ourselves in our own source tree
-# When we're embedded in someone else's subtree, it's not likely that they will want
-# us to bring all of our unit tests in with us.  Though, if they do desire this, they
-# can always set the AUTOWIRING_BUILD_TESTS flag
 get_filename_component(AUTOWIRING_ROOT_DIR . ABSOLUTE)
-if(AUTOWIRING_IS_EMBEDDED)
-  set(AUTOWIRING_BUILD_TESTS_DEFAULT OFF)
-else()
-  set(AUTOWIRING_BUILD_TESTS_DEFAULT ON)
 
-  # All of our binaries go to one place:  The binaries output directory.  We only want to tinker
-  # with this if we're building by ourselves, otherwise we just do whatever the enclosing project
-  # wants us to do.
-  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+# All of our binaries go to one place:  The binaries output directory.  We only want to tinker
+# with this if we're building by ourselves, otherwise we just do whatever the enclosing project
+# wants us to do.
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-  # Libraries not only all wind up in the libraries directory, but we also keep them all together
-  # here by putting them in the same place, regardless of whether they are debug or release.  This
-  # makes globbing them together much easier.
-  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/lib)
-  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/lib)
-  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/lib)
-  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/lib)
-endif()
+# Libraries not only all wind up in the libraries directory, but we also keep them all together
+# here by putting them in the same place, regardless of whether they are debug or release.  This
+# makes globbing them together much easier.
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/lib)
 
 # ARM installations should have "arm" as the suffix for the generated libraries and should be
 # position-independent
@@ -130,13 +114,6 @@ endif()
 
 # Postfix on all debug libraries should be "d"
 set(CMAKE_DEBUG_POSTFIX d${CMAKE_DEBUG_POSTFIX})
-
-option(AUTOWIRING_BUILD_TESTS "Build Autowiring unit tests" ${AUTOWIRING_BUILD_TESTS_DEFAULT})
-function(add_googletest dirname)
-  if(AUTOWIRING_BUILD_TESTS)
-    add_subdirectory(${dirname})
-  endif()
-endfunction()
 
 function(rewrite_header_paths target_SRC_VAR)
   # All include files are located in /autowiring from here, so prepend that to all sources
@@ -176,88 +153,85 @@ add_subdirectory(src)
 # Export library
 export(EXPORT AutowiringTargets FILE AutowiringTargets.cmake NAMESPACE Autowiring::)
 
-# Only attempt to do anything with cpack if we're being built stand-alone
-if(NOT AUTOWIRING_IS_EMBEDDED)
-  # Install autowiring-config.cmake and autowiring-configVersion.cmake
-  install(FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/autowiring-config.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/autowiring-configVersion.cmake"
-    DESTINATION ${CMAKE_INSTALL_PREFIX}
-    COMPONENT autowiring
-  )
+# Install autowiring-config.cmake and autowiring-configVersion.cmake
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/autowiring-config.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/autowiring-configVersion.cmake"
+  DESTINATION ${CMAKE_INSTALL_PREFIX}
+  COMPONENT autowiring
+)
 
-  # Install public header files
-  install(
-    DIRECTORY ${PROJECT_SOURCE_DIR}/autowiring
-    DESTINATION include
-    COMPONENT autowiring
-    FILES_MATCHING PATTERN "*.h"
-  )
+# Install public header files
+install(
+  DIRECTORY ${PROJECT_SOURCE_DIR}/autowiring
+  DESTINATION include
+  COMPONENT autowiring
+  FILES_MATCHING PATTERN "*.h"
+)
  
-  # Install autoboost headers on ARM, which still requires them
-  if(CMAKE_COMPILER_IS_GNUCC AND ("${CMAKE_CXX_COMPILER}" MATCHES "androideabi"))
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9")
-      install(
-        DIRECTORY ${PROJECT_SOURCE_DIR}/contrib/autoboost/autoboost
-        DESTINATION include
-        COMPONENT autowiring
-      )
-    endif()
+# Install autoboost headers on ARM, which still requires them
+if(CMAKE_COMPILER_IS_GNUCC AND ("${CMAKE_CXX_COMPILER}" MATCHES "androideabi"))
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9")
+    install(
+      DIRECTORY ${PROJECT_SOURCE_DIR}/contrib/autoboost/autoboost
+      DESTINATION include
+      COMPONENT autowiring
+    )
   endif()
- 
-  # Targets file is needed in order to describe how to link Autowiring to the rest of the system
-  install(EXPORT AutowiringTargets FILE AutowiringTargets.cmake COMPONENT autowiring NAMESPACE Autowiring:: DESTINATION cmake CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES})
-
-  # 64-bit installations get a different upgrade GUID
-  if(autowiring_BUILD_64)
-    set(autowiring_GUID_LAST_CHAR E)
-  else()
-    set(autowiring_GUID_LAST_CHAR D)
-  endif()
-
-  # This is the upgrade GUID.  Part of the GUID is derived from the major version number.  Any time
-  # the major version number is adjusted, the upgrade GUID changes.  This allows multiple versions
-  # of the same product to be installed on a user's system at the same time, but also means that
-  # manual uninstallation of older versions is required.
-  #
-  # For more information on the rationale for this process, see the discussion on semantic versioning
-  # found at http://semver.org/
-  SET(CPACK_WIX_UPGRADE_GUID "{060E5EDD-229${autowiring_VERSION_MAJOR}-4AD8-BAFA-A303D5696A2${autowiring_GUID_LAST_CHAR}}")
-
-  # Need a custom wix installation template so that we update the CMake package registry correctly
-  # Only really needed on Windows; Mac and Linux have pretty good default search behavior, so we
-  # leave those alone.
-  SET(CPACK_WIX_TEMPLATE "${CMAKE_SOURCE_DIR}/autowiring.wxs")
-  SET(CPACK_MONOLITHIC_INSTALL ON)
-
-  # Run the script that will grab the debug and release configurations and install them during packaging
-  set(CPACK_INSTALL_COMMANDS
-    "${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config Debug"
-    "${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config Release"
-    "${CMAKE_COMMAND} -DBUILD_TYPE=Debug -P \\\"${CMAKE_SOURCE_DIR}/cmake_package.cmake\\\""
-    "${CMAKE_COMMAND} -DBUILD_TYPE=Release -P \\\"${CMAKE_SOURCE_DIR}/cmake_package.cmake\\\""
-  )
-
-  # Pick the generator in an appropriate way
-  if(WIN32)
-    set(CPACK_GENERATOR WIX ZIP)
-  elseif(APPLE)
-    # TODO: Add Bundle as a generator here
-    set(CPACK_GENERATOR TGZ)
-  else()
-    set(CPACK_GENERATOR TGZ DEB)
-  endif()
-
-  # Packaging stuff, if an installer is being made instead
-  SET(CPACK_PACKAGE_VENDOR "Leap Motion")
-  SET(CPACK_PACKAGE_CONTACT "cmercenary@gmail.com")
-  SET(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
-  SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Autowiring")
-  SET(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.txt")
-  SET(CPACK_PACKAGE_VERSION_MAJOR "${autowiring_VERSION_MAJOR}")
-  SET(CPACK_PACKAGE_VERSION_MINOR "${autowiring_VERSION_MINOR}")
-  SET(CPACK_PACKAGE_VERSION_PATCH "${autowiring_VERSION_PATCH}")
-  SET(CPACK_PACKAGE_INSTALL_REGISTRY_KEY "autowiring")
-  SET(CPACK_PACKAGE_INSTALL_DIRECTORY "autowiring")
-  INCLUDE(CPack)
 endif()
+ 
+# Targets file is needed in order to describe how to link Autowiring to the rest of the system
+install(EXPORT AutowiringTargets FILE AutowiringTargets.cmake COMPONENT autowiring NAMESPACE Autowiring:: DESTINATION cmake CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES})
+
+# 64-bit installations get a different upgrade GUID
+if(autowiring_BUILD_64)
+  set(autowiring_GUID_LAST_CHAR E)
+else()
+  set(autowiring_GUID_LAST_CHAR D)
+endif()
+
+# This is the upgrade GUID.  Part of the GUID is derived from the major version number.  Any time
+# the major version number is adjusted, the upgrade GUID changes.  This allows multiple versions
+# of the same product to be installed on a user's system at the same time, but also means that
+# manual uninstallation of older versions is required.
+#
+# For more information on the rationale for this process, see the discussion on semantic versioning
+# found at http://semver.org/
+SET(CPACK_WIX_UPGRADE_GUID "{060E5EDD-229${autowiring_VERSION_MAJOR}-4AD8-BAFA-A303D5696A2${autowiring_GUID_LAST_CHAR}}")
+
+# Need a custom wix installation template so that we update the CMake package registry correctly
+# Only really needed on Windows; Mac and Linux have pretty good default search behavior, so we
+# leave those alone.
+SET(CPACK_WIX_TEMPLATE "${CMAKE_SOURCE_DIR}/autowiring.wxs")
+SET(CPACK_MONOLITHIC_INSTALL ON)
+
+# Run the script that will grab the debug and release configurations and install them during packaging
+set(CPACK_INSTALL_COMMANDS
+  "${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config Debug"
+  "${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config Release"
+  "${CMAKE_COMMAND} -DBUILD_TYPE=Debug -P \\\"${CMAKE_SOURCE_DIR}/cmake_package.cmake\\\""
+  "${CMAKE_COMMAND} -DBUILD_TYPE=Release -P \\\"${CMAKE_SOURCE_DIR}/cmake_package.cmake\\\""
+)
+
+# Pick the generator in an appropriate way
+if(WIN32)
+  set(CPACK_GENERATOR WIX ZIP)
+elseif(APPLE)
+  # TODO: Add Bundle as a generator here
+  set(CPACK_GENERATOR TGZ)
+else()
+  set(CPACK_GENERATOR TGZ DEB)
+endif()
+
+# Packaging stuff, if an installer is being made instead
+SET(CPACK_PACKAGE_VENDOR "Leap Motion")
+SET(CPACK_PACKAGE_CONTACT "cmercenary@gmail.com")
+SET(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Autowiring")
+SET(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.txt")
+SET(CPACK_PACKAGE_VERSION_MAJOR "${autowiring_VERSION_MAJOR}")
+SET(CPACK_PACKAGE_VERSION_MINOR "${autowiring_VERSION_MINOR}")
+SET(CPACK_PACKAGE_VERSION_PATCH "${autowiring_VERSION_PATCH}")
+SET(CPACK_PACKAGE_INSTALL_REGISTRY_KEY "autowiring")
+SET(CPACK_PACKAGE_INSTALL_DIRECTORY "autowiring")
+INCLUDE(CPack)

--- a/src/autonet/CMakeLists.txt
+++ b/src/autonet/CMakeLists.txt
@@ -1,4 +1,3 @@
-add_googletest(test)
 include_directories(
   ${PROJECT_SOURCE_DIR}/contrib/autoboost
 )
@@ -21,6 +20,8 @@ add_pch(AutoNet_SRCS "stdafx.h" "stdafx.cpp")
 add_library(AutoNet STATIC ${AutoNet_SRCS})
 target_link_libraries(AutoNet PRIVATE Autowiring)
 set_target_properties(AutoNet PROPERTIES INTERFACE_LINK_LIBRARIES Autowiring)
+
+add_subdirectory(test)
 
 #
 # Install library

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -2,8 +2,8 @@
 # Setup testing
 #
 
-add_googletest(test)
-add_googletest(benchmark)
+add_subdirectory(test)
+add_subdirectory(benchmark)
 
 #
 # Configure source files


### PR DESCRIPTION
Autowiring is a stand-alone library and we do not support embedding this library in any other project.  Eliminate whatever remains of the legacy code that supported this use pattern.