### PR TITLE
Replace all instances of Autowired.h with autowiring.h

### DIFF
--- a/examples/AutoFilterExample.cpp
+++ b/examples/AutoFilterExample.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
-#include <autowiring/Autowired.h>
+#include <autowiring/autowiring.h>
 #include <iostream>
 #include <string>
 

--- a/examples/AutoFilterTutorial.0.0.cpp
+++ b/examples/AutoFilterTutorial.0.0.cpp
@@ -18,7 +18,7 @@
 /// deal only with ordinary input and output.
 ///
 /// This tutorial will define and instantiate a simple filter network.
-#include <autowiring/Autowired.h> // Needed for Autowiring classes.
+#include <autowiring/autowiring.h> // Needed for Autowiring classes.
 #include <cmath>                  // Needed for std::round.
 #include <cstdlib>                // Needed for std::atof.
 #include <iostream>               // Needed for std::cout.

--- a/examples/AutoFilterTutorial.1.0.cpp
+++ b/examples/AutoFilterTutorial.1.0.cpp
@@ -16,7 +16,7 @@
 /// - `const std::shared_ptr<const T>`
 /// - `const std::shared_ptr<const T> &`
 ///
-#include <autowiring/Autowired.h> // Needed for Autowiring classes.
+#include <autowiring/autowiring.h> // Needed for Autowiring classes.
 #include <iostream>               // Needed for std::cout.
 #include <string>                 // Needed for std::string.
 #include <unordered_set>          // Needed for std::unordered_set.

--- a/examples/AutoNetExample.cpp
+++ b/examples/AutoNetExample.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
-#include <autowiring/Autowired.h>
+#include <autowiring/autowiring.h>
 #include <autonet/AutoNetServer.h>
 #include <iostream>
 #include THREAD_HEADER

--- a/examples/ContextExample.cpp
+++ b/examples/ContextExample.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
-#include <autowiring/Autowired.h>
+#include <autowiring/autowiring.h>
 #include <iostream>
 #include <memory>
 

--- a/examples/ThreadExample.cpp
+++ b/examples/ThreadExample.cpp
@@ -1,5 +1,5 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
-#include <autowiring/Autowired.h>
+#include <autowiring/autowiring.h>
 #include <autowiring/CoreThread.h>
 #include <iostream>
 #include <memory>
@@ -30,35 +30,35 @@ public:
 };
 
 int main(){
-  
+
   // The 2 main thread classes in Autowiring are the BasicThread and CoreThread.
   // Classes that inherit from these types will have thread capabilities
   // Both start when their enclosing context is 'initiated'. Threads injected
   // after the context is initiated will start immediatly
-  
+
   AutoRequired<MyBasicThread> myBasic;
-  
+
   AutoCurrentContext ctxt;
   ctxt->Initiate(); // myBasic->Run() starts now in its own thread
-  
+
   std::this_thread::sleep_for(std::chrono::milliseconds(250));
-  
+
   std::cout << "injecting a CoreThread" << std::endl;
-  
+
   // Types inheriting from CoreThread implement a dispatch queue in their 'run()'
   // function. Lambdas can be appended with operator+=
-  
+
   AutoRequired<MyCoreThread> myCore;
   myCore->AddToQueue(42);
   myCore->AddToQueue(1337);
-  
+
   *myCore += []{
     std::cout << "This gets run after '1337'" << std::endl;
   };
-  
+
   // This should be run before 'myCore' is finished
   std::cout << "This thread is faster\n";
-  
+
   // This will wait for all outstanding threads to finish before terminating the context
   ctxt->SignalShutdown(true);
 }

--- a/src/autonet/test/stdafx.h
+++ b/src/autonet/test/stdafx.h
@@ -5,7 +5,7 @@
 #include <gtest/gtest.h>
 
 #ifdef _MSC_VER
-  #include <autowiring/Autowired.h>
+  #include <autowiring/autowiring.h>
   #include <thread>
   #include <mutex>
 #endif

--- a/src/autowiring/test/AutowiringTest.cpp
+++ b/src/autowiring/test/AutowiringTest.cpp
@@ -3,7 +3,7 @@
 #include "TestFixtures/SimpleObject.hpp"
 #include "TestFixtures/SimpleReceiver.hpp"
 #include <autotesting/gtest-all-guard.hpp>
-#include <autowiring/Autowired.h>
+#include <autowiring/autowiring.h>
 #include <autowiring/AutowiringDebug.h>
 #include <autowiring/CoreThread.h>
 

--- a/src/autowiring/test/AutowiringUtilitiesTest.cpp
+++ b/src/autowiring/test/AutowiringUtilitiesTest.cpp
@@ -1,6 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
-#include <autowiring/Autowired.h>
+#include <autowiring/autowiring.h>
 #include <autowiring/BasicThread.h>
 #include <autowiring/CoreThread.h>
 #include <autowiring/thread_specific_ptr.h>

--- a/src/autowiring/test/BoltTest.cpp
+++ b/src/autowiring/test/BoltTest.cpp
@@ -1,6 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
-#include <autowiring/Autowired.h>
+#include <autowiring/autowiring.h>
 #include <autowiring/Bolt.h>
 #include "TestFixtures/SimpleObject.hpp"
 #include <string>

--- a/src/autowiring/test/ContextCleanupTest.cpp
+++ b/src/autowiring/test/ContextCleanupTest.cpp
@@ -2,7 +2,7 @@
 #include "stdafx.h"
 #include "TestFixtures/SimpleObject.hpp"
 #include "TestFixtures/SimpleThreaded.hpp"
-#include <autowiring/Autowired.h>
+#include <autowiring/autowiring.h>
 #include <autowiring/CoreContext.h>
 #include THREAD_HEADER
 

--- a/src/autowiring/test/ContextMapTest.cpp
+++ b/src/autowiring/test/ContextMapTest.cpp
@@ -2,7 +2,7 @@
 #include "stdafx.h"
 #include "TestFixtures/ExitRaceThreaded.hpp"
 #include "TestFixtures/SimpleThreaded.hpp"
-#include <autowiring/Autowired.h>
+#include <autowiring/autowiring.h>
 #include <autowiring/ContextMap.h>
 #include <string>
 #include THREAD_HEADER

--- a/src/autowiring/test/CoreThreadTest.cpp
+++ b/src/autowiring/test/CoreThreadTest.cpp
@@ -2,7 +2,7 @@
 #include "stdafx.h"
 #include "TestFixtures/SimpleThreaded.hpp"
 #include <autowiring/at_exit.h>
-#include <autowiring/Autowired.h>
+#include <autowiring/autowiring.h>
 #include <algorithm>
 #include THREAD_HEADER
 

--- a/src/autowiring/test/CurrentContextPusherTest.cpp
+++ b/src/autowiring/test/CurrentContextPusherTest.cpp
@@ -1,6 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
-#include <autowiring/Autowired.h>
+#include <autowiring/autowiring.h>
 #include <autowiring/CoreContext.h>
 #include <autowiring/CurrentContextPusher.h>
 #include <thread>

--- a/src/autowiring/test/GlobalInitTest.cpp
+++ b/src/autowiring/test/GlobalInitTest.cpp
@@ -2,7 +2,7 @@
 #include "stdafx.h"
 #include "GlobalInitTest.hpp"
 #include "TestFixtures/SimpleObject.hpp"
-#include <autowiring/Autowired.h>
+#include <autowiring/autowiring.h>
 #include <autowiring/GlobalCoreContext.h>
 
 void GlobalInitTest::SetUp(void) {

--- a/src/autowiring/test/MultiInheritTest.cpp
+++ b/src/autowiring/test/MultiInheritTest.cpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/MultiInherit.hpp"
-#include <autowiring/Autowired.h>
+#include <autowiring/autowiring.h>
 #include <autowiring/CoreContext.h>
 
 class MultiInheritTest:

--- a/src/autowiring/test/OnceTest.cpp
+++ b/src/autowiring/test/OnceTest.cpp
@@ -2,7 +2,7 @@
 #include "stdafx.h"
 #include "TestFixtures/SimpleObject.hpp"
 #include "TestFixtures/SimpleThreaded.hpp"
-#include <autowiring/Autowired.h>
+#include <autowiring/autowiring.h>
 #include <autowiring/CoreContext.h>
 #include <autowiring/once.h>
 #include THREAD_HEADER

--- a/src/autowiring/test/PostConstructTest.cpp
+++ b/src/autowiring/test/PostConstructTest.cpp
@@ -2,7 +2,7 @@
 #include "stdafx.h"
 #include "TestFixtures/SimpleObject.hpp"
 #include "HasForwardOnlyType.hpp"
-#include <autowiring/Autowired.h>
+#include <autowiring/autowiring.h>
 #include <autowiring/ContextMember.h>
 #include THREAD_HEADER
 

--- a/src/autowiring/test/ScopeTest.cpp
+++ b/src/autowiring/test/ScopeTest.cpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/SimpleObject.hpp"
-#include <autowiring/Autowired.h>
+#include <autowiring/autowiring.h>
 #include <autowiring/GlobalCoreContext.h>
 
 class ScopeTest:

--- a/src/autowiring/test/TestFixtures/ExitRaceThreaded.hpp
+++ b/src/autowiring/test/TestFixtures/ExitRaceThreaded.hpp
@@ -1,6 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include <autowiring/Autowired.h>
+#include <autowiring/autowiring.h>
 #include <autowiring/CoreThread.h>
 
 /// <summary>

--- a/src/autowiring/test/TypeRegistryTest.cpp
+++ b/src/autowiring/test/TypeRegistryTest.cpp
@@ -1,6 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
-#include <autowiring/Autowired.h>
+#include <autowiring/autowiring.h>
 #include <autowiring/GlobalCoreContext.h>
 #include <autowiring/TypeRegistry.h>
 


### PR DESCRIPTION
Autowired.h is an old header name, we shouldn't be using it anymore because it doesn't match the naming of the enclosing library, even though it is the central header.