### PR TITLE
General test performance enhancement

### DIFF
--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -421,7 +421,6 @@ public:
 
   Deferred AutoFilter(std::shared_ptr<const int>) {
     callCount++;
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
     return Deferred(this);
   }
 };
@@ -635,7 +634,7 @@ TEST_F(AutoFilterTest, WaitWhilePacketOutstanding) {
 
   AutoCurrentContext ctxt;
   ctxt->SignalShutdown();
-  ASSERT_FALSE(ctxt->Wait(std::chrono::milliseconds(100))) << "Wait incorrectly returned while packets were outstanding";
+  ASSERT_FALSE(ctxt->Wait(std::chrono::milliseconds(1))) << "Wait incorrectly returned while packets were outstanding";
   packet.reset();
   ASSERT_TRUE(ctxt->Wait(std::chrono::milliseconds(1))) << "Wait incorrectly timed out when nothing should have been running";
 }

--- a/src/autowiring/test/AutowiringUtilitiesTest.cpp
+++ b/src/autowiring/test/AutowiringUtilitiesTest.cpp
@@ -44,8 +44,10 @@ TEST_F(AutowiringUtilitiesTest, ThreadSpecificPtr) {
   
   ctxt->Initiate();
   
-  std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  
-  ASSERT_EQ(5, *s_thread_specific_int);
-  AutoCurrentContext()->SignalShutdown(true);
+  auto limit = std::chrono::high_resolution_clock::now() + std::chrono::seconds(10);
+  while(std::chrono::high_resolution_clock::now() < limit)
+    if(5 == *s_thread_specific_int)
+      return;
+ 
+  FAIL() << "Thread specific pointer did not increment to the destination value in a timely fashion";
 }

--- a/src/autowiring/test/ContextCleanupTest.cpp
+++ b/src/autowiring/test/ContextCleanupTest.cpp
@@ -144,7 +144,7 @@ TEST_F(ContextCleanupTest, VerifyGracefulThreadCleanup) {
   // Just create a CoreThread directly and have it pend some lambdas that will take awhile to run:
   auto called = std::make_shared<bool>(false);
   *ct += [] {
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   };
   *ct += [called] { *called = true; };
 
@@ -163,7 +163,7 @@ TEST_F(ContextCleanupTest, VerifyImmediateThreadCleanup) {
   // Just create a CoreThread directly and have it pend some lambdas that will take awhile to run:
   auto called = std::make_shared<bool>(false);
   *ct += [] {
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   };
 
   // Pend another lambda which will wait longer, for systems which will not complete SignalTerminate in 100ms

--- a/src/autowiring/test/CoreJobTest.cpp
+++ b/src/autowiring/test/CoreJobTest.cpp
@@ -68,16 +68,16 @@ TEST_F(CoreJobTest, VerifyTeardown) {
   bool check3 = false;
 
   *job += [&check1] {
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
     check1 = true;
   };
   *job += [&check2] {
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
     check2 = true;
   };
   ctxt->Initiate();
   *job += [&check3] {
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
     check3 = true;
   };
 

--- a/src/autowiring/test/CoreThreadTest.cpp
+++ b/src/autowiring/test/CoreThreadTest.cpp
@@ -275,7 +275,7 @@ TEST_F(CoreThreadTest, VerifyTimedSort) {
   // To doubly verify this property, we don't trivially increment i from the minimum to the
   // maximum--rather, we use a simple PRNG called a linear congruential generator and hop around
   // the interval [1...12] instead.
-  auto base = std::chrono::high_resolution_clock::now();
+  auto base = std::chrono::steady_clock::now();
   for(size_t i = 1; i != 0; i = (i * 5 + 1) % 16)
     *t += (base + std::chrono::microseconds(i * 3)), [&v, i] { v.push_back(i); };
 

--- a/src/autowiring/test/EventReceiverTest.cpp
+++ b/src/autowiring/test/EventReceiverTest.cpp
@@ -272,14 +272,14 @@ TEST_F(EventReceiverTest, PathologicalChildContextTest) {
   AutoRequired<FiresManyEventsWhenRun> jammer;
 
   // This by itself is sufficient to cause problems:
-  for(size_t i = 0; i < 500; i++) {
+  for(size_t i = 0; i < 50; i++) {
     AutoCreateContext subCtxt;
     CurrentContextPusher pshr(subCtxt);
     AutoRequired<SimpleReceiver> recvr;
   }
 
   // Spin until the jammer has transmitted a thousand messages:
-  while(jammer->totalXmit < 1000);
+  while(jammer->totalXmit < 100);
   jammer->Stop();
   jammer->Wait();
 

--- a/src/autowiring/test/ObjectPoolTest.cpp
+++ b/src/autowiring/test/ObjectPoolTest.cpp
@@ -227,7 +227,7 @@ public:
   std::shared_ptr<int> m_ptr;
 
   void Run(void) override {
-    ThreadSleep(std::chrono::milliseconds(100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
     m_ptr.reset();
   }
 };
@@ -341,7 +341,7 @@ TEST_F(ObjectPoolTest, MovableObjectPool) {
 }
 
 TEST_F(ObjectPoolTest, MovableObjectPoolAysnc) {
-  static const size_t s_count = 10000;
+  static const size_t s_count = 1000;
   ObjectPool<int> from;
 
   {

--- a/src/autowiring/test/ParallelTest.cpp
+++ b/src/autowiring/test/ParallelTest.cpp
@@ -20,7 +20,7 @@ TEST_F(ParallelTest, Basic) {
   for (int i : {0,4,2,5,1,3}) {
     int sleepTime = dist(mt);
     p += [i, sleepTime] {
-      std::this_thread::sleep_for(sleepTime*std::chrono::milliseconds(1));
+      std::this_thread::sleep_for(sleepTime*std::chrono::microseconds(1));
       return i;
     };
   }


### PR DESCRIPTION
Cut down on some unnecessarily long sleeps wherever possible.  This cuts the total unit test execution time down by about 50%.

|          | Debug    | Release  |
| -------- | -------- | -------- |
| Original | 4936 ms  | 3248 ms  |
| Current  | 2439 ms  | 1699 ms  |