### PR TITLE
Fix busted FindByType override

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -629,6 +629,13 @@ public:
   /// <param name="nonrecursive">False if ancestor contexts should not be searched</param>
   MemoEntry& FindByType(auto_id type, bool nonrecursive = false) const;
 
+  template<typename T>
+  MemoEntry& FindByType(std::shared_ptr<T>& ptr, bool nonrecursive = false) const {
+    auto& retVal = FindByType(auto_id_t<T>{}, nonrecursive);
+    ptr = retVal.m_value.template as<T>();
+    return retVal;
+  }
+
   /// <summary>
   /// Injects the specified types into this context.
   /// </summary>

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -580,3 +580,11 @@ TEST_F(CoreContextTest, Has) {
   ASSERT_TRUE(ctxt->Has<SimpleObject>()) << "Context failed to detect an extant type";
   ASSERT_TRUE(subCtxt->Has<SimpleObject>()) << "Child context failed to detect an extant type";
 }
+
+TEST_F(CoreContextTest, FindByTypeTest) {
+  AutoCurrentContext ctxt;
+
+  std::shared_ptr<SimpleObject> so;
+  ctxt->FindByType(so);
+  ASSERT_FALSE(so) << "Found a type in a context that should not exist";
+}


### PR DESCRIPTION
This method got broken in #796, correct the problem and improve test coverage.