### PR TITLE
Make CurrentContextPusher a tiny bit faster

### DIFF
--- a/autowiring/CoreContext.h
+++ b/autowiring/CoreContext.h
@@ -943,6 +943,11 @@ public:
   static std::shared_ptr<CoreContext> SetCurrent(const std::shared_ptr<CoreContext>& ctxt);
 
   /// <summary>
+  /// Move-optimized version of SetCurrent
+  /// </summary>
+  static std::shared_ptr<CoreContext> SetCurrent(std::shared_ptr<CoreContext>&& ctxt);
+
+  /// <summary>
   /// Makes this context the current context.
   /// </summary>
   /// <returns>The previously current context, or else nullptr if no context was current.</returns>

--- a/autowiring/CurrentContextPusher.h
+++ b/autowiring/CurrentContextPusher.h
@@ -21,6 +21,7 @@ public:
   CurrentContextPusher(void);
 
   CurrentContextPusher(CoreContext& context);
+  CurrentContextPusher(std::shared_ptr<CoreContext>&& pContext);
   CurrentContextPusher(const std::shared_ptr<CoreContext>& pContext);
   CurrentContextPusher(const std::shared_ptr<GlobalCoreContext>& pContext);
   CurrentContextPusher(CoreContext* pContext);

--- a/autowiring/CurrentContextPusher.h
+++ b/autowiring/CurrentContextPusher.h
@@ -21,7 +21,6 @@ public:
   CurrentContextPusher(void);
 
   CurrentContextPusher(CoreContext& context);
-  CurrentContextPusher(std::shared_ptr<CoreContext>&& pContext);
   CurrentContextPusher(const std::shared_ptr<CoreContext>& pContext);
   CurrentContextPusher(const std::shared_ptr<GlobalCoreContext>& pContext);
   CurrentContextPusher(CoreContext* pContext);

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -1166,6 +1166,22 @@ std::shared_ptr<CoreContext> CoreContext::SetCurrent(const std::shared_ptr<CoreC
   return retVal;
 }
 
+std::shared_ptr<CoreContext> CoreContext::SetCurrent(std::shared_ptr<CoreContext>&& ctxt) {
+  const auto& currentContext = CurrentContextOrNull();
+
+  // Short-circuit test, no need to proceed if we aren't changing the context:
+  if (currentContext == ctxt)
+    return currentContext;
+
+  // Value is changing, update:
+  auto retVal = currentContext;
+  if (ctxt)
+    autoCurrentContext.reset(new std::shared_ptr<CoreContext>(std::move(ctxt)));
+  else
+    autoCurrentContext.reset();
+  return retVal;
+}
+
 std::shared_ptr<CoreContext> CoreContext::SetCurrent(void) {
   return CoreContext::SetCurrent(shared_from_this());
 }

--- a/src/autowiring/CurrentContextPusher.cpp
+++ b/src/autowiring/CurrentContextPusher.cpp
@@ -37,7 +37,7 @@ std::shared_ptr<CoreContext> CurrentContextPusher::Pop(void) {
     return nullptr;
 
   pop_invoked = true;
-  auto retVal = CoreContext::SetCurrent(m_prior);
+  auto retVal = CoreContext::SetCurrent(std::move(m_prior));
   m_prior.reset();
   return retVal;
 }


### PR DESCRIPTION
By using r-value behaviors in `CurrentContextPusher::Pop`, we can avoid needless adjustment to the shared pointer count.