### PR TITLE
Ensure we properly autowire unused base types

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -1122,6 +1122,9 @@ public:
   /// </remarks>
   template<class T, class Fn>
   void NotifyWhenAutowired(Fn&& listener) {
+    // Ensure we instantiate casters for type T, regardless of whether the listener intends to use it
+    autowiring::instantiate<T>();
+
     MemoEntry& memo = FindByType(auto_id_t<T>{});
     memo.onSatisfied += std::forward<Fn&&>(listener);
   }

--- a/autowiring/CoreObjectDescriptor.h
+++ b/autowiring/CoreObjectDescriptor.h
@@ -15,6 +15,18 @@
 #include <typeinfo>
 #include MEMORY_HEADER
 
+namespace autowiring {
+  /// <summary>
+  /// Instantiates all casters and traits for type T
+  /// </summary>
+  template<typename T>
+  void instantiate(void) {
+    (void)fast_pointer_cast_initializer<CoreObject, T>::sc_init;
+    (void)fast_pointer_cast_initializer<T, CoreObject>::sc_init;
+    (void)auto_id_t_init<T>::init;
+  }
+}
+
 /// <summary>
 /// Mapping and extraction structure used to provide a runtime version of an Object-implementing shared pointer
 /// </summary>
@@ -61,12 +73,8 @@ struct CoreObjectDescriptor {
     )
   {
     // We can instantiate casts to CoreObject here at the point where object traits are being generated
-    (void) autowiring::fast_pointer_cast_initializer<CoreObject, TActual>::sc_init;
-    (void) autowiring::fast_pointer_cast_initializer<TActual, CoreObject>::sc_init;
-    (void) autowiring::fast_pointer_cast_initializer<CoreObject, T>::sc_init;
-    (void) autowiring::fast_pointer_cast_initializer<T, CoreObject>::sc_init;
-    (void) auto_id_t_init<TActual>::init;
-    (void) auto_id_t_init<T>::init;
+    autowiring::instantiate<T>();
+    autowiring::instantiate<TActual>();
   }
 
   /// <summary>

--- a/src/autowiring/test/HasForwardOnlyType.cpp
+++ b/src/autowiring/test/HasForwardOnlyType.cpp
@@ -12,3 +12,7 @@ HasForwardOnlyType::HasForwardOnlyType(void) {}
 void HasForwardOnlyType::AutoFilter(std::shared_ptr<MyForwardedType>& output) {
 
 }
+
+void InjectForwardOnlyType(CoreContext& ctxt) {
+  ctxt.Inject<HasForwardOnlyType>();
+}

--- a/src/autowiring/test/HasForwardOnlyType.hpp
+++ b/src/autowiring/test/HasForwardOnlyType.hpp
@@ -4,7 +4,11 @@
 
 class MyForwardedType;
 
-class HasForwardOnlyType {
+class ForwardedOnlyBaseType {};
+
+class HasForwardOnlyType:
+  public ForwardedOnlyBaseType
+{
 public:
   HasForwardOnlyType(void);
 
@@ -12,3 +16,8 @@ public:
 
   void AutoFilter(std::shared_ptr<MyForwardedType>& output);
 };
+
+/// <summary>
+/// Injects the forward-only type into the passed context
+/// </summary>
+void InjectForwardOnlyType(CoreContext& ctxt);

--- a/src/autowiring/test/PostConstructTest.cpp
+++ b/src/autowiring/test/PostConstructTest.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/SimpleObject.hpp"
+#include "test/HasForwardOnlyType.hpp"
 #include <autowiring/Autowired.h>
 #include <autowiring/ContextMember.h>
 #include THREAD_HEADER
@@ -397,4 +398,21 @@ TEST_F(PostConstructTest, StrictNotificationArrangement) {
 
   for (int i = 0; i < 7; i++)
     ASSERT_EQ(i + 1, call[i]) << "Registered autowired handler was not called in the correct order";
+}
+
+class ForwardedOnlyBaseType;
+
+void InjectForwardOnlyType(CoreContext& ctxt);
+
+TEST_F(PostConstructTest, ForwardOnlyBaseType) {
+  AutoCurrentContext ctxt;
+  InjectForwardOnlyType(*ctxt);
+
+  bool called = false;
+  ctxt->NotifyWhenAutowired<ForwardedOnlyBaseType>(
+    [&called] {
+      called = true;
+    }
+  );
+  ASSERT_TRUE(called) << "Failed to find expected base type";
 }


### PR DESCRIPTION
There are cases where base type notification requests are made but the type itself is never used anywhere by anyone.  Ensure we catch these in a test and that we properly instantiate the right casters so we can find these types, too.