### PR TITLE
Fix a Build Error of Android

### DIFF
--- a/src/autowiring/CoreThreadLinux.cpp
+++ b/src/autowiring/CoreThreadLinux.cpp
@@ -34,7 +34,10 @@ void BasicThread::SetThreadPriority(ThreadPriority threadPriority) {
 
   switch (threadPriority) {
   case ThreadPriority::Idle:
+//Android kernel(3.10.x) has not implemented SCHED_IDLE yet.
+#ifndef __ANDROID__
     policy = SCHED_IDLE;
+#endif
     percent = 0;
     break;
   case ThreadPriority::Lowest:


### PR DESCRIPTION
- SCHED_IDLE is not included in Kernel 3.1.x.

Fixes #792 