### PR TITLE
Do not hold lock under notification where possible

### DIFF
--- a/autowiring/DispatchQueue.h
+++ b/autowiring/DispatchQueue.h
@@ -335,9 +335,9 @@ public:
     // Create the thunk first to reduce the amount of time we spend in lock:
     auto thunk = new DispatchThunk<_Fx>(std::forward<_Fx>(fx));
 
-    std::unique_lock<std::mutex> lk(m_dispatchLock);
+    m_dispatchLock.lock();
     if (m_count >= m_dispatchCap) {
-      lk.unlock();
+      m_dispatchLock.unlock();
       delete thunk;
       return;
     }
@@ -346,15 +346,18 @@ public:
     m_count++;
 
     // Linked list setup:
-    if (m_pHead)
-      m_pTail->m_pFlink = thunk; 
+    if (m_pHead) {
+      m_pTail->m_pFlink = thunk;
+      m_pTail = thunk;
+      m_dispatchLock.unlock();
+    }
     else {
-      m_pHead = thunk;
+      m_pHead = m_pTail = thunk;
+      m_dispatchLock.unlock();
       m_queueUpdated.notify_all();
     }
-    m_pTail = thunk;
 
     // Notification as needed:
-    OnPended(std::move(lk));
+    OnPended(std::unique_lock<std::mutex>{});
   }
 };

--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -96,7 +96,7 @@ void BasicThread::DoRunLoopCleanup(std::shared_ptr<CoreContext>&& ctxt, std::sha
 
   // Notify other threads that we are done.  At this point, any held references that might still exist
   // notification must happen from a synchronized level in order to ensure proper ordering.
-  std::lock_guard<std::mutex> lk(state->m_lock);
+  std::lock_guard<std::mutex>{state->m_lock},
   state->m_completed = true;
   state->m_stateCondition.notify_all();
 }
@@ -114,7 +114,7 @@ void BasicThread::WaitForStateUpdate(const std::function<bool()>& fn) const {
 }
 
 void BasicThread::PerformStatusUpdate(const std::function<void()>& fn) const {
-  std::unique_lock<std::mutex> lk(m_state->m_lock);
+  std::unique_lock<std::mutex>{m_state->m_lock},
   fn();
   m_state->m_stateCondition.notify_all();
 }

--- a/src/autowiring/CoreContextStateBlock.cpp
+++ b/src/autowiring/CoreContextStateBlock.cpp
@@ -25,13 +25,15 @@ RunCounter::~RunCounter(void) {
   owner.reset();
 
   std::weak_ptr<CoreObject> outstanding;
-  std::lock_guard<std::mutex> lk(stateBlock->m_lock);
+  {
+    std::lock_guard<std::mutex> lk(stateBlock->m_lock);
 
-  // Unfortunately, this destructor callback is made before weak pointers are
-  // invalidated, which requires that we manually reset the outstanding count
-  // We don't want to free memory while holding the lock, so defer
-  outstanding = std::move(stateBlock->m_outstanding);
-  stateBlock->m_outstanding.reset();
+    // Unfortunately, this destructor callback is made before weak pointers are
+    // invalidated, which requires that we manually reset the outstanding count
+    // We don't want to free memory while holding the lock, so defer
+    outstanding = std::move(stateBlock->m_outstanding);
+    stateBlock->m_outstanding.reset();
+  }
 
   // Wake everyone up
   stateBlock->m_stateChanged.notify_all();

--- a/src/autowiring/CoreJob.cpp
+++ b/src/autowiring/CoreJob.cpp
@@ -49,10 +49,10 @@ void CoreJob::OnPended(std::unique_lock<std::mutex>&& lk){
   } else {
     // Need to ask the thread pool to handle our events again:
     m_curEventInTeardown = false;
-    
+
     if (m_curEvent)
       delete static_cast<std::future<void>*>(m_curEvent);
-    
+
     m_curEvent = new std::future<void>(
       std::async(
         std::launch::async,
@@ -81,9 +81,10 @@ void CoreJob::DispatchAllAndClearCurrent(void) {
     // a signal to consumers that a call to m_curEvent.wait() will be nearly
     // non-blocking.
     m_curEventInTeardown = true;
-    m_queueUpdated.notify_all();
     break;
   }
+
+  m_queueUpdated.notify_all();
 }
 
 bool CoreJob::OnStart(void) {

--- a/src/autowiring/CoreRunnable.cpp
+++ b/src/autowiring/CoreRunnable.cpp
@@ -46,10 +46,9 @@ void CoreRunnable::Stop(bool graceful) {
   }
 
   if (m_outstanding) {
-    std::shared_ptr<CoreObject> outstanding;
-    std::lock_guard<std::mutex> lk(m_lock);
-
     // Ensure we do not invoke the outstanding count dtor while holding a lock
+    std::shared_ptr<CoreObject> outstanding;
+    std::lock_guard<std::mutex>{m_lock},
     outstanding.swap(m_outstanding);
 
     // Everything looks good now

--- a/src/autowiring/DispatchQueue.cpp
+++ b/src/autowiring/DispatchQueue.cpp
@@ -62,7 +62,7 @@ void DispatchQueue::DispatchEventUnsafe(std::unique_lock<std::mutex>& lk) {
   MakeAtExit([&] {
     if (!--m_count) {
       // Notify that we have hit zero:
-      std::lock_guard<std::mutex>{ *lk.mutex() },
+      std::lock_guard<std::mutex>{ *lk.mutex() };
       m_queueUpdated.notify_all();
     }
   }),

--- a/src/autowiring/benchmark/DispatchQueueBm.cpp
+++ b/src/autowiring/benchmark/DispatchQueueBm.cpp
@@ -44,7 +44,7 @@ Benchmark DispatchQueueBm::Dispatch(void) {
 
         sw.Start();
         for (size_t i = n; i--;) {
-          std::lock_guard<std::mutex> lk(lock);
+          std::lock_guard<std::mutex>{lock},
           fns.push_back(l);
           cv.notify_all();
         }

--- a/src/autowiring/stdafx.h
+++ b/src/autowiring/stdafx.h
@@ -34,7 +34,7 @@
   #include <unordered_set>
   #include <vector>
 #endif
-  
+
 #ifndef _MSC_VER
   #include <stdlib.h>
 #endif

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -355,7 +355,7 @@ public:
   }
 
   void Proceed(void) {
-    std::lock_guard<std::mutex> lk(lock);
+    std::lock_guard<std::mutex>{ lock },
     outstanding.reset();
     cv.notify_all();
   }

--- a/src/autowiring/test/CoreThreadTest.cpp
+++ b/src/autowiring/test/CoreThreadTest.cpp
@@ -499,7 +499,7 @@ TEST_F(CoreThreadTest, SpuriousWakeupTest) {
   size_t countOnWake = -1;
 
   auto wakeFn = [&] {
-    std::lock_guard<std::mutex> lk(lock);
+    std::lock_guard<std::mutex>{ lock },
     ready = true;
     cv.notify_all();
     countOnWake = extraction->GetDispatchQueueLength();
@@ -542,7 +542,7 @@ public:
   }
 
   void Continue(void) {
-    std::lock_guard<std::mutex> lk(m_lock);
+    std::lock_guard<std::mutex>{ m_lock },
     signal = true;
     m_cv.notify_all();
   }
@@ -594,11 +594,9 @@ TEST_F(CoreThreadTest, SubContextHoldsParentContext) {
     // Terminate the parent, verify that the child has exited:
     parent->SignalShutdown();
     ASSERT_FALSE(parent->Wait(std::chrono::milliseconds(5))) << "Parent context returned before all child threads were done";
-    {
-      std::lock_guard<std::mutex> lk(*lock);
-      *proceed = true;
-      cv->notify_all();
-    }
+    std::lock_guard<std::mutex> { *lock },
+    *proceed = true;
+    cv->notify_all();
     ASSERT_TRUE(parent->Wait(std::chrono::seconds(5))) << "Signalled thread did not terminate in a timely fashion";
   }
   ASSERT_EQ(initUses, parent.use_count()) << "Parent had spurious references after all objects should have been destroyed";

--- a/src/autowiring/test/CoreThreadTest.cpp
+++ b/src/autowiring/test/CoreThreadTest.cpp
@@ -505,7 +505,7 @@ TEST_F(CoreThreadTest, SpuriousWakeupTest) {
     countOnWake = extraction->GetDispatchQueueLength();
   };
 
-  // Add a delayed lambda that we know won't launch and another one that should launch right away
+  // Add a lambda that should launch right away and a delayed lambda that we know won't launch
   *extraction += wakeFn;
   *extraction += std::chrono::hours(1), [] {};
 

--- a/src/autowiring/test/CoreThreadTest.cpp
+++ b/src/autowiring/test/CoreThreadTest.cpp
@@ -499,10 +499,12 @@ TEST_F(CoreThreadTest, SpuriousWakeupTest) {
   size_t countOnWake = -1;
 
   auto wakeFn = [&] {
-    std::lock_guard<std::mutex>{ lock },
-    ready = true;
+    {
+      std::lock_guard<std::mutex> lk{ lock };
+      ready = true;
+      countOnWake = extraction->GetDispatchQueueLength();
+    }
     cv.notify_all();
-    countOnWake = extraction->GetDispatchQueueLength();
   };
 
   // Add a lambda that should launch right away and a delayed lambda that we know won't launch

--- a/src/autowiring/test/DispatchQueueTest.cpp
+++ b/src/autowiring/test/DispatchQueueTest.cpp
@@ -30,21 +30,21 @@ class Thread:
 
 TEST_F(DispatchQueueTest, SimpleEvents) {
   int count = 0;
-  
+
   *this += [&count] () {
     ++count;
   };
-  
+
   *this += [&count] () {
     count += 5 ;
   };
-  
+
   int num = DispatchAllEvents();
-  
+
   *this += [&count]() {
     count += 5 ;
   };
-  
+
   ASSERT_EQ(2, num);
   ASSERT_EQ(6, count);
 }
@@ -140,11 +140,9 @@ TEST_F(DispatchQueueTest, BarrierWithAbort) {
   auto f = std::async(
     std::launch::async,
     [=] {
-      {
-        std::unique_lock<std::mutex> lk(b->lock);
-        b->nReady++;
-        b->cv.notify_all();
-      }
+      std::unique_lock<std::mutex> { b->lock },
+      b->nReady++;
+      b->cv.notify_all();
       return ct->Barrier(std::chrono::seconds(5));
     }
   );

--- a/src/autowiring/test/InterlockedRoutinesTest.cpp
+++ b/src/autowiring/test/InterlockedRoutinesTest.cpp
@@ -96,11 +96,9 @@ TEST_F(InterlockedRoutinesTest, VerifyCompareExchangePathological) {
   }
 
   // Now we can wake up the threads:
-  {
-    std::lock_guard<std::mutex> lk(lock);
-    canContinue = true;
-    cv.notify_all();
-  }
+  std::lock_guard<std::mutex> { lock },
+  canContinue = true;
+  cv.notify_all();
 
   // Wait for all threads to complete:
   for(size_t i = 0; i < threadCount; i++)

--- a/src/autowiring/test/ParallelTest.cpp
+++ b/src/autowiring/test/ParallelTest.cpp
@@ -88,7 +88,7 @@ TEST_F(ParallelTest, VoidReturnAll) {
 TEST_F(ParallelTest, Barrier) {
   AutoCurrentContext()->Initiate();
   autowiring::parallel p;
-  
+
   std::atomic<size_t> x{ 0 };
   for (size_t i = 0; i < 1000; i++)
     p += [&x] { x++; };


### PR DESCRIPTION
It is not needed to hold the lock while calling `condition_variable::notify_all()`, and in fact this is a pessimization.  Release this lock wherever we can to improve performance.

This modification improves performance of `DispatchQueue::operator+=` by about 4%.