### PR TITLE
Allow tests to be repeated

### DIFF
--- a/src/autowiring/test/AutoPacketTest.cpp
+++ b/src/autowiring/test/AutoPacketTest.cpp
@@ -222,6 +222,8 @@ namespace {
 }
 
 TEST_F(AutoPacketTest, NoUnneededOutputCopy) {
+  CountsCopies::s_nConstructions = 0;
+
   AutoRequired<AutoPacketFactory> factory;
   auto packet = factory->NewPacket();
 

--- a/src/autowiring/test/TupleTest.cpp
+++ b/src/autowiring/test/TupleTest.cpp
@@ -75,6 +75,8 @@ namespace {
 }
 
 TEST_F(TupleTest, NoUnneededCopies) {
+  CountsCopies::nCopies = 0;
+
   CountsCopies isCopied;
   autowiring::tuple<CountsCopies> nCopies(isCopied);
 


### PR DESCRIPTION
There are some statics that aren't being reset between test runs, this is preventing `--gtest-repeat` from giving reliable values.  Reset them.