### PR TITLE
Add `const` GetSelf override

### DIFF
--- a/autowiring/ContextMember.h
+++ b/autowiring/ContextMember.h
@@ -70,7 +70,7 @@ public:
   /// Returns a shared pointer that refers to ourselves
   /// </summary>
   template<class T>
-  std::shared_ptr<T> GetSelf(void) {
+  std::shared_ptr<T> GetSelf(void) const {
     return std::static_pointer_cast<T, ContextMember>(shared_from_this());
   }
 };

--- a/autowiring/ContextMember.h
+++ b/autowiring/ContextMember.h
@@ -70,7 +70,15 @@ public:
   /// Returns a shared pointer that refers to ourselves
   /// </summary>
   template<class T>
-  std::shared_ptr<T> GetSelf(void) const {
+  std::shared_ptr<const T> GetSelf(void) const {
+    return std::static_pointer_cast<const T, const ContextMember>(shared_from_this());
+  }
+
+  /// <summary>
+  /// Returns a shared pointer that refers to ourselves
+  /// </summary>
+  template<class T>
+  std::shared_ptr<T> GetSelf(void) {
     return std::static_pointer_cast<T, ContextMember>(shared_from_this());
   }
 };


### PR DESCRIPTION
We'd like to be able to use `GetSelf` in `const` situations.