### PR TITLE
Fix toolchain file again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(autowiring VERSION ${autowiring_VERSION})
 include(CTest)
 include(CheckTypeSize)
 
+message(STATUS "sizeof(void*) is ${CMAKE_SIZEOF_VOID_P}")
+
 if(APPLE)
   option(autowiring_BUILD_FAT "Build fat binaries for Autowiring" ON)
   set(CMAKE_OSX_ARCHITECTURES "x86_64;i386" CACHE STRING "Mac OS X build architectures" FORCE)
@@ -162,7 +164,7 @@ install(
   COMPONENT autowiring
   FILES_MATCHING PATTERN "*.h"
 )
- 
+
 # Install autoboost headers on ARM, which still requires them
 if(CMAKE_COMPILER_IS_GNUCC AND ("${CMAKE_CXX_COMPILER}" MATCHES "androideabi"))
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9")
@@ -173,7 +175,7 @@ if(CMAKE_COMPILER_IS_GNUCC AND ("${CMAKE_CXX_COMPILER}" MATCHES "androideabi"))
     )
   endif()
 endif()
- 
+
 # Targets file is needed in order to describe how to link Autowiring to the rest of the system
 install(EXPORT AutowiringTargets FILE AutowiringTargets.cmake COMPONENT autowiring NAMESPACE Autowiring:: DESTINATION cmake CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES})
 

--- a/contrib/autoboost/autoboost/thread/pthread/thread_data.hpp
+++ b/contrib/autoboost/autoboost/thread/pthread/thread_data.hpp
@@ -24,9 +24,6 @@
 #include <vector>
 #include <utility>
 
-#if defined(__ANDROID__)
-#include <asm/page.h> // http://code.google.com/p/android/issues/detail?id=39983
-#endif
 
 #include <pthread.h>
 #include <unistd.h>

--- a/toolchain-android.cmake
+++ b/toolchain-android.cmake
@@ -1,20 +1,20 @@
-if(BUILD_64_BIT) # ARMv8 with GCC 4.9
-  set(BUILD_ANDROID64 1)
-  set(ANDROID_NDK_TOOL_PREFIX aarch64-linux-android)
-  set(_ndk_suffix -4.9-aarch64)
-else() # GCC 4.8
-  set(ARM_TARGET "armeabi-v7a")
-  set(ANDROID_NDK_TOOL_PREFIX arm-linux-androideabi)
+if(NOT ANDROID_NDK_TOOL_PREFIX)
+  # Default to the 32-bit toolchain version for legacy compatibility
+  if(0.9.0 VERSION_LESS autowiring_VERSION)
+    message(FATAL_ERROR "Eliminate this compatibility hack")
+  endif()
+
+  if($ENV{ARMv8})
+    include(${CMAKE_CURRENT_LIST_DIR}/toolchain-android64.cmake)
+  else()
+    include(${CMAKE_CURRENT_LIST_DIR}/toolchain-android32.cmake)
+  endif()
+  return()
 endif()
-set(BUILD_ANDROID 1)
+
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 set(CMAKE_SYSTEM_VERSION 1)
-set(BUILD_ARM 1)
-
-if(MSYS)
-  set(_exe_suffix .exe)
-endif()
 
 #For reasons beyond my comprehension, this file is parsed multiple times
 #and in some of them, cache variables are not preserved so we have to store

--- a/toolchain-android32.cmake
+++ b/toolchain-android32.cmake
@@ -1,0 +1,3 @@
+set(ARM_TARGET "armeabi-v7a")
+set(ANDROID_NDK_TOOL_PREFIX arm-linux-androideabi)
+include(${CMAKE_CURRENT_LIST_DIR}/toolchain-android.cmake)

--- a/toolchain-android64.cmake
+++ b/toolchain-android64.cmake
@@ -1,0 +1,3 @@
+set(ANDROID_NDK_TOOL_PREFIX aarch64-linux-android)
+set(_ndk_suffix -4.9-aarch64)
+include(${CMAKE_CURRENT_LIST_DIR}/toolchain-android.cmake)


### PR DESCRIPTION
Eliminate the `ARMv8` flag completely, just use different toolchain files for 32 and 64 bit.  The two require different compilers anyway, makes sense to divide up the toolchain files as well.  Furthermore, we no longer need `#include <asm/page.h>` on our target build platforms, so we can remove this.