### PR TITLE
Extend signal_base contract

### DIFF
--- a/autowiring/signal_base.h
+++ b/autowiring/signal_base.h
@@ -7,13 +7,26 @@ namespace autowiring {
   struct signal_base {
     virtual ~signal_base(void) {}
 
+    /// <returns>
+    /// True if signal handlers are presently being invoked
+    /// </returns>
+    virtual bool is_executing(void) const = 0;
+
     /// <summary>
     /// Removes the signal node identified on the rhs without requiring full type information
     /// </summary>
+    /// <returns>
+    /// True if the registration could be removed, false if the request could not be completed
+    /// before the function returned control.
+    /// </returns>
     /// <remarks>
+    /// Regardless of the return code, this routine guarantees that the specified registration will
+    /// _eventually_ be removed from the signal, provided that the application is free from
+    /// deadlocks and the argument is valid.
+    ///
     /// This operation invalidates the specified unique pointer.  If the passed unique pointer is
     /// already nullptr, this operation has no effect.
     /// </remarks>
-    virtual void operator-=(registration_t& rhs) = 0;
+    virtual bool operator-=(registration_t& rhs) = 0;
   };
 }

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -852,7 +852,7 @@ void CoreContext::UpdateDeferredElement(std::unique_lock<std::mutex>&& lk, MemoE
 
 void CoreContext::UpdateDeferredElements(std::unique_lock<std::mutex>&& lk, const CoreObjectDescriptor& entry, bool local) {
   {
-    std::vector<MemoEntry *> entries;
+    std::vector<MemoEntry*> entries;
 
     // Notify any autowired field whose autowiring was deferred.  We do this by processing each entry
     // in the entire type memos collection.


### PR DESCRIPTION
This is intended to allow callers to have at least some options when dealing with circumstances where listener unregistration fails in the short run.

Spinning is inefficient, but sometimes the only option.