### PR TITLE
Make unit test more reliable, fix resulting failure

### DIFF
--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -223,7 +223,7 @@ public:
       MemoEntry* entry = &context->FindByDeferrableAutowiring(this);
 
       autowiring::registration_t reg =
-        entry->m_sig += [this, fn] (autowiring::registration_t registration){
+        entry->m_sig += [this, fn] (autowiring::registration_t registration) mutable {
           fn();
           for(auto iter = m_autowired_notifications.begin(); iter != m_autowired_notifications.end(); ++iter) {
             if( *iter == registration) {

--- a/autowiring/auto_signal.h
+++ b/autowiring/auto_signal.h
@@ -230,7 +230,7 @@ namespace autowiring {
         fn(std::forward<_Fn>(fn))
       {}
       signal& owner;
-      const Fn fn;
+      Fn fn;
       void operator()(const Args&... args) override { fn(registration_t{ &owner, this }, args...); }
     };
 

--- a/src/autowiring/test/AutoSignalTest.cpp
+++ b/src/autowiring/test/AutoSignalTest.cpp
@@ -661,6 +661,7 @@ TEST_F(AutoSignalTest, OuterPostDereference) {
 
   // This should trigger an exception:
   outer->sig();
+  ASSERT_FALSE(WiresInOuterScope::s_isConstructed) << "An object registered with a signal handle was unexpectedly leaked";
 }
 
 namespace {

--- a/src/autowiring/test/AutoSignalTest.cpp
+++ b/src/autowiring/test/AutoSignalTest.cpp
@@ -628,10 +628,7 @@ namespace {
     WiresInOuterScope(void) {
       s_wasHit = false;
       s_isConstructed = true;
-      outer(&OuterType::sig) += [this] {
-        s_wasHit = true;
-        ASSERT_TRUE(s_isConstructed) << "Signal handler invoked on an object that was already destroyed";
-      };
+      outer(&OuterType::sig) += [this] { s_wasHit = true; };
     }
 
     ~WiresInOuterScope(void) {


### PR DESCRIPTION
This unit test was not catching a defect on Mac/Linux because of the way that the compiler can optionally optimize out write operations that occur in the destructor.  Change the test to make use of a static member instead so as to avoid this.

- [x] Fixes #791