### PR TITLE
Fix annoying Mac linker warnings

### DIFF
--- a/autowiring/AutoPacketFactory.h
+++ b/autowiring/AutoPacketFactory.h
@@ -239,4 +239,9 @@ extern template std::shared_ptr<AutoPacketFactory> autowiring::fast_pointer_cast
 extern template class RegType<AutoPacketFactory>;
 extern template struct autowiring::fast_pointer_cast_blind<CoreObject, AutoPacketFactory>;
 extern template struct autowiring::fast_pointer_cast_initializer<CoreObject, AutoPacketFactory>;
+extern template struct autowiring::fast_pointer_cast_blind<AutoPacketFactory, CoreObject>;
+extern template struct autowiring::fast_pointer_cast_initializer<AutoPacketFactory, CoreObject>;
+extern template struct auto_id_t<AutoPacketFactory>;
+extern template class auto_id_t_init<AutoPacketFactory, false>;
+extern template class auto_id_t_init<AutoPacketFactory, true>;
 // @endcond

--- a/autowiring/auto_id.h
+++ b/autowiring/auto_id.h
@@ -36,8 +36,8 @@ namespace autowiring {
       pFromObj(NullFromObj)
     {}
 
-    static std::shared_ptr<CoreObject> NullToObj(const std::shared_ptr<void>&) { return nullptr; }
-    static std::shared_ptr<void> NullFromObj(const std::shared_ptr<CoreObject>&) { return nullptr; }
+    static std::shared_ptr<CoreObject> NullToObj(const std::shared_ptr<void>&);
+    static std::shared_ptr<void> NullFromObj(const std::shared_ptr<CoreObject>&);
 
     template<class T>
     auto_id_block(

--- a/src/autowiring/AutoPacketFactory.cpp
+++ b/src/autowiring/AutoPacketFactory.cpp
@@ -212,3 +212,8 @@ template std::shared_ptr<AutoPacketFactory> autowiring::fast_pointer_cast<AutoPa
 template class RegType<AutoPacketFactory>;
 template struct autowiring::fast_pointer_cast_blind<CoreObject, AutoPacketFactory>;
 template struct autowiring::fast_pointer_cast_initializer<CoreObject, AutoPacketFactory>;
+template struct autowiring::fast_pointer_cast_blind<AutoPacketFactory, CoreObject>;
+template struct autowiring::fast_pointer_cast_initializer<AutoPacketFactory, CoreObject>;
+template struct auto_id_t<AutoPacketFactory>;
+template class auto_id_t_init<AutoPacketFactory, false>;
+template class auto_id_t_init<AutoPacketFactory, true>;

--- a/src/autowiring/auto_id.cpp
+++ b/src/autowiring/auto_id.cpp
@@ -9,3 +9,13 @@ const autowiring::auto_id_block auto_id_t<void>::s_block{};
 int autowiring::CreateIndex(void) {
   return s_index++;
 }
+
+std::shared_ptr<CoreObject> autowiring::auto_id_block::NullToObj(const std::shared_ptr<void>&)
+{
+  return nullptr;
+}
+
+std::shared_ptr<void> autowiring::auto_id_block::NullFromObj(const std::shared_ptr<CoreObject>&)
+{
+  return nullptr;
+}


### PR DESCRIPTION
These are happening because some template instantiations were not properly declared, fix them up.