### PR TITLE
Refactor and extend the autowiring::once type

### DIFF
--- a/autowiring/auto_signal.h
+++ b/autowiring/auto_signal.h
@@ -6,6 +6,7 @@
 #include "Decompose.h"
 #include "index_tuple.h"
 #include "noop.h"
+#include "registration.h"
 #include "signal_base.h"
 #include "spin_lock.h"
 #include <atomic>
@@ -22,8 +23,6 @@
 namespace autowiring {
   template<typename T>
   struct signal;
-
-  struct registration_t;
 
   namespace detail {
     // Holds true if type T can be copied safely
@@ -78,37 +77,6 @@ namespace autowiring {
       const T& operator*(void) const { return val; }
     };
   }
-
-  struct registration_t {
-    registration_t(void) = default;
-
-    registration_t(signal_base* owner, void* pobj) :
-      owner(owner),
-      pobj(pobj)
-    {}
-
-    registration_t(registration_t&& rhs) :
-      owner(rhs.owner),
-      pobj(rhs.pobj)
-    {
-      rhs.pobj = nullptr;
-    }
-
-    registration_t(const registration_t& rhs) = delete;
-
-    signal_base* owner;
-    void* pobj;
-
-    bool operator==(const registration_t& rhs) const { return pobj == rhs.pobj; }
-
-    void operator=(registration_t&& rhs) {
-      owner = rhs.owner;
-      pobj = rhs.pobj;
-      rhs.pobj = nullptr;
-    }
-
-    operator bool(void) const { return pobj != nullptr; }
-  };
 
   // Current state of the signal, used as a type of lock.
   enum class SignalState {

--- a/autowiring/auto_signal.h
+++ b/autowiring/auto_signal.h
@@ -6,6 +6,7 @@
 #include "Decompose.h"
 #include "index_tuple.h"
 #include "noop.h"
+#include "signal_base.h"
 #include "spin_lock.h"
 #include <atomic>
 #include <functional>
@@ -77,17 +78,6 @@ namespace autowiring {
       const T& operator*(void) const { return val; }
     };
   }
-
-  struct signal_base {
-    /// <summary>
-    /// Removes the signal node identified on the rhs without requiring full type information
-    /// </summary>
-    /// <remarks>
-    /// This operation invalidates the specified unique pointer.  If the passed unique pointer is
-    /// already nullptr, this operation has no effect.
-    /// </remarks>
-    virtual void operator-=(registration_t& rhs) = 0;
-  };
 
   struct registration_t {
     registration_t(void) = default;

--- a/autowiring/auto_signal.h
+++ b/autowiring/auto_signal.h
@@ -2,6 +2,7 @@
 #pragma once
 #include "auto_tuple.h"
 #include "autowiring_error.h"
+#include "callable.h"
 #include "Decompose.h"
 #include "index_tuple.h"
 #include "noop.h"
@@ -74,22 +75,6 @@ namespace autowiring {
       dereferencer(const T& val) : val(val) {}
       T val;
       const T& operator*(void) const { return val; }
-    };
-
-    // Callable wrapper type, always invoked in a synchronized context
-    struct callable_base {
-      virtual ~callable_base(void) {}
-      virtual void operator()() = 0;
-      callable_base* m_pFlink = nullptr;
-    };
-
-    template<typename Fn>
-    struct callable :
-      callable_base
-    {
-      callable(Fn&& fn) : fn(std::move(fn)) {}
-      Fn fn;
-      void operator()() override { fn(); }
     };
   }
 

--- a/autowiring/callable.h
+++ b/autowiring/callable.h
@@ -1,0 +1,22 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+
+namespace autowiring {
+  namespace detail {
+    // Callable wrapper type, always invoked in a synchronized context
+    struct callable_base {
+      virtual ~callable_base(void) {}
+      virtual void operator()() = 0;
+      callable_base* m_pFlink = nullptr;
+    };
+
+    template<typename Fn>
+    struct callable :
+      callable_base
+    {
+      callable(Fn&& fn) : fn(std::move(fn)) {}
+      Fn fn;
+      void operator()() override { fn(); }
+    };
+  }
+}

--- a/autowiring/once.h
+++ b/autowiring/once.h
@@ -29,8 +29,32 @@ namespace autowiring {
   /// Implements an observable boolean variable that can only be set to true once
   /// </summary>
   /// <remarks>
-  /// There are many one-way state transitions in Autowiring which may require that
-  /// specific 
+  /// There are many one-way state transitions in Autowiring which much implement the
+  /// observable pattern.  Uers should be able to register a callback that will be
+  /// invoked when a state transition occurs.  If the state transition has already
+  /// occurred, then the callback must be made immediately.
+  ///
+  /// Once the state transition takes place, this type releases all memory associated
+  /// with registered callbacks.
+  ///
+  /// There are a few thread contexts from which the callback may be made:
+  ///
+  /// 1. If the signal is already set, the callback is made immediately in the current
+  ///    thread context.
+  /// 2. If the signal has not yet been set, the callback is registered to be executed
+  ///    later.  The callback will be invoked from the thread that eventually sets the
+  ///    flag.
+  ///
+  /// If a callback is being registered at about the same time as the flag is being
+  /// set, there is an ambiguity as to who will be responsible for making the call,
+  /// but that ambiguity will always be resolved and the callback will be invoked at
+  /// some point.
+  ///
+  /// There are no sequentiality or concurrency guarantees made with respect to
+  /// registered listeners.  The last registered listener could potentially be the
+  /// first one invoked, and may be executed concurrently with any other listener.
+  /// This behavior represents a substantial departure from the behavior of the plain
+  /// autowiring signal datatype.
   /// </remarks>
   struct once
   {

--- a/autowiring/once.h
+++ b/autowiring/once.h
@@ -41,6 +41,11 @@ namespace autowiring {
   struct once :
     signal_base
   {
+  public:
+    once(void) = default;
+    once(const once& rhs) = delete;
+    once(once&& rhs);
+
   protected:
     bool flag = false;
     autowiring::spin_lock m_spin;

--- a/autowiring/once.h
+++ b/autowiring/once.h
@@ -47,6 +47,9 @@ namespace autowiring {
     std::vector<std::unique_ptr<detail::callable_base>> m_fns;
 
   public:
+    // Getter methods:
+    bool get(void) const { return flag; }
+
     template<typename Fn>
     registration_t operator+=(Fn&& rhs) {
       // Initial check of the flag, we don't even want to bother with the rest
@@ -80,6 +83,11 @@ namespace autowiring {
 
     // Unlink function
     void operator-=(registration_t& rhs) override final;
+
+    /// <returns>
+    /// True if the flag has been set
+    /// </returns>
+    operator bool(void) const { return flag; }
 
     /// <summary>
     /// Sets the control flag

--- a/autowiring/registration.h
+++ b/autowiring/registration.h
@@ -20,8 +20,8 @@ namespace autowiring {
 
     registration_t(const registration_t& rhs) = delete;
 
-    signal_base* owner;
-    void* pobj;
+    signal_base* owner = nullptr;
+    void* pobj = nullptr;
 
     bool operator==(const registration_t& rhs) const { return pobj == rhs.pobj; }
 

--- a/autowiring/registration.h
+++ b/autowiring/registration.h
@@ -1,0 +1,36 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "signal_base.h"
+
+namespace autowiring {
+  struct registration_t {
+    registration_t(void) = default;
+
+    registration_t(signal_base* owner, void* pobj) :
+      owner(owner),
+      pobj(pobj)
+    {}
+
+    registration_t(registration_t&& rhs) :
+      owner(rhs.owner),
+      pobj(rhs.pobj)
+    {
+      rhs.pobj = nullptr;
+    }
+
+    registration_t(const registration_t& rhs) = delete;
+
+    signal_base* owner;
+    void* pobj;
+
+    bool operator==(const registration_t& rhs) const { return pobj == rhs.pobj; }
+
+    void operator=(registration_t&& rhs) {
+      owner = rhs.owner;
+      pobj = rhs.pobj;
+      rhs.pobj = nullptr;
+    }
+
+    operator bool(void) const { return pobj != nullptr; }
+  };
+}

--- a/autowiring/signal_base.h
+++ b/autowiring/signal_base.h
@@ -5,6 +5,8 @@ namespace autowiring {
   struct registration_t;
 
   struct signal_base {
+    virtual ~signal_base(void) {}
+
     /// <summary>
     /// Removes the signal node identified on the rhs without requiring full type information
     /// </summary>

--- a/autowiring/signal_base.h
+++ b/autowiring/signal_base.h
@@ -1,0 +1,17 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+
+namespace autowiring {
+  struct registration_t;
+
+  struct signal_base {
+    /// <summary>
+    /// Removes the signal node identified on the rhs without requiring full type information
+    /// </summary>
+    /// <remarks>
+    /// This operation invalidates the specified unique pointer.  If the passed unique pointer is
+    /// already nullptr, this operation has no effect.
+    /// </remarks>
+    virtual void operator-=(registration_t& rhs) = 0;
+  };
+}

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -143,6 +143,7 @@ set(Autowiring_SRCS
   once.cpp
   Parallel.h
   Parallel.cpp
+  registration.h
   SatCounter.h
   SatCounter.cpp
   signal_base.h

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -64,6 +64,7 @@ set(Autowiring_SRCS
   Bolt.h
   BoltBase.cpp
   BoltBase.h
+  callable.h
   CallExtractor.h
   CallExtractor.cpp
   ContextEnumerator.cpp
@@ -79,6 +80,7 @@ set(Autowiring_SRCS
   CoreJob.h
   CoreObject.cpp
   CoreObject.h
+  CoreObjectDescriptor.h
   CoreRunnable.cpp
   CoreRunnable.h
   CoreThread.cpp
@@ -141,7 +143,6 @@ set(Autowiring_SRCS
   once.cpp
   Parallel.h
   Parallel.cpp
-  CoreObjectDescriptor.h
   SatCounter.h
   SatCounter.cpp
   SlotInformation.cpp

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -145,6 +145,7 @@ set(Autowiring_SRCS
   Parallel.cpp
   SatCounter.h
   SatCounter.cpp
+  signal_base.h
   SlotInformation.cpp
   SlotInformation.h
   spin_lock.h

--- a/src/autowiring/once.cpp
+++ b/src/autowiring/once.cpp
@@ -4,6 +4,25 @@
 
 using namespace autowiring;
 
+void once::operator-=(registration_t& rhs) {
+  // No unregistration supported after the flag is set--we assume a cancellation race
+  if (flag)
+    return;
+
+  // Double-check under lock
+  std::lock_guard<autowiring::spin_lock> lk(m_spin);
+  if (flag)
+    return;
+
+  for (size_t i = 0; i < m_fns.size(); i++)
+    if (m_fns[i].get() == rhs.pobj) {
+      m_fns[i] = std::move(m_fns.back());
+      m_fns.pop_back();
+      return;
+    }
+  throw std::runtime_error("Attempted to unregister a once signal that was not created on this object.");
+}
+
 void once::signal(void) {
   // Standard lock double-check
   if (flag)

--- a/src/autowiring/once.cpp
+++ b/src/autowiring/once.cpp
@@ -4,6 +4,13 @@
 
 using namespace autowiring;
 
+once::once(once&& rhs) :
+  flag(rhs.flag),
+  m_fns(std::move(rhs.m_fns))
+{
+  rhs.m_fns.clear();
+}
+
 void once::operator-=(registration_t& rhs) {
   // No unregistration supported after the flag is set--we assume a cancellation race
   if (flag)

--- a/src/autowiring/once.cpp
+++ b/src/autowiring/once.cpp
@@ -9,7 +9,7 @@ void once::signal(void) {
   if (flag)
     return;
 
-  std::vector<std::unique_ptr<detail::once_fn>> fns;
+  std::vector<std::unique_ptr<detail::callable_base>> fns;
   {
     std::lock_guard<autowiring::spin_lock> lk(m_spin);
     if (flag)

--- a/src/autowiring/test/OnceTest.cpp
+++ b/src/autowiring/test/OnceTest.cpp
@@ -78,6 +78,14 @@ public:
   }
 };
 
+TEST(OnceTest, SignalSetWhileCalling) {
+  autowiring::once sig;
+  sig += [&] {
+    ASSERT_TRUE(sig) << "Flag was not set while handler was being invoked";
+  };
+  sig = true;
+}
+
 TEST(OnceTest, OwnedSignal) {
   PrivateSignal priv;
 

--- a/src/autowiring/test/OnceTest.cpp
+++ b/src/autowiring/test/OnceTest.cpp
@@ -86,3 +86,15 @@ TEST(OnceTest, OwnedSignal) {
   priv.signal();
   ASSERT_TRUE(hit) << "Private signal did not get set as expected";
 }
+
+TEST(OnceTest, UnregisterHandler) {
+  autowiring::once sig;
+
+  bool hit = false;
+  auto reg = sig += [&hit] {
+    hit = true;
+  };
+  sig -= reg;
+  sig();
+  ASSERT_FALSE(hit) << "Handler not unregistered as expected";
+}


### PR DESCRIPTION
Eliminate some redundant types and also support unregistration in `autowiring::once`.