### PR TITLE
More volatile keyword fixes

### DIFF
--- a/autowiring/auto_signal.h
+++ b/autowiring/auto_signal.h
@@ -181,8 +181,8 @@ namespace autowiring {
     };
 
     // Doubly linked list of all of our listeners
-    entry_base* m_pFirstListener = nullptr;
-    entry_base* m_pLastListener = nullptr;
+    entry_base* volatile m_pFirstListener = nullptr;
+    entry_base* volatile m_pLastListener = nullptr;
 
     // Calls that had to be delayed due to asynchronous issues
     mutable std::atomic<detail::callable_base*> m_pFirstDelayedCall{ nullptr };


### PR DESCRIPTION
If we don't mark these volatile, then the dispatcher loop will attempt to cache the value of `m_pFirstListener`, which could potentially be invalid in the second pass where the value is considered.