### PR TITLE
Fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ via the [find_package](http://www.cmake.org/cmake/help/v3.0/command/find_package
 
 ### Arm-linux
 
-Building on Android requires the use of a toolchain file.  You will need to use an alternate prefix path if you are trying to cross-compile, the prefix path should contain your version of the Boost libraries built for Android.  To configure, use the following invocation:
+Building on Android requires the use of a toolchain file.  To configure, use the following invocation:
 
     cmake . -DCMAKE_TOOLCHAIN_FILE=toolchain-arm.cmake -DCMAKE_PREFIX_PATH:PATH=/your/lib/path
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ via the [find_package](http://www.cmake.org/cmake/help/v3.0/command/find_package
 
 ### Arm-linux
 
-Building on Android requires the use of a toolchain file.  To configure, use the following invocation:
+Building on ARM-Linux requires the use of a toolchain file.  This file is included with Autowiring.  To configure, use the following invocation:
 
     cmake . -DCMAKE_TOOLCHAIN_FILE=toolchain-arm.cmake -DCMAKE_PREFIX_PATH:PATH=/your/lib/path
 


### PR DESCRIPTION
Current build instructions for ARM-Linux still imply that we need to install Boost, this has not been true for almost a year.