### PR TITLE
Eliminate legacy types

### DIFF
--- a/autowiring/GlobalCoreContext.h
+++ b/autowiring/GlobalCoreContext.h
@@ -2,10 +2,6 @@
 #pragma once
 #include "CoreContext.h"
 
-/// \internal
-template<class T>
-struct EnableBoltInternal {};
-
 /// A special class designed to make it easier to detect when our context is the global context
 class GlobalCoreContext:
   public CoreContextT<GlobalCoreContext>
@@ -66,16 +62,3 @@ private:
 /// Obtains the global context, provided at global scope to allow forward declaration
 /// </summary>
 std::shared_ptr<GlobalCoreContext> GetGlobalContext(void);
-
-/// \internal
-/// <summary>
-/// Provides a declarative way to set the global context
-/// </summary>
-template<class W>
-struct GlobalContextDesignation {
-  GlobalContextDesignation(void) {
-    CurrentContextPusher pshr(GetGlobalContext());
-    W w;
-    GetGlobalContext()->Initiate();
-  }
-};

--- a/src/autowiring/test/GlobalInitTest.cpp
+++ b/src/autowiring/test/GlobalInitTest.cpp
@@ -37,20 +37,3 @@ TEST_F(GlobalInitTest, VerifyGlobalExists) {
   // reference, and the thread-current reference
   ASSERT_EQ(global.use_count(), 3) << "Unexpected global use count after bare initialization";
 }
-
-struct Simple {
-  AutoRequired<SimpleObject> m_simple;
-};
-
-TEST_F(GlobalInitTest, VerifySimpleContext) {
-  // Set our global scope stuff:
-  GlobalContextDesignation<Simple> d;
-
-  // Obtain reference:
-  std::shared_ptr<GlobalCoreContext> global = GlobalCoreContext::Get();
-  ASSERT_TRUE(!!global.get());
-
-  // Verify that initialization happened as we expected:
-  Autowired<SimpleObject> simpleObj;
-  ASSERT_TRUE(!!simpleObj.get());
-}


### PR DESCRIPTION
This is a relic from back when we thought we could instantiate the global context declaratively; eliminate it