### PR TITLE
Fix install command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,7 @@ if(NOT AUTOWIRING_IS_EMBEDDED)
   install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/autowiring-config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/autowiring-configVersion.cmake"
-    DESTINATION ${CMAKE_INSTALL_PREFIX}
+    DESTINATION "."
     COMPONENT autowiring
   )
 


### PR DESCRIPTION
When a relative directory is given as the value to the DESTINATION argument of the cmake [`install`](https://cmake.org/cmake/help/v3.0/command/install.html) command, it is already treated as being relative to `CMAKE_INSTALL_PREFIX`.  When we redundantly specify it, then the PACKAGE operation can fail if the user specified `CMAKE_INSTALL_PREFIX` during configuration because it is interpreted to an absolute path at configuration time and is not resolved again when it has to be overridden at package time.