### PR TITLE
Add volatile keywords to single-value accessors

### DIFF
--- a/autowiring/CoreRunnable.h
+++ b/autowiring/CoreRunnable.h
@@ -82,11 +82,11 @@ protected:
 public:
   // Accessor methods:
   /// Reports whether this runnable is currently running.
-  bool IsRunning(void) const { return (bool)m_outstanding; }
+  bool IsRunning(void) const;
   /// Reports whether this runnable was ever started.
-  bool WasStarted(void) const { return m_wasStarted; }
+  bool WasStarted(void) volatile const { return m_wasStarted; }
   /// Reports whether this runnable should stop.
-  bool ShouldStop(void) const { return m_shouldStop; }
+  bool ShouldStop(void) volatile const { return m_shouldStop; }
 
   /// <summary>
   /// Causes this runnable to begin processing.

--- a/src/autowiring/CoreRunnable.cpp
+++ b/src/autowiring/CoreRunnable.cpp
@@ -9,6 +9,10 @@ template<> bool CoreRunnable::WaitUntil(std::chrono::system_clock::time_point);
 CoreRunnable::CoreRunnable(void) {}
 CoreRunnable::~CoreRunnable(void) {}
 
+bool CoreRunnable::IsRunning(void) const {
+  return (bool)m_outstanding;
+}
+
 const std::shared_ptr<CoreObject>& CoreRunnable::GetOutstanding(void) const {
   return m_outstanding;
 }

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -557,7 +557,8 @@ namespace {
     {}
 
     void Run(void) override {
-      while (!ShouldStop());
+      while (!ShouldStop())
+        std::this_thread::yield();
       AutoCreateContext();
     }
   };


### PR DESCRIPTION
Required because of the way the compiler will try to optimize these calls if it thinks these members are accessing nonvolatile values.  Also synchronize access to `IsRunning`, we have to do this because the underlying type does not support `volatile` access.