### PR TITLE
Move forward declarations closer to the point of use

### DIFF
--- a/autowiring/AutoFilterDescriptor.h
+++ b/autowiring/AutoFilterDescriptor.h
@@ -10,9 +10,6 @@
 #include "is_shared_ptr.h"
 #include MEMORY_HEADER
 
-class AutoPacket;
-class Deferred;
-
 /// <summary>
 /// The unbound part of an AutoFilter, includes everything except the AnySharedPointer representing the filter proper
 /// </summary>

--- a/autowiring/AutoPacket.h
+++ b/autowiring/AutoPacket.h
@@ -8,7 +8,6 @@
 #include "AutoFilterArgument.h"
 #include "Decompose.h"
 #include "DecorationDisposition.h"
-#include "demangle.h"
 #include "is_any.h"
 #include "index_tuple.h"
 #include "is_shared_ptr.h"
@@ -27,9 +26,6 @@ struct AutoFilterDescriptor;
 
 template<class T>
 class auto_arg;
-
-template<class MemFn>
-struct Decompose;
 
 namespace autowiring {
   template<class MemFn, class Index>

--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -34,7 +34,6 @@
 struct CoreContextStateBlock;
 class BasicThread;
 class BoltBase;
-class CoreContext;
 class GlobalCoreContext;
 class JunctionBoxBase;
 

--- a/autowiring/CoreJob.h
+++ b/autowiring/CoreJob.h
@@ -4,8 +4,6 @@
 #include "CoreRunnable.h"
 #include "DispatchQueue.h"
 
-class CoreObject;
-
 class CoreJob:
   public ContextMember,
   public DispatchQueue,

--- a/autowiring/auto_id.h
+++ b/autowiring/auto_id.h
@@ -4,6 +4,8 @@
 #include <functional>
 #include TYPE_INDEX_HEADER
 
+class CoreObject;
+
 namespace autowiring {
   template<typename> struct s {};
 

--- a/autowiring/fast_pointer_cast.h
+++ b/autowiring/fast_pointer_cast.h
@@ -4,9 +4,6 @@
 #include MEMORY_HEADER
 #include TYPE_TRAITS_HEADER
 
-class AutoPacketFactory;
-class CoreObject;
-
 namespace autowiring {
   template<class T, class U>
   struct fast_pointer_cast_blind;

--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -2,6 +2,7 @@
 #include "stdafx.h"
 #include "AutowiringDebug.h"
 #include "Autowired.h"
+#include "demangle.h"
 #include <algorithm>
 #include <iomanip>
 #include <iostream>

--- a/src/autowiring/test/DemangleTest.cpp
+++ b/src/autowiring/test/DemangleTest.cpp
@@ -1,6 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
-#include <autowiring/autowiring.h>
+#include <autowiring/demangle.h>
 
 class DemangleTest:
   public testing::Test


### PR DESCRIPTION
Makes it easier to understand the rest of the system when unneeded forward declarations are removed.