### PR TITLE
Use case improvements for autowiring::parallel

### DIFF
--- a/src/autowiring/Parallel.cpp
+++ b/src/autowiring/Parallel.cpp
@@ -2,6 +2,7 @@
 #include "stdafx.h"
 #include "Parallel.h"
 #include "autowiring.h"
+#include <thread>
 
 using namespace autowiring;
 

--- a/src/autowiring/Parallel.cpp
+++ b/src/autowiring/Parallel.cpp
@@ -10,9 +10,62 @@ void parallel_iterator<void>::operator++(int) {
 }
 
 parallel::parallel(void):
-  m_ctxt(AutoCurrentContext{})
+  parallel{ *CoreContext::CurrentContext(), std::thread::hardware_concurrency() }
 {}
 
-parallel::parallel(CoreContext& ctxt) :
-  m_ctxt(ctxt.shared_from_this())
+parallel::parallel(size_t concurrency) :
+  parallel{ *CoreContext::CurrentContext(), concurrency }
 {}
+
+parallel::parallel(CoreContext& ctxt, size_t concurrency):
+  m_ctxt(ctxt.shared_from_this())
+{
+  if (!concurrency)
+    concurrency = std::thread::hardware_concurrency();
+
+  auto block = m_block;
+
+  // Fire off a bunch of threads to do work:
+  while (concurrency--)
+    std::thread(
+      [block] {
+        while(block->owned)
+          try { block->dq.WaitForEvent(); }
+          catch(dispatch_aborted_exception&) {
+            // Expected behavior, things tearing down, end here
+            return;
+          }
+      }
+    ).detach();
+
+  // Configure our signal after everything else is done
+  onStopReg = ctxt.onShutdown += [this, block] {
+    std::lock_guard<std::mutex> lk(block->m_lock);
+    if (!block->owned)
+      // Status block already destroyed, we're in a teardown race
+      // Short-circuit here, no reason to double-call stop
+      return;
+
+    stop_unsafe();
+  };
+}
+
+parallel::~parallel(void) {
+  stop();
+}
+
+void parallel::stop(void) {
+  std::lock_guard<std::mutex> lk(m_block->m_lock);
+  stop_unsafe();
+}
+
+void parallel::stop_unsafe(void) {
+  // Trivial return check:
+  if (!m_block)
+    return;
+
+  m_block->owned = false;
+  m_ctxt->onShutdown -= onStopReg;
+  m_ctxt.reset();
+  m_block.reset();
+}

--- a/src/autowiring/test/ParallelTest.cpp
+++ b/src/autowiring/test/ParallelTest.cpp
@@ -11,7 +11,6 @@ class ParallelTest:
 {};
 
 TEST_F(ParallelTest, Basic) {
-  AutoCurrentContext()->Initiate();
   autowiring::parallel p;
 
   std::mt19937_64 mt(time(nullptr));
@@ -42,7 +41,6 @@ TEST_F(ParallelTest, Basic) {
 }
 
 TEST_F(ParallelTest, All) {
-  AutoCurrentContext()->Initiate();
   autowiring::parallel p;
 
   for (size_t i = 0; i < 10; i++)
@@ -57,7 +55,6 @@ TEST_F(ParallelTest, All) {
 }
 
 TEST_F(ParallelTest, VoidReturn) {
-  AutoCurrentContext()->Initiate();
   autowiring::parallel p;
 
   auto val = std::make_shared<std::atomic<size_t>>(0);
@@ -71,7 +68,6 @@ TEST_F(ParallelTest, VoidReturn) {
 }
 
 TEST_F(ParallelTest, VoidReturnAll) {
-  AutoCurrentContext()->Initiate();
   autowiring::parallel p;
 
   auto val = std::make_shared<std::atomic<size_t>>(0);
@@ -86,9 +82,8 @@ TEST_F(ParallelTest, VoidReturnAll) {
 }
 
 TEST_F(ParallelTest, Barrier) {
-  AutoCurrentContext()->Initiate();
   autowiring::parallel p;
-  
+
   std::atomic<size_t> x{ 0 };
   for (size_t i = 0; i < 1000; i++)
     p += [&x] { x++; };


### PR DESCRIPTION
This type is a little hard to use because the underlying thread pool is unpredictable.  Typical use cases do not mind the construction expense of this type, and instead simply prefer that the behavior is predictable.  Therefore, optimize on these use cases, and manually maintain a thread pool for system use.