### PR TITLE
Address unsynchronized reset issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
   # Build Autowiring, run unit tests, and install
   - $CMAKE_DIRNAME/bin/cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX:PATH=~/autowiring/
   - make -j 4 || make
-  - ctest --output-on-failure
+  - ctest --output-on-failure --timeout 30
   - make install > logfile || cat logfile
   - cpack || (cat _CPack_Packages/Linux/TGZ/InstallOutput.log; exit 3)
   - cd examples

--- a/autowiring/AnySharedPointer.h
+++ b/autowiring/AnySharedPointer.h
@@ -109,6 +109,12 @@ public:
     m_ptr = rhs.m_ptr;
   }
 
+  // Allows dynamic assignment of the type directly from an auto_id field
+  void operator=(auto_id ti) {
+    m_ti = ti;
+    m_ptr.reset();
+  }
+
   /// <summary>
   /// Convenience overload for shared pointer assignment
   /// </summary>

--- a/autowiring/AutowirableSlot.h
+++ b/autowiring/AutowirableSlot.h
@@ -15,39 +15,6 @@ class DeferrableAutowiring;
 class GlobalCoreContext;
 
 /// <summary>
-/// Strategy class for performing unsynchronized operations on an autowirable slot
-/// </summary>
-/// <remarks>
-/// The DeferrableAutowiring base class' SatisfyAutowiring routine is  guaranteed to be run in a
-/// synchronized context.  Unfortunately, this lock also excludes many other types of operations, such
-/// as CoreContext::Inject and CoreContext::FindByType, which means that handing control to a user
-/// specified callback is unsafe.
-///
-/// Exacerbating the problem is the fact that the original DeferrableAutowiring may refer to an
-/// object on the stack or whose destruction cannot otherwise be delayed.  As soon as the synchronized
-/// context is exited, the object could already be in a teardown pathway, which means we can't invoke
-/// any kind of virtual function call on the object.
-///
-/// Thus, the Finalize operation is only supported on objects whose lifetimes can be externally
-/// guaranteed.  Currently, only AutowirableSlotFn supports this behavior, and it is accessable via
-/// CoreContext::NotifyWhenAutowired and Autowired::NotifyWhenAutowired.
-/// </remarks>
-class DeferrableUnsynchronizedStrategy {
-public:
-  ~DeferrableUnsynchronizedStrategy(void) {}
-
-  /// <summary>
-  /// Releases memory allocated by this object, where appropriate
-  /// </summary>
-  /// <summary>
-  /// Implementors of this method are permitted to delete "this" or perform any other work while
-  /// outside of the context of a lock.  Once this method returns, this object is guaranteed never
-  /// to be referred to again by CoreContext.
-  /// </remarks>
-  virtual void Finalize(void) = 0;
-};
-
-/// <summary>
 /// Utility class which represents any kind of autowiring entry that may be deferred to a later date
 /// </summary>
 class DeferrableAutowiring

--- a/autowiring/AutowirableSlot.h
+++ b/autowiring/AutowirableSlot.h
@@ -3,14 +3,16 @@
 #include "AnySharedPointer.h"
 #include "auto_signal.h"
 #include "autowiring_error.h"
+#include "CoreContext.h"
 #include "fast_pointer_cast.h"
 #include "SlotInformation.h"
 #include MEMORY_HEADER
 
+struct MemoEntry;
 class CoreContext;
+class CoreObject;
 class DeferrableAutowiring;
 class GlobalCoreContext;
-class CoreObject;
 
 /// <summary>
 /// Strategy class for performing unsynchronized operations on an autowirable slot
@@ -51,12 +53,32 @@ public:
 class DeferrableAutowiring
 {
 public:
+  DeferrableAutowiring(const DeferrableAutowiring& rhs);
   DeferrableAutowiring(AnySharedPointer&& witness, const std::shared_ptr<CoreContext>& context);
   virtual ~DeferrableAutowiring(void);
 
 protected:
-  // The held shared pointer
+  // Lock for fields on this type
+  autowiring::spin_lock m_lock;
+
+  // All registrations attached to this object:
+  std::vector<autowiring::registration_t> m_autowired_notifications;
+
+  // The held shared pointer.
   AnySharedPointer m_ptr;
+
+  class Handler {
+  public:
+    Handler(DeferrableAutowiring& parent, MemoEntry& memo) :
+      parent(parent),
+      memo(memo)
+    {}
+
+    DeferrableAutowiring& parent;
+    MemoEntry& memo;
+
+    void operator()();
+  };
 
   /// <summary>
   /// This is the context that was available at the time the autowiring was performed.
@@ -68,22 +90,10 @@ protected:
   /// </remarks>
   std::weak_ptr<CoreContext> m_context;
 
-  /// The registration of the singal handler which is used to finish the autowiring.
-  /// It can be used to cancel the signal handler.
-  autowiring::registration_t m_deferred_registration;
-
-  /// Cancel the signal handler regsitered in m_deferred_regsitration. This is used when this
-  /// is already autowired or to cancel autowiring.
-  void UnregisterDeferredAutowire(void);
-
-  /// <summary>
-  /// Causes this deferrable to unregister itself with the enclosing context
-  /// </summary>
-  void CancelAutowiring(void);
-
 public:
   // Accessor method:
   const AnySharedPointer& GetSharedPointer(void) const { return m_ptr; }
+  operator bool(void) const { return m_ptr != nullptr; }
 
   /// <returns>
   /// True if the underlying field is autowired
@@ -107,17 +117,47 @@ public:
   /// This method may not be safely called from an unsynchronized context.  Callers must ensure that
   /// this field is not in use during the call to reset or a data race will result.
   /// </remarks>
-  virtual void reset(void);
+  void reset(void);
 
   /// <summary>
-  /// Satisfies autowiring with a so-called "witness slot" which is guaranteed to be satisfied on the same type
+  /// Assigns a lambda function to be called when the dependency for this slot is autowired.
   /// </summary>
-  void SatisfyAutowiring(const AnySharedPointer& ptr);
+  /// <remarks>
+  /// In contrast with CoreContext::NotifyWhenAutowired, the specified lambda is only
+  /// called as long as this Autowired slot has not been destroyed.  If this slot is destroyed
+  /// before the dependency is satisfied, i.e. because the owning context shuts down, the
+  /// lambda is cancelled.
+  ///
+  /// Note that, if T is injected at about the same time as this object is destroyed, then cancellation
+  /// of the autowired lambda could potentially race with satisfaction of that same lambda.  This type
+  /// of race is called a cancellation race, and can result in the lambda being invoked even though this
+  /// object has been destroyed.
+  ///
+  /// Users who use Autowired as a member of their class do not need to consider this case.  Autowired
+  /// fields declared as class members are always cancelled before the enclosing object is destroyed.
+  ///
+  /// \include snippets/Autowired_Notify.txt
+  /// </remarks>
+  template<class Fn>
+  void NotifyWhenAutowired(Fn&& fn) {
+    // Trivial initial check:
+    if (*this) {
+      fn();
+      return;
+    }
 
-  /// <summary>
-  /// Register the singal handler which is used to finish the autowiring
-  /// </summary>
-  void RegisterDeferredAutowire(autowiring::registration_t&& reg);
+    if (std::shared_ptr<CoreContext> context = DeferrableAutowiring::m_context.lock()) {
+      MemoEntry& entry = context->FindByType(m_ptr.type());
+
+      // Need to memorialize registration of this entry
+      auto reg = entry.onSatisfied += std::move(fn);
+      if (!reg)
+        return;
+
+      std::lock_guard<autowiring::spin_lock> lk(m_lock);
+      m_autowired_notifications.push_back(std::move(reg));
+    }
+  }
 
   bool operator!=(const AnySharedPointer& rhs) const { return m_ptr != rhs; }
   bool operator==(const AnySharedPointer& rhs) const { return m_ptr == rhs; }
@@ -139,10 +179,6 @@ public:
     DeferrableAutowiring(AnySharedPointerT<typename std::remove_const<T>::type>(), ctxt)
   {
     SlotInformationStackLocation::RegisterSlot(this);
-  }
-
-  virtual ~AutowirableSlot(void) {
-    CancelAutowiring();
   }
 
   /// <remarks>

--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -37,7 +37,6 @@ class BoltBase;
 class CoreContext;
 class GlobalCoreContext;
 class JunctionBoxBase;
-class OutstandingCountTracker;
 
 template<typename T>
 class Autowired;
@@ -52,9 +51,6 @@ template<typename T>
 class JunctionBox;
 
 namespace autowiring {
-  template<typename... Args>
-  struct signal_relay_t;
-
   class ThreadPool;
 }
 

--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -629,7 +629,8 @@ public:
   /// <returns>
   /// The memo entry where this type was found
   /// </returns>
-  /// <param name="id">The type to be located</param>
+  /// <param name="type">The type to be located</param>
+  /// <param name="nonrecursive">False if ancestor contexts should not be searched</param>
   MemoEntry& FindByType(auto_id type, bool nonrecursive = false) const;
 
   /// <summary>

--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -701,9 +701,8 @@ public:
   /// </summary>
   template<class T>
   bool Has(void) const {
-    std::shared_ptr<T> ptr;
-    FindByType(ptr);
-    return ptr != nullptr;
+    auto& reg = FindByType(auto_id_t<T>{});
+    return reg.m_value != nullptr;
   }
 
   /// <summary>

--- a/autowiring/CoreObjectDescriptor.h
+++ b/autowiring/CoreObjectDescriptor.h
@@ -6,11 +6,12 @@
 #include "AutowiringEvents.h"
 #include "BoltBase.h"
 #include "ContextMember.h"
+#include "CoreObject.h"
 #include "CoreRunnable.h"
 #include "BasicThread.h"
 #include "ExceptionFilter.h"
 #include "fast_pointer_cast.h"
-#include "CoreObject.h"
+#include "SlotInformation.h"
 #include <typeinfo>
 #include MEMORY_HEADER
 

--- a/autowiring/MemoEntry.h
+++ b/autowiring/MemoEntry.h
@@ -1,7 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AnySharedPointer.h"
-#include "auto_signal.h"
+#include "once.h"
 
 struct CoreObjectDescriptor;
 class DeferrableAutowiring;
@@ -12,13 +12,14 @@ class DeferrableAutowiring;
 /// </summary>
 struct MemoEntry {
   MemoEntry(void);
+  MemoEntry(const MemoEntry& rhs) = delete;
 
   // A signal which would be fired on the satisfaction of this entry
-  autowiring::signal<void()> m_sig;
+  autowiring::once onSatisfied;
 
   // A back reference to the concrete type from which this memo was generated.  This field may be null
   // if there is no corresponding concrete type.
-  const CoreObjectDescriptor* pObjTraits;
+  const CoreObjectDescriptor* pObjTraits = nullptr;
 
   // Once this memo entry is satisfied, this will contain the AnySharedPointer instance that performs
   // the satisfaction

--- a/src/autowiring/AutowirableSlot.cpp
+++ b/src/autowiring/AutowirableSlot.cpp
@@ -49,7 +49,14 @@ DeferrableAutowiring::DeferrableAutowiring(AnySharedPointer&& witness, const std
 }
 
 DeferrableAutowiring::~DeferrableAutowiring(void) {
-  // BUG:  The reset call does not strictly prohibit 
+  // BUG:  The reset call does not strictly prohibit signal handlers defined on this type from
+  // being invoked after the destruction of this type.  We must rely on external synchronization
+  // strategies to prevent a use-after-free; in particular, users that are making use of
+  // Autowired<T> on the stack may be subject to race conditions under teardown.  There is no
+  // general solution to this problem that does not introduce the possibility of a deadlock.
+  //
+  // The only solution available may be to trigger a fatal exception when a cancellation race
+  // is detected.
   reset();
 }
 

--- a/src/autowiring/AutowirableSlot.cpp
+++ b/src/autowiring/AutowirableSlot.cpp
@@ -8,45 +8,73 @@
 
 using namespace std;
 
-DeferrableAutowiring::DeferrableAutowiring(AnySharedPointer&& witness, const std::shared_ptr<CoreContext>& context) :
-  m_ptr(std::move(witness)),
-  m_context(context),
-  m_deferred_registration(autowiring::registration_t(nullptr, nullptr))
+void DeferrableAutowiring::Handler::operator()() {
+  parent.m_ptr = memo.m_value;
+
+  // Move to a stack-allocated field under lock so we can free outside of the lock
+  // Also has the side effect of releasing _all_ memory, as opposed to `clear`, which
+  // only sets the size to zero.
+  auto autowired_notifications =
+    (
+      std::lock_guard<autowiring::spin_lock>{ parent.m_lock },
+      std::move(parent.m_autowired_notifications)
+    );
+}
+
+DeferrableAutowiring::DeferrableAutowiring(const DeferrableAutowiring& rhs) :
+  DeferrableAutowiring(AnySharedPointer{ rhs.m_ptr }, rhs.m_context.lock())
 {}
 
+DeferrableAutowiring::DeferrableAutowiring(AnySharedPointer&& witness, const std::shared_ptr<CoreContext>& context) :
+  m_ptr(std::move(witness)),
+  m_context(context)
+{
+  if (!context)
+    return;
+
+  // We need to know when the type itself becomes available:
+  MemoEntry& memo = context->FindByType(witness.type(), false);
+  autowiring::registration_t reg =
+    memo.onSatisfied += Handler{ *this, memo };
+
+  if (!reg)
+    // Invoked, do not need our notifications structure
+    return;
+
+  // Deferred notifications are extremely common.  Generally clients only need one or so, and resizing requires
+  // that we perform an expensive memory reallocation, so let's pay a little memory in advance to help make the
+  // most common use case pretty fast.
+  m_autowired_notifications.reserve(2);
+  m_autowired_notifications.emplace_back(std::move(reg));
+}
+
 DeferrableAutowiring::~DeferrableAutowiring(void) {
-  // Clients MUST call CancelAutowiring from their destructor--if this line is being hit,
-  // it's because the type being destructed isn't calling CancelAutowiring properly.
-  assert(m_context.expired());
+  // BUG:  The reset call does not strictly prohibit 
+  reset();
 }
 
 void DeferrableAutowiring::reset(void) {
-  m_ptr.reset();
-  CancelAutowiring();
-}
+  // Local versions of the members we are clearing out
+  std::weak_ptr<CoreContext> contextWeak;
+  AnySharedPointer ptr;
+  std::vector<autowiring::registration_t> autowired_notifications;
+  
+  // Move and handle resources under lock
+  {
+    std::lock_guard<autowiring::spin_lock> lk{ m_lock };
+    autowired_notifications = std::move(m_autowired_notifications);
+    ptr = std::move(m_ptr);
+    contextWeak = std::move(m_context);
+    m_context.reset();
+  }
 
-void DeferrableAutowiring::CancelAutowiring(void) {
-  auto context = m_context.lock();
-  if(!context)
-    // Nothing to do here, then
+  std::shared_ptr<CoreContext> context = contextWeak.lock();
+  if (!context)
+    // Nothing to do, context is already gone.  No chance of a signal being
+    // asserted now.
     return;
 
-  m_context.reset();
-
-  UnregisterDeferredAutowire();
-}
-
-void DeferrableAutowiring::SatisfyAutowiring(const AnySharedPointer& ptr) {
-  m_ptr = ptr;
-  UnregisterDeferredAutowire();
-}
-
-void DeferrableAutowiring::RegisterDeferredAutowire(autowiring::registration_t&& reg) {
-  m_deferred_registration = std::move(reg);
-}
-
-void DeferrableAutowiring::UnregisterDeferredAutowire() {
-  if (m_deferred_registration) {
-    *m_deferred_registration.owner -= m_deferred_registration;
-  }
+  // Clear out any registered signal handlers, context is still valid:
+  for (auto& notification : autowired_notifications)
+    *notification.owner -= notification;
 }

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -794,9 +794,6 @@ void CoreContext::UnregisterEventReceiversUnsafe(void) {
   if(m_pParent)
     m_pParent->RemoveEventReceivers(m_eventReceivers);
 
-  // Recursively unregister packet factory subscribers:
-  FindByTypeUnsafe(auto_id_t<AutoPacketFactory>{});
-
   // Wipe out all collections so we don't try to free these multiple times:
   m_eventReceivers.clear();
 }

--- a/src/autowiring/test/AutoSignalTest.cpp
+++ b/src/autowiring/test/AutoSignalTest.cpp
@@ -688,19 +688,19 @@ TEST_F(AutoSignalTest, ReallocationCheck) {
     new Autowired<WithSignal>{}
   };
 
-  {
+  (*contrived)(&WithSignal::sig) += [&] {
+    hitCount++;
+
     // Delete the Autowired field while the signal handler is being called.  This is intended to simulate
     // a legal possible multithreaded scenario where a signal handler is being asserted at about the same
     // time as an Autowired field is being destroyed.
-    (*contrived)(&WithSignal::sig) += [&] {
-      hitCount++;
-      contrived.reset();
+    contrived.reset();
 
-      Autowired<WithSignal> ws;
-      ws->sig();
-    };
-    ctxt->Inject<WithSignal>();
-  }
+    Autowired<WithSignal> ws;
+    ws->sig();
+  };
+  ctxt->Inject<WithSignal>();
+
   Autowired<WithSignal> sig3;
   sig3->sig();
 

--- a/src/autowiring/test/ContextMemberTest.cpp
+++ b/src/autowiring/test/ContextMemberTest.cpp
@@ -184,13 +184,15 @@ TEST_F(ContextMemberTest, PathologicalResetCase) {
   auto resetsV = [&] {
     while(proceed) {
       ++nBarr;
-      while (proceed && !go);
+      while (proceed && !go)
+        std::this_thread::yield();
       if (!proceed)
         break;
 
       pv->reset();
       --nBarr;
-      while (proceed && go);
+      while (proceed && go)
+        std::this_thread::yield();
     }
   };
 
@@ -204,9 +206,11 @@ TEST_F(ContextMemberTest, PathologicalResetCase) {
       v.NotifyWhenAutowired([] {});
 
     // Bump the threads to spin around:
-    while (nBarr != 2);
+    while (nBarr != 2)
+      std::this_thread::yield();
     go = true;
-    while (nBarr);
+    while (nBarr)
+      std::this_thread::yield();
     go = false;
   }
 

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -570,3 +570,13 @@ TEST_F(CoreContextTest, TerminatedContextHarmless) {
   ctxt->SignalShutdown();
   ASSERT_THROW(ctxt->Create<void>(), dispatch_aborted_exception) << "An exception should have been thrown when attempting to create a child from a terminated context";
 }
+
+TEST_F(CoreContextTest, Has) {
+  AutoCurrentContext ctxt;
+  AutoCreateContext subCtxt;
+  ASSERT_FALSE(ctxt->Has<SimpleObject>()) << "Context reported as owning a type that did not yet exist";
+  ASSERT_FALSE(subCtxt->Has<SimpleObject>()) << "Child context reported as owning a type that did not yet exist";
+  AutoRequired<SimpleObject> so;
+  ASSERT_TRUE(ctxt->Has<SimpleObject>()) << "Context failed to detect an extant type";
+  ASSERT_TRUE(subCtxt->Has<SimpleObject>()) << "Child context failed to detect an extant type";
+}

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -482,13 +482,16 @@ TEST_F(CoreContextTest, UnlinkOnTeardown) {
     weakA = a;
     strongB = b;
     
+    ASSERT_TRUE(a->so.IsAutowired()) << "Root object pointer not correctly obtained";
+    ASSERT_TRUE(b->so.IsAutowired()) << "Root object pointer not correctly obtained";
+
     ctxt->AddTeardownListener(
       [weakA, strongB] {
         // Verify that nothing got screwed up at this point:
         auto a = weakA.lock();
         ASSERT_FALSE(weakA.expired()) << "Weak pointer expired prematurely";
         ASSERT_EQ(strongB, a->b) << "Unlink occurred prematurely";
-        ASSERT_EQ(a, strongB->a) << "Unlink occurred prematurely";
+        ASSERT_EQ(a, strongB->a) << "Unlink occured prematurely";
       }
     );
 

--- a/src/autowiring/test/ScopeTest.cpp
+++ b/src/autowiring/test/ScopeTest.cpp
@@ -22,27 +22,25 @@ class D : public ContextMember {};
 TEST_F(ScopeTest, VerifyInherit) {
   AutoCurrentContext ctxt;
 
-  //Add a member to the current context
+  // Add a member to the current context
   ctxt->Inject<A>();
 
+  // Create and switch to a sub-context
   AutoCreateContext pContext(ctxt);
-  //Create and switch to a sub-context
   {
-    CurrentContextPusher pusher;
-    pContext->SetCurrent();
-
-    ASSERT_TRUE(ctxt.get() != pContext.get()) << "Failed to create a sub-context";
+    CurrentContextPusher pusher(pContext);
+    ASSERT_NE(ctxt.get(), pContext.get()) << "Failed to create a sub-context";
 
     //try and autowire a member from the parent context
     Autowired<A> autoA;
-    ASSERT_FALSE(!autoA.get()) << "Autowired member not wired from parent context";
+    ASSERT_TRUE(autoA) << "Autowired member not wired from parent context";
 
     //add a member in the subcontext
     pContext->Inject<B>();
   }
 
   Autowired<B> autoB;
-  ASSERT_TRUE(!autoB.get()) << "Autowired member wired from sub-context";
+  ASSERT_FALSE(autoB.get()) << "Autowired member wired from sub-context";
 }
 
 struct NoSimpleConstructor:
@@ -191,8 +189,8 @@ TEST_F(ScopeTest, RequireVsWire) {
 
   //this overrides the slot in the middle context;
   AutoRequired<A> a_required_middle(ctxt_middle);
-  ASSERT_TRUE(a_required_middle.IsAutowired()) << "AutoRequired member not satisfied!";
-  ASSERT_EQ(a_required_middle->GetContext(), ctxt_middle) << "AutoRequired member not created in child context";
+  ASSERT_TRUE(a_required_middle) << "AutoRequired member not satisfied!";
+  ASSERT_EQ(ctxt_middle, a_required_middle->GetContext()) << "AutoRequired member not created in child context";
   ASSERT_NE(a_required_middle, a_required_outer) << "AutoRequired member not constructed in child context";
   
   Autowired<A> a_wired_inner2(ctxt_inner);


### PR DESCRIPTION
This pull request only partially addresses the asynchronous reset problem.  There is no general solution to this problem because at the heart of the issue is a cancellation race with `NotifyWhenAutowired`.  The simplest case that demonstrates this issue is as follows:

Thread 1:
```C++
{
    std::lock_guard<std::mutex> lk(lock);
    Autowired<T> ptr;
    ptr->NotifyWhenAutowired([&] {
        std::lock_guard<std::mutex> lk(lock);
        // ...do more work...
    });
    std::this_thread::sleep_for(std::chrono::seconds(1));
}
```

If `T` is injected during the sleep, the callback will be invoked and the injecting thread will block on the lock acquisition attempt.  The sleeping thread wakes up, and tries to destroy `ptr`.  This causes `DeferrableAutowiring::~DeferrableAutowiring()` to be called.

1.  If this destructor blocks until all registered handlers have been cancelled, a deadlock results.
2.  If it cancels on a best-effort basis, a potential use-after-free results.

The only solution is to require that users externally synchronize `Autowired::~Autowired` with `CoreContext::Inject`.