### PR TITLE
Split out atomic linked list behaviors into their own datatype

### DIFF
--- a/autowiring/atomic_list.h
+++ b/autowiring/atomic_list.h
@@ -1,0 +1,170 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include <atomic>
+
+namespace autowiring {
+  template<typename T>
+  struct atomic_list {
+  public:
+    ~atomic_list(void) {
+      entry* next;
+      for (entry* cur = m_pHead.load(std::memory_order_relaxed); cur; cur = next) {
+        next = cur->pFlink;
+        delete cur;
+      }
+    }
+
+    struct entry {
+      entry(void) = default;
+      entry(const T& value) :
+        value(value)
+      {}
+      entry(T&& value) :
+        value(std::move(value))
+      {}
+
+      entry* pFlink = nullptr;
+      T value;
+    };
+
+  private:
+    // First entry in the atomic list
+    std::atomic<entry*> m_pHead{ nullptr };
+
+    // Current chain identifier
+    std::atomic<uint32_t> m_chainID{ 0 };
+
+  public:
+    /// <returns>
+    /// The current chain identifier
+    /// </returns>
+    /// <remarks>
+    /// No guarantee is made about how long the returned value will be valid.  Calls to
+    /// `release` will change the returned value.
+    /// </remarks>
+    uint32_t chain_id(void) volatile const throw() { return m_chainID.load(std::memory_order_relaxed); }
+
+    /// <summary>
+    /// Adds the already-constructed entry to the ist
+    /// </summary>
+    uint32_t push(entry* e) throw() {
+      entry* pHead;
+      uint32_t retVal;
+      do {
+        pHead = m_pHead.load(std::memory_order_acquire);
+        retVal = m_chainID.load(std::memory_order_relaxed);
+        e->pFlink = pHead;
+      } while (
+        !m_pHead.compare_exchange_weak(
+          pHead,
+          e,
+          std::memory_order_release,
+          std::memory_order_relaxed
+        )
+      );
+      return retVal;
+    }
+
+    uint32_t push(T&& rhs) { return push(new entry(std::move(rhs))); }
+    uint32_t push(const T& rhs) { return push(new entry(rhs)); }
+
+    /// <summary>
+    /// Represents a single chain of elements added to the list
+    /// </summary>
+    struct chain {
+      chain(const chain&) = delete;
+      chain(chain&& rhs) :
+        head(rhs.head)
+      {
+        rhs.head = nullptr;
+      }
+
+      chain(entry* head) :
+        head(head)
+      {}
+      ~chain(void) {
+        // Deletion convenience:
+        for(auto& x : *this) {}
+      }
+
+      struct end_iterator;
+
+      struct iterator {
+        iterator(void) = default;
+        iterator(entry*& e) :
+          e(e)
+        {}
+
+        typedef std::input_iterator_tag iterator_category;
+        typedef T value_type;
+        typedef size_t difference_type;
+        typedef const T* pointer;
+        typedef value_type reference;
+
+      private:
+        entry*& e;
+
+      public:
+        iterator& operator++(int) = delete;
+
+        iterator& operator++(void) {
+          auto prior = e;
+          e = e->pFlink;
+          delete prior;
+          return *this;
+        }
+
+        T& operator*(void) const { return e->value; }
+        T* operator->(void) const { return &e->value; }
+        bool operator==(const iterator& rhs) const { return e == rhs.e; }
+        bool operator!=(const iterator& rhs) const { return e != rhs.e; }
+        bool operator==(const end_iterator& rhs) const { return !e; }
+        bool operator!=(const end_iterator& rhs) const { return !!e; }
+      };
+
+    private:
+      entry* head = nullptr;
+
+    public:
+      iterator begin(void) {
+        return{ head };
+      }
+
+      iterator end(void) {
+        static entry* np = nullptr;
+        return{ np };
+      }
+
+      chain& operator=(const chain& rhs) = delete;
+      chain& operator=(chain&& rhs) {
+        std::swap(head, rhs.head);
+        return *this;
+      }
+    };
+
+    /// <summary>
+    /// Retrieves a list of entries in the order of insertion
+    /// </summary>
+    /// <remarks>
+    /// The caller is responsible for freeing the returned entry
+    /// </remarks>
+    chain release(void) throw() {
+      entry* head = m_pHead.load(std::memory_order_relaxed);
+      do m_chainID.fetch_add(1, std::memory_order_acq_rel);
+      while (
+        !m_pHead.compare_exchange_weak(
+          head,
+          nullptr,
+          std::memory_order_release,
+          std::memory_order_relaxed
+        )
+      );
+      
+      // Take ownership of the dispatcher list and reverse this forward-linked list.
+      entry* lastLink = nullptr;
+      for (; head; std::swap(head, lastLink))
+        std::swap(lastLink, head->pFlink);
+      return lastLink;
+    }
+  };
+}

--- a/autowiring/atomic_list.h
+++ b/autowiring/atomic_list.h
@@ -6,6 +6,9 @@ namespace autowiring {
   template<typename T>
   struct atomic_list {
   public:
+    atomic_list(void) = default;
+    atomic_list(const atomic_list&) = delete;
+
     ~atomic_list(void) {
       entry* next;
       for (entry* cur = m_pHead.load(std::memory_order_relaxed); cur; cur = next) {
@@ -164,7 +167,7 @@ namespace autowiring {
       entry* lastLink = nullptr;
       for (; head; std::swap(head, lastLink))
         std::swap(lastLink, head->pFlink);
-      return lastLink;
+      return { lastLink };
     }
   };
 }

--- a/autowiring/atomic_list.h
+++ b/autowiring/atomic_list.h
@@ -140,7 +140,7 @@ namespace autowiring {
     /// The caller is responsible for freeing the returned entry
     /// </remarks>
     template<typename T>
-    chain<T> release(void) throw() {
+    chain<T> release(void) volatile throw() {
       static_assert(std::is_base_of<callable_base, T>::value, "Can only obtain chains of types that inherit from callable_base");
 
       callable_base* head = m_pHead.load(std::memory_order_relaxed);

--- a/autowiring/callable.h
+++ b/autowiring/callable.h
@@ -1,22 +1,21 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include <memory>
 
 namespace autowiring {
-  namespace detail {
-    // Callable wrapper type, always invoked in a synchronized context
-    struct callable_base {
-      virtual ~callable_base(void) {}
-      virtual void operator()() = 0;
-      callable_base* m_pFlink = nullptr;
-    };
+  // Callable wrapper type, always invoked in a synchronized context
+  struct callable_base {
+    virtual ~callable_base(void) {}
+    virtual void operator()() {}
+    callable_base* m_pFlink = nullptr;
+  };
 
-    template<typename Fn>
-    struct callable :
-      callable_base
-    {
-      callable(Fn&& fn) : fn(std::move(fn)) {}
-      Fn fn;
-      void operator()() override { fn(); }
-    };
-  }
+  template<typename Fn>
+  struct callable :
+    callable_base
+  {
+    callable(Fn&& fn) : fn(std::move(fn)) {}
+    Fn fn;
+    void operator()() override { fn(); }
+  };
 }

--- a/autowiring/once.h
+++ b/autowiring/once.h
@@ -60,7 +60,7 @@ namespace autowiring {
   protected:
     state m_state = state::unsignalled;
     autowiring::spin_lock m_spin;
-    std::vector<std::unique_ptr<detail::callable_base>> m_fns;
+    std::vector<std::unique_ptr<callable_base>> m_fns;
 
   public:
     // Getter methods:
@@ -78,8 +78,8 @@ namespace autowiring {
 
       // Move the lambda into our unique pointer outside of the lock to reduce
       // total contention time
-      std::unique_ptr<detail::callable<Fn>> fn{
-        new detail::callable<Fn>{ std::forward<Fn&&>(rhs) }
+      std::unique_ptr<callable<Fn>> fn{
+        new callable<Fn>{ std::forward<Fn&&>(rhs) }
       };
 
       // Double-check the flag under lock:

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -15,6 +15,7 @@ set(Autowiring_SRCS
   atomic_object.h
   at_exit.h
   altitude.h
+  atomic_list.h
   auto_arg.h
   auto_arg.cpp
   auto_id.h

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -12,10 +12,11 @@ add_subdirectory(benchmark)
 set(Autowiring_SRCS
   AnySharedPointer.cpp
   AnySharedPointer.h
+  atomic_list.h
+  atomic_list.cpp
   atomic_object.h
   at_exit.h
   altitude.h
-  atomic_list.h
   auto_arg.h
   auto_arg.cpp
   auto_id.h

--- a/src/autowiring/atomic_list.cpp
+++ b/src/autowiring/atomic_list.cpp
@@ -1,32 +1,46 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "atomic_list.h"
+#include <mutex>
 
 using autowiring::callable_base;
 using autowiring::atomic_list;
 
 atomic_list::~atomic_list(void) {
   callable_base* next;
-  for (callable_base* cur = m_pHead.load(std::memory_order_relaxed); cur; cur = next) {
-    next = cur->m_pFlink;
-    delete cur;
+  while(m_pHead) {
+    next = m_pHead->m_pFlink;
+    delete m_pHead;
   }
 }
 
 uint32_t atomic_list::push_entry(callable_base* e) throw() {
-  callable_base* pHead;
-  uint32_t retVal;
-  do {
-    pHead = m_pHead.load(std::memory_order_acquire);
-    retVal = m_chainID.load(std::memory_order_relaxed);
-    e->m_pFlink = pHead;
-  } while (
-    !m_pHead.compare_exchange_weak(
-      pHead,
-      e,
-      std::memory_order_release,
-      std::memory_order_relaxed
-    )
-  );
+  std::lock_guard<autowiring::spin_lock> lk(lock);
+  e->m_pFlink = m_pHead;
+  m_pHead = e;
+  return m_chainID;
+}
+
+callable_base* atomic_list::release(void) throw() {
+  callable_base* retVal = nullptr;
+  callable_base* pHead = nullptr;
+
+  // Extract the list head and increment the chain identifier for the next customer
+  {
+    std::lock_guard<autowiring::spin_lock> lk(lock);
+    m_chainID++;
+    pHead = m_pHead;
+    m_pHead = nullptr;
+  }
+
+  // Flip the links around, append to return collection in order
+  for (callable_base* pNext; pHead; pHead = pNext) {
+    // Record the next pointer before we nullify it
+    pNext = pHead->m_pFlink;
+
+    // Append to the return list:
+    pHead->m_pFlink = retVal;
+    retVal = pHead;
+  }
   return retVal;
 }

--- a/src/autowiring/atomic_list.cpp
+++ b/src/autowiring/atomic_list.cpp
@@ -2,24 +2,24 @@
 #include "stdafx.h"
 #include "atomic_list.h"
 
-using autowiring::atomic_entry;
+using autowiring::callable_base;
 using autowiring::atomic_list;
 
 atomic_list::~atomic_list(void) {
-  atomic_entry* next;
-  for (atomic_entry* cur = m_pHead.load(std::memory_order_relaxed); cur; cur = next) {
-    next = cur->pFlink;
+  callable_base* next;
+  for (callable_base* cur = m_pHead.load(std::memory_order_relaxed); cur; cur = next) {
+    next = cur->m_pFlink;
     delete cur;
   }
 }
 
-uint32_t atomic_list::push_entry(atomic_entry* e) throw() {
-  atomic_entry* pHead;
+uint32_t atomic_list::push_entry(callable_base* e) throw() {
+  callable_base* pHead;
   uint32_t retVal;
   do {
     pHead = m_pHead.load(std::memory_order_acquire);
     retVal = m_chainID.load(std::memory_order_relaxed);
-    e->pFlink = pHead;
+    e->m_pFlink = pHead;
   } while (
     !m_pHead.compare_exchange_weak(
       pHead,

--- a/src/autowiring/atomic_list.cpp
+++ b/src/autowiring/atomic_list.cpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "atomic_list.h"
+
+using autowiring::atomic_entry;
+using autowiring::atomic_list;
+
+atomic_list::~atomic_list(void) {
+  atomic_entry* next;
+  for (atomic_entry* cur = m_pHead.load(std::memory_order_relaxed); cur; cur = next) {
+    next = cur->pFlink;
+    delete cur;
+  }
+}
+
+uint32_t atomic_list::push_entry(atomic_entry* e) throw() {
+  atomic_entry* pHead;
+  uint32_t retVal;
+  do {
+    pHead = m_pHead.load(std::memory_order_acquire);
+    retVal = m_chainID.load(std::memory_order_relaxed);
+    e->pFlink = pHead;
+  } while (
+    !m_pHead.compare_exchange_weak(
+      pHead,
+      e,
+      std::memory_order_release,
+      std::memory_order_relaxed
+    )
+  );
+  return retVal;
+}

--- a/src/autowiring/atomic_list.cpp
+++ b/src/autowiring/atomic_list.cpp
@@ -11,6 +11,7 @@ atomic_list::~atomic_list(void) {
   while(m_pHead) {
     next = m_pHead->m_pFlink;
     delete m_pHead;
+    m_pHead = next;
   }
 }
 

--- a/src/autowiring/once.cpp
+++ b/src/autowiring/once.cpp
@@ -51,7 +51,7 @@ void once::signal(void) {
 
   // Completely clear the vector, releasing absolutely all memory.  We will never need it again.
   m_state = state::signalled;
-  m_fns = std::vector<std::unique_ptr<detail::callable_base>>{};
+  m_fns = std::vector<std::unique_ptr<callable_base>>{};
 }
 
 void once::operator=(bool rhs) {

--- a/src/autowiring/test/AtomicListTest.cpp
+++ b/src/autowiring/test/AtomicListTest.cpp
@@ -37,7 +37,7 @@ TEST(AtomicListTest, SimpleInsertion) {
 TEST(AtomicListTest, IdIncrement) {
   atomic_list l;
   uint32_t id1 = l.push<HoldsInt>(101);
-  auto e = l.release<HoldsInt>();
+  l.release<HoldsInt>();
   uint32_t id2 = l.push<HoldsInt>(102);
   ASSERT_NE(id1, id2) << "Identifier not incremented as expected";
 }

--- a/src/autowiring/test/AtomicListTest.cpp
+++ b/src/autowiring/test/AtomicListTest.cpp
@@ -1,0 +1,84 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "at_exit.h"
+#include "atomic_list.h"
+#include <thread>
+#include <unordered_set>
+
+using autowiring::atomic_list;
+
+TEST(AtomicListTest, SimpleInsertion) {
+  atomic_list<int> l;
+  uint32_t ids[] = {
+    l.push(55),
+    l.push(56),
+    l.push(57)
+  };
+  ASSERT_EQ(ids[0], ids[1]);
+  ASSERT_EQ(ids[0], ids[2]);
+
+  auto e = l.release();
+  auto q = e.begin();
+
+  for (size_t i = 55; i <= 57; i++) {
+    ASSERT_NE(e.end(), q) << "Unexpected end of list encountered";
+    EXPECT_EQ(i, *q) << "List retrieved in the wrong order";
+    ++q;
+  }
+}
+
+TEST(AtomicListTest, IdIncrement) {
+  atomic_list<int> l;
+  uint32_t id1 = l.push(101);
+  auto e = l.release();
+  uint32_t id2 = l.push(102);
+  ASSERT_NE(id1, id2) << "Identifier not incremented as expected";
+}
+
+TEST(AtomicListTest, IdIncrementPathological) {
+  enum class Owner { None, Consumer, Producer };
+
+  atomic_list<int> l;
+  std::unordered_set<int> S;
+  volatile bool proceed = false;
+
+  // Initial owner is the consumer:
+  std::atomic<Owner> owner{ Owner::Consumer };
+
+  std::thread consumer([&] {
+    owner = Owner::None;
+
+    while (proceed) {
+      Owner exp;
+      do exp = Owner::None;
+      while(!owner.compare_exchange_weak(exp, Owner::Consumer));
+      auto x = MakeAtExit([&owner] { owner = Owner::None; });
+
+      auto f = l.release();
+      for(int value : f)
+        S.insert(value);
+    }
+  });
+  auto x = MakeAtExit([&] {
+    proceed = false;
+    consumer.join();
+  });
+
+  // Drive items into the list and see if we can rip them back:
+  for (size_t i = 10000; i--;) {
+    uint32_t insertedID = l.push(i);
+
+    Owner exp;
+    do exp = Owner::None;
+    while (!owner.compare_exchange_weak(exp, Owner::Producer));
+    auto x = MakeAtExit([&owner] { owner = Owner::None; });
+
+    auto curChainID = l.chain_id();
+    if (curChainID == insertedID)
+      // Still in the list, should not have been observed by the consumer yet
+      ASSERT_EQ(0UL, S.count(i)) << "Chain ID was not updated, but element was found in consumer set";
+    else
+      // Not in the list, must be in the set
+      ASSERT_EQ(1UL, S.count(i)) << "Chain ID was updated, but element was not found in consumer set";
+  }
+}

--- a/src/autowiring/test/AtomicListTest.cpp
+++ b/src/autowiring/test/AtomicListTest.cpp
@@ -8,7 +8,7 @@
 using autowiring::atomic_list;
 
 struct HoldsInt :
-  autowiring::atomic_entry
+  autowiring::callable_base
 {
   HoldsInt(int value) : value(value) {}
   int value;

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(AutowiringTest_SRCS
   AnySharedPointerTest.cpp
   ArgumentTypeTest.cpp
+  AtomicListTest.cpp
   AutoConstructTest.cpp
   AutoFilterAltitudeTest.cpp
   AutoFilterCollapseRulesTest.cpp


### PR DESCRIPTION
There are some signal issues that are related to bugs with an atomic list behavior on Linux.  Create a dedicated atomic linked list concept that allows us to build and test a reliable atomic linked list concept separate from the rest of signal.

- [x] Ensure this type can be used with polymorphic types without needing reallocation