### PR TITLE
Tighten move behavior for AnySharedPointer

### DIFF
--- a/autowiring/AnySharedPointer.h
+++ b/autowiring/AnySharedPointer.h
@@ -98,6 +98,12 @@ public:
   bool operator<(const AnySharedPointer& rhs) const { return m_ptr < rhs.m_ptr;}
   bool operator!=(const AnySharedPointer& rhs) const { return !(*this == rhs); }
 
+  void operator=(AnySharedPointer&& rhs) {
+    m_ti = rhs.m_ti;
+    m_ptr = std::move(rhs.m_ptr);
+    rhs.m_ptr.reset();
+  }
+
   void operator=(const AnySharedPointer& rhs) {
     m_ti = rhs.m_ti;
     m_ptr = rhs.m_ptr;

--- a/src/autowiring/test/AnySharedPointerTest.cpp
+++ b/src/autowiring/test/AnySharedPointerTest.cpp
@@ -241,3 +241,13 @@ TEST_F(AnySharedPointerTest, CanCrossCast) {
   ASSERT_EQ(102, bASP.as<AnySharedPtrObjB>()->bVal);
   ASSERT_EQ(aASP, bASP) << "An aliased shared pointer was not detected as being equal";
 }
+
+TEST_F(AnySharedPointerTest, NullAfterMove) {
+  auto ptr = std::make_shared<bool>(false);
+  AnySharedPointer p1 = ptr;
+  AnySharedPointer p2 = std::move(p1);
+  ASSERT_FALSE(p1) << "Move construction of AnySharedPointer did not nullify rhs";
+  AnySharedPointer p3;
+  p3 = std::move(p2);
+  ASSERT_FALSE(p2) << "Move assignment of AnySharedPointer did not nullify rhs";
+}


### PR DESCRIPTION
Also add a test here.  We'd like move operations on this type to be as efficient as possible.