### PR TITLE
Add extended information about null field dereferences

### DIFF
--- a/autowiring/AutowirableSlot.h
+++ b/autowiring/AutowirableSlot.h
@@ -4,6 +4,7 @@
 #include "auto_signal.h"
 #include "autowiring_error.h"
 #include "CoreContext.h"
+#include "deref_error.h"
 #include "fast_pointer_cast.h"
 #include "SlotInformation.h"
 #include MEMORY_HEADER
@@ -73,7 +74,7 @@ public:
   auto_id GetType(void) const {
     return m_ptr.type();
   }
-  
+
   /// <summary>
   /// Performs a full reset of this slot
   /// </summary>
@@ -135,7 +136,7 @@ public:
   }
 };
 
-template<class T>
+template<typename T>
 class AutowirableSlot:
   public DeferrableAutowiring
 {
@@ -200,14 +201,14 @@ public:
 
     auto retVal = get();
     if (!retVal)
-      throw autowiring_error("Attempted to dereference a null autowired field");
+      throw autowiring::deref_error(*this);
     return retVal;
   }
 
   T& operator*(void) const {
     auto retVal = get();
     if (!retVal)
-      throw autowiring_error("Attempted to dereference a null autowired field");
+      throw autowiring::deref_error(*this);
 
     // We have to initialize here, in the operator context, because we don't actually know if the
     // user will be making use of this type.

--- a/autowiring/Autowired.h
+++ b/autowiring/Autowired.h
@@ -93,7 +93,7 @@ typedef AutoCreateContextT<void> AutoCreateContext;
 ///
 /// This class may be safely used even when the member in question is an abstract type.
 /// </remarks>
-template<class T>
+template<typename T>
 class Autowired:
   public AutowirableSlot<T>
 {
@@ -110,11 +110,11 @@ public:
   operator const std::shared_ptr<T>&(void) const {
     return static_cast<const AnySharedPointerT<T>&>(this->m_ptr).get();
   }
-  
+
   operator std::weak_ptr<T>(void) const {
     return this->operator const std::shared_ptr<T>&();
   }
-  
+
   operator T*(void) const {
     return this->operator const std::shared_ptr<T>&().get();
   }
@@ -160,7 +160,7 @@ public:
   struct signal_relay {
     signal_relay(Autowired<T>& f, autowiring::signal<void(Args...)> U::*m) :
       field(&f),
-      member(m) 
+      member(m)
     {}
 
     Autowired<T>* field;
@@ -173,7 +173,7 @@ public:
       );
     }
   };
-  
+
   template<typename U, typename... Args>
   signal_relay<U,Args...> operator()(autowiring::signal<void(Args...)> U::*sig) {
     static_assert(std::is_base_of<U, T>::value, "Cannot reference member of unrelated type");
@@ -214,7 +214,7 @@ public:
   AutoRequired(const AutoRequired<T>& rhs) :
     std::shared_ptr<T>(rhs)
   {}
-  
+
   // !!!!! READ THIS IF YOU ARE GETTING A COMPILER ERROR HERE !!!!!
   // If you are getting an error tracked to this line, ensure that class T is totally
   // defined at the point where the Autowired instance is constructed.  Generally,
@@ -241,7 +241,7 @@ public:
   AutoRequired(const std::shared_ptr<CoreContext>& ctxt = CoreContext::CurrentContext()):
     std::shared_ptr<T>(ctxt->template Inject<T>())
   {}
-  
+
   /// <summary>
   /// AutoRequired overload that forwards constructor arguments to the type being wired.
   /// </summary>
@@ -249,15 +249,15 @@ public:
   AutoRequired(const std::shared_ptr<CoreContext>& ctxt, Args&&... args) :
     std::shared_ptr<T>(ctxt->template Inject<T>(std::forward<Args>(args)...))
   {}
-  
+
   operator bool(void) const {
     return IsAutowired();
   }
-  
+
   operator T*(void) const {
     return std::shared_ptr<T>::get();
   }
-  
+
   bool IsAutowired(void) const { return std::shared_ptr<T>::get() != nullptr; }
 };
 
@@ -279,7 +279,7 @@ public:
 /// be completely defined before construction.  By comparison, Autowired fields do not ever
 /// need to be defined.
 /// </remarks>
-template<class T>
+template<typename T>
 class AutowiredFast:
   public std::shared_ptr<T>
 {
@@ -310,14 +310,14 @@ public:
   T* operator->(void) const {
     auto* retVal = std::shared_ptr<T>::operator->();
     if (!retVal)
-      throw autowiring_error("Attempted to dereference a null autowired field");
+      throw autowiring::deref_error(*this);
     return retVal;
   }
 
   T& operator*(void) const {
     T* retVal = std::shared_ptr<T>::get();
     if (!retVal)
-      throw autowiring_error("Attempted to dereference a null autowired field");
+      throw autowiring::deref_error(*this);
     return *retVal;
   }
 

--- a/autowiring/deref_error.h
+++ b/autowiring/deref_error.h
@@ -1,0 +1,29 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "autowiring_error.h"
+
+template<class T>
+class AutowirableSlot;
+
+template<typename T>
+class AutowiredFast;
+
+namespace autowiring {
+  std::string GenerateExceptionTextAWF(const std::type_info& ti);
+  std::string GenerateExceptionTextAW(const std::type_info& ti);
+
+  class deref_error:
+    public autowiring_error
+  {
+  public:
+    template<typename T>
+    deref_error(const AutowirableSlot<T>&) :
+      autowiring_error(GenerateExceptionTextAW(typeid(T)))
+    {};
+
+    template<typename T>
+    deref_error(const AutowiredFast<T>&) :
+      autowiring_error(GenerateExceptionTextAWF(typeid(T)))
+    {};
+  };
+}

--- a/autowiring/deref_error.h
+++ b/autowiring/deref_error.h
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "autowiring_error.h"
+#include <typeinfo>
 
 template<class T>
 class AutowirableSlot;

--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -2,6 +2,7 @@
 #include "stdafx.h"
 #include "AutowiringDebug.h"
 #include "Autowired.h"
+#include "AutoPacketFactory.h"
 #include "demangle.h"
 #include <algorithm>
 #include <iomanip>
@@ -66,7 +67,7 @@ std::string autowiring::dbg::ContextName(void) {
 
 void PrintContextTreeRecursive(std::ostream& os, const std::shared_ptr<CoreContext>& root, std::shared_ptr<CoreContext> ctxt) {
   for (; ctxt; ctxt = ctxt->NextSibling()) {
-    
+
     // Create of vector of contexts from child of global to 'ctxt'
     std::deque<std::shared_ptr<CoreContext>> path;
     for (auto c = ctxt; c != root; c = c->GetParentContext()) {

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -92,6 +92,8 @@ set(Autowiring_SRCS
   Deferred.h
   demangle.cpp
   demangle.h
+  deref_error.h
+  deref_error.cpp
   Deserialize.h
   dispatch_aborted_exception.h
   dispatch_aborted_exception.cpp

--- a/src/autowiring/deref_error.cpp
+++ b/src/autowiring/deref_error.cpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "deref_error.h"
+#include "demangle.h"
+#include <sstream>
+
+static std::string GenerateExceptionText(const char* type, const std::type_info& ti) {
+  std::stringstream ss;
+  ss << "Attempted to dereference a null " << type << "<" << autowiring::demangle(ti) << ">";
+  return ss.str();
+}
+
+std::string autowiring::GenerateExceptionTextAWF(const std::type_info& ti) {
+  return GenerateExceptionText("AutowiredFast", ti);
+}
+
+std::string autowiring::GenerateExceptionTextAW(const std::type_info& ti) {
+  return GenerateExceptionText("Autowired", ti);
+}

--- a/src/autowiring/test/AutowiringTest.cpp
+++ b/src/autowiring/test/AutowiringTest.cpp
@@ -221,7 +221,7 @@ TEST_F(AutowiringTest, NullDereferenceTest) {
   Autowired<SimpleObject> nwa;
   ASSERT_THROW(*nwa, autowiring::deref_error);
   try {
-    nwa->one;
+    (void)nwa->one;
     FAIL() << "Dereference error not thrown for a null Autowired field";
   }
   catch (autowiring::deref_error& dre) {
@@ -233,7 +233,7 @@ TEST_F(AutowiringTest, FastNullDereferenceTest) {
   AutowiredFast<SimpleObject> nwaFast;
   ASSERT_THROW(*nwaFast, autowiring::deref_error);
   try {
-    nwaFast->one;
+    (void)nwaFast->one;
     FAIL() << "Dereference error not thrown for a null AutowiredFast field";
   }
   catch (autowiring::deref_error& dre) {

--- a/src/autowiring/test/AutowiringTest.cpp
+++ b/src/autowiring/test/AutowiringTest.cpp
@@ -79,7 +79,7 @@ TEST_F(AutowiringTest, PathologicalAutowiringRace) {
   InjectAll();
 
   // Now insert at about the same time as other threads are waking up.  If there are synchronization problems
-  // in spin-up or tear-down, 
+  // in spin-up or tear-down,
   AutoRequired<SimpleObject>();
 }
 
@@ -200,18 +200,6 @@ TEST_F(AutowiringTest, StaticNewWithArgs) {
   }
 }
 
-TEST_F(AutowiringTest, NullDereferenceAttempt) {
-  Autowired<SimpleObject> co;
-  ASSERT_ANY_THROW(*co) << "A dereference attempt on a CoreObject did not throw an exception as expected";
-  ASSERT_ANY_THROW((void)co->one) << "A dereference attempt on a CoreObject did not throw an exception as expected";
-}
-
-TEST_F(AutowiringTest, FastNullDereferenceAttempt) {
-  AutowiredFast<SimpleObject> co;
-  ASSERT_ANY_THROW(*co) << "A dereference attempt on a CoreObject did not throw an exception as expected";
-  ASSERT_ANY_THROW((void)co->one) << "A dereference attempt on a CoreObject did not throw an exception as expected";
-}
-
 namespace {
   class InjectsItself:
     public CoreObject
@@ -227,4 +215,28 @@ namespace {
 TEST_F(AutowiringTest, AutowiresItself) {
   // Try to overtake:
   ASSERT_NO_THROW(AutoConstruct<InjectsItself> bii(true)) << "An overtaken constructor incorrectly caused an exception to be thrown";
+}
+
+TEST_F(AutowiringTest, NullDereferenceTest) {
+  Autowired<SimpleObject> nwa;
+  ASSERT_THROW(*nwa, autowiring::deref_error);
+  try {
+    nwa->one;
+    FAIL() << "Dereference error not thrown for a null Autowired field";
+  }
+  catch (autowiring::deref_error& dre) {
+    ASSERT_STREQ("Attempted to dereference a null Autowired<SimpleObject>", dre.what());
+  }
+}
+
+TEST_F(AutowiringTest, FastNullDereferenceTest) {
+  AutowiredFast<SimpleObject> nwaFast;
+  ASSERT_THROW(*nwaFast, autowiring::deref_error);
+  try {
+    nwaFast->one;
+    FAIL() << "Dereference error not thrown for a null AutowiredFast field";
+  }
+  catch (autowiring::deref_error& dre) {
+    ASSERT_STREQ("Attempted to dereference a null AutowiredFast<SimpleObject>", dre.what());
+  }
 }


### PR DESCRIPTION
Fixes #835, just adds a little bit more information about null dereference exceptions when they occur.