### PR TITLE
Add a configuration concept to Autowiring

### DIFF
--- a/src/autowiring/AnySharedPointer.h
+++ b/src/autowiring/AnySharedPointer.h
@@ -139,6 +139,15 @@ public:
     AnySharedPointer(std::shared_ptr<T>{})
   {}
 
+  AnySharedPointerT(T&& value) :
+    AnySharedPointer(std::make_shared<T>(std::forward<T&&>(value)))
+  {}
+
+  template<typename U>
+  AnySharedPointerT(U&& value) :
+    AnySharedPointer(std::make_shared<T>(std::forward<U&&>(value)))
+  {}
+
   T& operator*(void) { return *as<T>(); }
   const T& operator*(void) const { return *as<T>(); }
 

--- a/src/autowiring/Autowired.h
+++ b/src/autowiring/Autowired.h
@@ -174,7 +174,7 @@ public:
   };
 
   template<typename U, typename... Args>
-  signal_relay<U,Args...> operator()(autowiring::signal<void(Args...)> U::*sig) {
+  signal_relay<U, Args...> operator()(autowiring::signal<void(Args...)> U::*sig) {
     static_assert(std::is_base_of<U, T>::value, "Cannot reference member of unrelated type");
     return signal_relay<U, Args... >(*this, sig);
   }

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -62,6 +62,12 @@ set(Autowiring_SRCS
   callable.h
   CallExtractor.h
   CallExtractor.cpp
+  config_descriptor.h
+  config_descriptor.cpp
+  ConfigManager.h
+  ConfigManager.cpp
+  ConfigRegistry.h
+  ConfigRegistry.cpp
   ContextEnumerator.cpp
   ContextEnumerator.h
   ContextMap.h
@@ -104,6 +110,7 @@ set(Autowiring_SRCS
   hash_tuple.h
   has_autofilter.h
   has_autoinit.h
+  has_getconfigdescriptor.h
   has_simple_constructor.h
   has_static_new.h
   has_validate.h
@@ -127,8 +134,10 @@ set(Autowiring_SRCS
   ObjectPool.h
   ObjectPoolMonitor.cpp
   ObjectPoolMonitor.h
+  observable.h
   once.h
   once.cpp
+  optional.h
   Parallel.h
   Parallel.cpp
   registration.h

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -62,6 +62,7 @@ set(Autowiring_SRCS
   callable.h
   CallExtractor.h
   CallExtractor.cpp
+  config.h
   config_descriptor.h
   config_descriptor.cpp
   ConfigManager.h
@@ -123,6 +124,7 @@ set(Autowiring_SRCS
   is_shared_ptr.h
   ManualThreadPool.h
   ManualThreadPool.cpp
+  marshaller.h
   member_new_type.h
   MemoEntry.h
   MemoEntry.cpp

--- a/src/autowiring/ConfigManager.cpp
+++ b/src/autowiring/ConfigManager.cpp
@@ -1,0 +1,50 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "ConfigManager.h"
+
+using namespace autowiring;
+
+ConfigManager::ConfigManager(void) :
+  m_empty("")
+{}
+
+void ConfigManager::Register(void* pObj, const config_descriptor& desc) {
+  std::lock_guard<autowiring::spin_lock> lk(m_lock);
+  for (const auto& field : desc.fields) {
+    Entry& entry = m_config[field.second.name];
+    entry.attached.push_back({
+      &field.second,
+      static_cast<uint8_t*>(pObj) + field.second.offset
+    });
+
+    if (entry.value)
+      entry.attached.back().field->marshaller->unmarshal(
+        entry.attached.back().pObj,
+        entry.value->c_str()
+      );
+  }
+}
+
+const std::string& ConfigManager::Get(std::string name) const {
+  auto q = m_config.find(name);
+  if (q == m_config.end())
+    return m_empty;
+
+  return *q->second.value;
+}
+
+void ConfigManager::Set(std::string&& name, std::string&& value) {
+  std::lock_guard<autowiring::spin_lock> lk(m_lock);
+  auto q = m_config.find(name);
+  if (q == m_config.end())
+    q = m_config.insert(q, { std::move(name), {} });
+
+  Entry& entry = q->second;
+  entry.value = std::move(value);
+
+  for (Entry::Attachment& attachment : entry.attached)
+    attachment.field->marshaller->unmarshal(
+      attachment.pObj,
+      entry.value->c_str()
+    );
+}

--- a/src/autowiring/ConfigManager.cpp
+++ b/src/autowiring/ConfigManager.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ConfigManager.h"
+#include <mutex>
 
 using namespace autowiring;
 

--- a/src/autowiring/ConfigManager.h
+++ b/src/autowiring/ConfigManager.h
@@ -2,6 +2,7 @@
 #pragma once
 #include "config_descriptor.h"
 #include "optional.h"
+#include "spin_lock.h"
 #include <string>
 #include <unordered_map>
 

--- a/src/autowiring/ConfigManager.h
+++ b/src/autowiring/ConfigManager.h
@@ -1,0 +1,55 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "config_descriptor.h"
+#include "optional.h"
+#include <string>
+#include <unordered_map>
+
+namespace autowiring {
+  class ConfigManager {
+  public:
+    ConfigManager(void);
+
+  private:
+    spin_lock m_lock;
+
+    // A single entry, which has a string representation part paired
+    // with a pointer to the value part
+    struct Entry {
+      // The value held here
+      optional<std::string> value;
+
+      struct Attachment {
+        const config_field* field;
+        void* pObj;
+      };
+
+      // Fields attached on this entry:
+      std::vector<Attachment> attached;
+    };
+
+    // Empty string sentry, used when a miss occurs
+    const std::string m_empty;
+
+    // All configuration values
+    std::unordered_map<std::string, Entry> m_config;
+
+  public:
+    /// <summary>
+    /// Registers a new configurable object
+    /// </summary>
+    /// <param name="pObj">The object that may be configured</param>
+    /// <param name="desc">A descriptor for the object</param>
+    void Register(void* pObj, const config_descriptor& desc);
+
+    /// <summary>
+    /// Gets the current configuration value from the map
+    /// </summary>
+    const std::string& Get(std::string name) const;
+
+    /// <summary>
+    /// Sets the named config value in the map
+    /// </summary>
+    void Set(std::string&& name, std::string&& value);
+  };
+}

--- a/src/autowiring/ConfigManager.h
+++ b/src/autowiring/ConfigManager.h
@@ -5,6 +5,7 @@
 #include "spin_lock.h"
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace autowiring {
   class ConfigManager {

--- a/src/autowiring/ConfigRegistry.cpp
+++ b/src/autowiring/ConfigRegistry.cpp
@@ -1,0 +1,11 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "ConfigRegistry.h"
+
+using namespace autowiring;
+
+std::atomic<config_registry_entry_base*> autowiring::g_pFirstEntry;
+
+config_registry_entry_base::config_registry_entry_base(void) {
+  while (!g_pFirstEntry.compare_exchange_weak(pFlink, this));
+}

--- a/src/autowiring/ConfigRegistry.h
+++ b/src/autowiring/ConfigRegistry.h
@@ -1,0 +1,64 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "config_descriptor.h"
+#include <atomic>
+
+namespace autowiring {
+  struct config_registry_entry_base {
+  protected:
+    config_registry_entry_base(void);
+
+  public:
+    // Next entry in the registry:
+    config_registry_entry_base* pFlink = nullptr;
+  };
+
+  template<typename T, typename = void>
+  struct config_registry_entry {
+    static const config_descriptor* desc(void) { return nullptr; }
+  };
+
+  template<typename T>
+  struct config_registry_entry<T, typename std::enable_if<has_getconfigdescriptor<T>::value>::type> :
+    config_registry_entry_base
+  {
+  public:
+    static const config_descriptor* desc(void) {
+      static const config_descriptor desc = T::GetConfigDescriptor();
+      return &desc;
+    }
+  };
+
+  extern std::atomic<config_registry_entry_base*> g_pFirstEntry;
+
+  /// <summary>
+  /// Gets a string representation of the named configuration value
+  /// </summary>
+  template<typename T>
+  std::string ConfigGet(const char* name, T& obj) {
+    const config_descriptor& desc = *config_registry_entry<T>::desc();
+    auto q = desc.fields.find(name);
+    if (q == desc.fields.end())
+      throw std::invalid_argument("Configuration name not found in the specified object's configuration descriptor");
+
+    const autowiring::config_field& f = q->second;
+    return f.marshaller->marshal(reinterpret_cast<uint8_t*>(&obj) + f.offset);
+  }
+
+  /// <summary>
+  /// Sets the named configuration value to the specified string value
+  /// </summary>
+  template<typename T>
+  void ConfigSet(const char* name, T& obj, const char* value) {
+    const config_descriptor& desc = *config_registry_entry<T>::desc();
+    auto q = desc.fields.find(name);
+    if (q == desc.fields.end())
+      throw std::invalid_argument("Configuration name not found in the specified object's configuration descriptor");
+
+    const autowiring::config_field& f = q->second;
+    f.marshaller->unmarshal(
+      reinterpret_cast<uint8_t*>(&obj) + f.offset,
+      value
+    );
+  }
+}

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -969,11 +969,3 @@ std::shared_ptr<CoreContext> CoreContext::SetCurrent(void) {
 void CoreContext::EvictCurrent(void) {
   autoCurrentContext.reset();
 }
-
-void CoreContext::ConfigSet(std::string name, std::string value) {
-  m_cfgManager.Set(std::move(name), std::move(value));
-}
-
-const std::string& CoreContext::ConfigGet(std::string name) const {
-  return m_cfgManager.Get(std::move(name));
-}

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -969,3 +969,11 @@ std::shared_ptr<CoreContext> CoreContext::SetCurrent(void) {
 void CoreContext::EvictCurrent(void) {
   autoCurrentContext.reset();
 }
+
+void CoreContext::ConfigSet(std::string name, std::string value) {
+  m_cfgManager.Set(std::move(name), std::move(value));
+}
+
+const std::string& CoreContext::ConfigGet(std::string name) const {
+  return m_cfgManager.Get(std::move(name));
+}

--- a/src/autowiring/CoreContext.h
+++ b/src/autowiring/CoreContext.h
@@ -134,6 +134,9 @@ public:
   // Asserted any time a new object is added to the context
   autowiring::signal<void(const CoreObjectDescriptor&)> newObject;
 
+  // The one and only configuration manager type
+  autowiring::ConfigManager Config;
+
   virtual ~CoreContext(void);
 
   /// <summary>
@@ -214,9 +217,6 @@ protected:
   // All known context members, exception filters:
   std::vector<ContextMember*> m_contextMembers;
   std::vector<ExceptionFilter*> m_filters;
-
-  // The one and only configuration manager type
-  autowiring::ConfigManager m_cfgManager;
 
   // Context members from other contexts that have snooped this context
   std::set<AnySharedPointer> m_snoopers;
@@ -616,7 +616,7 @@ public:
     // value of pConfigDesc because it's a little faster and one necessarily follows the other
     // We also want this to happen before the AutoInit call is made
     if(autowiring::has_getconfigdescriptor<T>::value)
-      m_cfgManager.Register(static_cast<T*>(retVal.get()), *objDesc.pConfigDesc);
+      Config.Register(static_cast<T*>(retVal.get()), *objDesc.pConfigDesc);
 
     // AutoInit if sensible to do so:
     CallAutoInit(*retVal, has_autoinit<T>());
@@ -969,16 +969,6 @@ public:
     CurrentContextPusher pshr(*this);
     memo.onSatisfied += std::forward<Fn&&>(listener);
   }
-
-  /// <summary>
-  /// Sets a single configuration value from the context
-  /// </summary>
-  void ConfigSet(std::string name, std::string value);
-
-  /// <summary>
-  /// Gets a configuration value from the context
-  /// </summary>
-  const std::string& ConfigGet(std::string name) const;
 
   /// <summary>
   /// Adds a teardown notifier which receives a pointer to this context on destruction

--- a/src/autowiring/CoreObjectDescriptor.h
+++ b/src/autowiring/CoreObjectDescriptor.h
@@ -4,6 +4,7 @@
 #include "auto_id.h"
 #include "AutoFilterDescriptor.h"
 #include "BoltBase.h"
+#include "ConfigRegistry.h"
 #include "ContextMember.h"
 #include "CoreObject.h"
 #include "CoreRunnable.h"
@@ -49,6 +50,7 @@ struct CoreObjectDescriptor {
     pBasicThread(autowiring::fast_pointer_cast<BasicThread>(value)),
     pFilter(autowiring::fast_pointer_cast<ExceptionFilter>(value)),
     pBoltBase(autowiring::fast_pointer_cast<BoltBase>(value)),
+    pConfigDesc(autowiring::config_registry_entry<T>::desc()),
     primitiveOffset(
       reinterpret_cast<size_t>(
         static_cast<T*>(
@@ -122,6 +124,9 @@ struct CoreObjectDescriptor {
   std::shared_ptr<BasicThread> pBasicThread;
   std::shared_ptr<ExceptionFilter> pFilter;
   std::shared_ptr<BoltBase> pBoltBase;
+
+  // Configuration descriptor, if the object provides one
+  const autowiring::config_descriptor* pConfigDesc;
 
   // Distance from TActual to T
   size_t primitiveOffset;

--- a/src/autowiring/Decompose.h
+++ b/src/autowiring/Decompose.h
@@ -1,14 +1,11 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "is_any.h"
-#include <tuple>
 #include <typeinfo>
 
 template<class... Ts>
 struct TemplatePack {
   static const int N = sizeof...(Ts);
-
-  typedef std::tuple<Ts...> t_args;
 
   /// <returns>
   /// An array of type T, parameterized by the bound function's arguments

--- a/src/autowiring/DecorationDisposition.h
+++ b/src/autowiring/DecorationDisposition.h
@@ -6,25 +6,24 @@
 #include <cassert>
 #include <set>
 #include <vector>
-#include TYPE_INDEX_HEADER
 
 struct SatCounter;
 
 struct DecorationKey {
   DecorationKey(void) = default;
-  
+
   explicit DecorationKey(auto_id id, int tshift) :
     id(id),
     tshift(tshift)
   {}
-  
+
   // The type index
   auto_id id;
 
   // Zero refers to a decoration created on this packet, a positive number [tshift] indicates
   // a decoration attached [tshift] packets ago.
   int tshift = -1;
-  
+
   bool operator==(const DecorationKey& rhs) const {
     return id == rhs.id && tshift == rhs.tshift;
   }
@@ -126,7 +125,7 @@ struct DecorationDisposition
 
   // The current state of this disposition
   DispositionState m_state = DispositionState::Unsatisfied;
-  
+
   /// <returns>
   /// True if all publishers have run on this disposition
   /// </summary>

--- a/src/autowiring/DispatchQueue.h
+++ b/src/autowiring/DispatchQueue.h
@@ -4,7 +4,6 @@
 #include "DispatchThunk.h"
 #include "once.h"
 #include <atomic>
-#include <list>
 #include <queue>
 #include MUTEX_HEADER
 #include RVALUE_HEADER

--- a/src/autowiring/Parallel.h
+++ b/src/autowiring/Parallel.h
@@ -5,7 +5,6 @@
 #include "DispatchQueue.h"
 #include <iterator>
 #include <unordered_map>
-#include <typeindex>
 #include <deque>
 
 class CoreContext;

--- a/src/autowiring/auto_id.h
+++ b/src/autowiring/auto_id.h
@@ -1,8 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "fast_pointer_cast.h"
-#include <functional>
-#include TYPE_INDEX_HEADER
 
 class CoreObject;
 

--- a/src/autowiring/config.h
+++ b/src/autowiring/config.h
@@ -29,12 +29,17 @@ namespace autowiring {
     explicit config(const T& value) { values[0] = value; }
     explicit config(T&& value) { values[0] = std::move(value); }
 
+    template<typename U>
+    explicit config(U&& value) {
+      values[0] = std::forward<U&&>(value);
+    }
+
   private:
     // Lock, used to move the asyncrhonous value to the value field
     autowiring::spin_lock lock;
 
     // Tracks whether the backing value has been updated
-    bool dirty = false;
+    bool dirty = true;
 
     // The index of the currently active value
     size_t valueIndex = 0;

--- a/src/autowiring/config.h
+++ b/src/autowiring/config.h
@@ -1,0 +1,93 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include <autowiring/spin_lock.h>
+#include <array>
+
+namespace autowiring {
+  /// <summary>
+  /// A configuration value tracker class used with the configuration systems
+  /// </summary>
+  /// <remarks>
+  /// This class uses a double-buffered value approach to avoid synchronization requirements
+  /// under asynchronous update.  It assumes a single point of use and multiple points of
+  /// update.  The clear_dirty call can be used to simaltaneously switch the active value
+  /// buffer and also clear the dirty flag.
+  /// </remarks>
+  template<typename T>
+  struct config {
+    config(void) = default;
+    config(const config&) = delete;
+    config(config&& rhs):
+      dirty(rhs.dirty),
+      valueIndex(rhs.valueIndex)
+    {
+      values[0] = std::move(rhs.values[0]);
+      values[1] = std::move(rhs.values[1]);
+    }
+
+    explicit config(const T& value) { values[0] = value; }
+    explicit config(T&& value) { values[0] = std::move(value); }
+
+  private:
+    // Lock, used to move the asyncrhonous value to the value field
+    autowiring::spin_lock lock;
+
+    // Tracks whether the backing value has been updated
+    bool dirty = false;
+
+    // The index of the currently active value
+    size_t valueIndex = 0;
+
+    // The active value, advertised by accessors, and the dirty value, accessed
+    // by assigners.
+    std::array<T, 2> values;
+
+  public:
+    bool is_dirty(void) const { return dirty; }
+    const T& get(void) const { return values[valueIndex]; }
+
+    /// <summary>
+    /// Clears the dirty bit and returns its value prior to the clear
+    /// </summary>
+    /// <returns>True if the field was dirty, false otherwise</returns>
+    /// <remarks>
+    /// This method must be synchronized with all accessors.
+    /// </remarks>
+    bool clear_dirty(void) {
+      if (!dirty)
+        return false;
+
+      std::lock_guard<autowiring::spin_lock> lk(lock);
+      valueIndex = !valueIndex;
+      dirty = false;
+      return true;
+    }
+
+    operator const T&(void) const { return get(); }
+    const T* operator->(void) const { return &get(); }
+    const T& operator*(void) const { return get(); }
+    bool operator==(const T& rhs) const { return get() == rhs; }
+    bool operator!=(const T& rhs) const { return get() != rhs; }
+
+    config& operator=(const config& value) {
+      // Local copy to hold the spin lock a minimum amount of time
+      return *this = value.get();
+    }
+
+    template<typename U>
+    config& operator=(const U& rhs) {
+      return *this = T{ rhs };
+    }
+
+    template<typename U>
+    config& operator=(U&& rhs) {
+      std::lock_guard<autowiring::spin_lock> lk(lock);
+      this->values[!valueIndex] = std::forward<U&&>(rhs);
+      dirty = true;
+      return *this;
+    }
+  };
+
+  template<typename T>
+  bool operator==(const T& lhs, const config<T>& rhs) { return rhs == lhs; }
+}

--- a/src/autowiring/config_descriptor.cpp
+++ b/src/autowiring/config_descriptor.cpp
@@ -1,0 +1,10 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "config_descriptor.h"
+
+autowiring::config_descriptor::t_mpType autowiring::config_descriptor::MakeFields(const std::initializer_list<config_field>& fields) {
+  t_mpType retVal;
+  for (auto& field : fields)
+    retVal[field.name] = field;
+  return retVal;
+}

--- a/src/autowiring/config_descriptor.h
+++ b/src/autowiring/config_descriptor.h
@@ -25,7 +25,7 @@ namespace autowiring {
       "Marshaller for type T does not implement the marshal_base interface"
     );
 
-    static const marshaller<T> sc_marshaller;
+    static const marshaller<T> sc_marshaller{};
     return sc_marshaller;
   }
 

--- a/src/autowiring/config_descriptor.h
+++ b/src/autowiring/config_descriptor.h
@@ -1,293 +1,32 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AnySharedPointer.h"
-#include "config.h"
 #include "has_getconfigdescriptor.h"
-#include "observable.h"
+#include "marshaller.h"
 #include <initializer_list>
 #include <stdexcept>
-#include TYPE_TRAITS_HEADER
 
 namespace autowiring {
-  struct invalid_marshal_base {};
-  template<typename T> struct marshaller;
-
-  /// <summary>
-  /// The interface all marshallers must support
-  /// </summary>
-  struct marshaller_base {
-    /// <summary>
-    /// Marshals the underlying type to a string value
-    /// </summary>
-    virtual std::string marshal(const void* ptr) const { return ""; }
-
-    /// <summary>
-    /// Converts the specified string value to the output type
-    /// </summary>
-    /// <param name="szValue">The string value to be converted</param>
-    /// <param name="ptr">A pointer to the memory region where the output will be stored</param>
-    virtual void unmarshal(void* ptr, const char* szValue) const = 0;
-  };
-
-  /// <summary>
-  /// Built-in marshaller, declared separately because it's a little more complicated
-  /// </summary>
-  template<typename T, typename>
-  struct builtin_marshaller :
-    invalid_marshal_base
-  {};
+  template<typename T>
+  struct marshaller;
 
   template<typename T>
-  struct builtin_marshaller<autowiring::observable<T>, void>:
-    marshaller_base
-  {
-    typedef autowiring::observable<T> type;
+  static const marshaller<T>& get_marshaller(void) {
+    // To fix this, specialize autowiring::marshal for your type
+    static_assert(
+      !std::is_base_of<invalid_marshal_base, autowiring::marshaller<T>>::value,
+      "Autowiring does not provide a built-in marshaller for type T"
+    );
 
-    // Marshaller for the interior type
-    marshaller<T> interior;
+    // To fix this, ensure your specialization implements marshal_base
+    static_assert(
+      std::is_base_of<autowiring::marshaller_base, autowiring::marshaller<T>> ::value,
+      "Marshaller for type T does not implement the marshal_base interface"
+    );
 
-    std::string marshal(const void* ptr) const override {
-      return interior.marshal(&static_cast<const type*>(ptr)->get());
-    }
-
-    void unmarshal(void* ptr, const char* szValue) const override {
-      T value;
-      interior.unmarshal(&value, szValue);
-      *static_cast<type*>(ptr) = std::move(value);
-    }
-  };
-
-  template<typename T>
-  struct builtin_marshaller<std::atomic<T>, void>:
-    marshaller_base
-  {
-    typedef std::atomic<T> type;
-
-    // Marshaller for the interior type
-    marshaller<T> interior;
-
-    std::string marshal(const void* ptr) const override {
-      T value = static_cast<const type*>(ptr)->load();
-      return interior.marshal(&value);
-    }
-
-    void unmarshal(void* ptr, const char* szValue) const override {
-      T value;
-      interior.unmarshal(&value, szValue);
-      *static_cast<type*>(ptr) = std::move(value);
-    }
-  };
-
-  template<typename T>
-  struct builtin_marshaller<autowiring::config<T>, void>:
-    marshaller_base
-  {
-    typedef autowiring::config<T> type;
-
-    // Marshaller for the interior type
-    marshaller<T> interior;
-
-    std::string marshal(const void* ptr) const override {
-      return interior.marshal(&static_cast<const type*>(ptr)->get());
-    }
-
-    void unmarshal(void* ptr, const char* szValue) const override {
-      T value;
-      interior.unmarshal(&value, szValue);
-      *static_cast<type*>(ptr) = std::move(value);
-    }
-  };
-
-  template<>
-  struct builtin_marshaller<std::string, void> :
-    marshaller_base
-  {
-    typedef std::string type;
-
-    std::string marshal(const void* ptr) const override {
-      return *static_cast<const type*>(ptr);
-    }
-
-    void unmarshal(void* ptr, const char* szValue) const override {
-      *static_cast<std::string*>(ptr) = szValue;
-    }
-  };
-
-  template<>
-  struct builtin_marshaller<bool, void> :
-    marshaller_base
-  {
-    typedef bool type;
-
-    std::string marshal(const void* ptr) const override {
-      return *static_cast<const bool*>(ptr) ? "true" : "false";
-    }
-
-    void unmarshal(void* ptr, const char* szValue) const override {
-      if (!strcmp("true", szValue))
-        *static_cast<bool*>(ptr) = true;
-      else if (!strcmp("false", szValue))
-        *static_cast<bool*>(ptr) = false;
-      else
-        throw std::invalid_argument("Boolean unmarshaller expects true or false keyword");
-    }
-  };
-
-  template<>
-  struct builtin_marshaller<volatile bool, void> :
-    builtin_marshaller<bool, void>
-  {};
-
-  template<typename T>
-  struct builtin_marshaller<T, typename std::enable_if<std::is_integral<T>::value>::type> :
-    marshaller_base
-  {
-    typedef typename std::remove_volatile<T>::type type;
-
-    std::string marshal(const void* ptr) const override {
-      std::string retVal;
-      type val = *static_cast<const type*>(ptr);
-      bool pos = 0 < val;
-      for (; val; val /= 10) {
-        retVal.push_back(static_cast<char>(val % 10 + '0'));
-      }
-      if (!pos)
-        retVal.push_back('-');
-      std::reverse(retVal.begin(), retVal.end());
-      return retVal;
-    }
-
-    void unmarshal(void* ptr, const char* szValue) const override {
-      type& value = *static_cast<type*>(ptr);
-      bool negative = *szValue == '-';
-      if(negative) {
-        // Skip over the sign, verify we aren't assigning to the wrong field type
-        szValue++;
-        if (std::is_unsigned<type>::value)
-          throw std::range_error("Attempted to set a signed value on an unsigned calibration field");
-      }
-
-      for (value = 0; *szValue; szValue++) {
-        if (*szValue < '0' || '9' < *szValue)
-          throw std::invalid_argument("String value is not an integer");
-        value = *szValue - '0' + value * 10;
-      }
-      if(negative)
-        value *= -1;
-    }
-  };
-
-  template<typename T>
-  struct builtin_marshaller<T, typename std::enable_if<std::is_floating_point<T>::value>::type> :
-    marshaller_base
-  {
-    typedef typename std::remove_volatile<T>::type type;
-
-    std::string marshal(const void* ptr) const override {
-      std::string retVal;
-      type value = *static_cast<const type*>(ptr);
-      if (value == 0.0f)
-        return "0";
-
-      bool neg = value < 0.0f;
-      if (neg)
-        value *= -1.0f;
-
-      // Convert input value to scientific notation
-      int power = static_cast<int>(std::log10(value));
-
-      // We will be assembling the number backwards, need to keep track of the
-      // current digit
-      int curDigit = std::numeric_limits<type>::digits10 - power;
-
-      // We only want a certain number of digits, this digit count will fit in
-      // a large integer and elimintes the loss of precision we experience when
-      // using floating point math to try to do digit shifts
-      uint64_t digits = static_cast<uint64_t>(value * std::pow(10.0, curDigit));
-
-      // Trailing zero introduction
-      if (power > std::numeric_limits<type>::digits10)
-        retVal.append(power - std::numeric_limits<type>::digits10, '0');
-
-      // Trailing zero omission
-      while (0 < curDigit && 0 == (digits % 10)) {
-        digits /= 10;
-        curDigit--;
-      }
-
-      for(; digits; digits /= 10, curDigit--) {
-        char digit = static_cast<char>(digits % 10);
-
-        // String conversion step, straightforward mapping
-        retVal.push_back('0' + digit);
-        if (curDigit == 1)
-          retVal.push_back('.');
-
-        if (!digits)
-          // Short-circuit for precise representations
-          break;
-      }
-
-      // Zeroes before the decimal:
-      if (power < 0) {
-        retVal.append(-power, '0');
-        retVal.append(".0");
-      }
-
-      if (neg)
-        retVal.push_back('-');
-      std::reverse(retVal.begin(), retVal.end());
-      return retVal;
-    }
-
-    void unmarshal(void* ptr, const char* szValue) const override {
-      T& value = *static_cast<type*>(ptr);
-      bool negative = *szValue == '-';
-      if (negative)
-        szValue++;
-
-      uint64_t whole = 0;
-      for (; *szValue; szValue++) {
-        // Detect the decimal marker, switch to fractional part
-        if (*szValue == '.') {
-          szValue++;
-          break;
-        }
-        if (*szValue < '0' || '9' < *szValue)
-          throw std::invalid_argument("String value is not a decimal number");
-        whole = whole * 10 + *szValue - '0';
-      }
-
-      uint64_t fractional = 0;
-      size_t n = 0;
-      for (; szValue[n]; n++) {
-        if (szValue[n] < '0' || '9' < szValue[n])
-          throw std::invalid_argument("String value is not a decimal number");
-        fractional = fractional * 10 + szValue[n] - '0';
-      }
-      value = static_cast<type>(fractional);
-      while(n--)
-        value /= 10.0f;
-      value += static_cast<type>(whole);
-      if (negative)
-        value *= -1.0f;
-    }
-  };
-
-  /// <summary>
-  /// Default marshaller, a point of specialization for external users
-  /// </summary>
-  template<typename T>
-  struct marshaller :
-    builtin_marshaller<T, void>
-  {};
-
-  template<typename T>
-  struct marshal_holder {
-    static const marshaller<T> marshaller;
-  };
-  template<typename T>
-  const marshaller<T> marshal_holder<T>::marshaller;
+    static const marshaller<T> sc_marshaller;
+    return sc_marshaller;
+  }
 
   struct config_field {
     config_field(void) = default;
@@ -297,30 +36,17 @@ namespace autowiring {
       name(name),
       description(desc),
       offset(reinterpret_cast<size_t>(&(static_cast<T*>(nullptr)->*memptr))),
-      default_value(std::make_shared<typename std::remove_cv<U>::type>())
-    {
-      // To fix this, specialize autowiring::marshal for your type
-      static_assert(
-        !std::is_base_of<invalid_marshal_base, autowiring::marshaller<U>>::value,
-        "Autowiring does not provide a built-in marshaller for type T"
-      );
-
-      // To fix this, ensure your specialization implements marshal_base
-      static_assert(
-        std::is_base_of<autowiring::marshaller_base, autowiring::marshaller<U>> ::value,
-        "Marshaller for type T does not implement the marshal_base interface"
-      );
-      marshaller = &marshal_holder<U>::marshaller;
-    }
+      default_value(std::make_shared<typename std::remove_cv<U>::type>()),
+      marshaller{ &get_marshaller<U>() }
+    {}
 
     template<typename T, typename U>
     config_field(const char* name, U T::* memptr) :
       name(name),
       offset(reinterpret_cast<size_t>(&(static_cast<T*>(nullptr)->*memptr))),
+      marshaller{ &get_marshaller<U>() },
       default_value(std::make_shared<typename std::remove_cv<U>::type>())
-    {
-      marshaller = &marshal_holder<U>::marshaller;
-    }
+    {}
 
     // Name and optional description
     const char* name = nullptr;

--- a/src/autowiring/config_descriptor.h
+++ b/src/autowiring/config_descriptor.h
@@ -5,6 +5,7 @@
 #include "marshaller.h"
 #include <initializer_list>
 #include <stdexcept>
+#include <unordered_map>
 
 namespace autowiring {
   template<typename T>

--- a/src/autowiring/config_descriptor.h
+++ b/src/autowiring/config_descriptor.h
@@ -1,0 +1,363 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "AnySharedPointer.h"
+#include "config.h"
+#include "has_getconfigdescriptor.h"
+#include "observable.h"
+#include <initializer_list>
+#include <stdexcept>
+#include TYPE_TRAITS_HEADER
+
+namespace autowiring {
+  struct invalid_marshal_base {};
+  template<typename T> struct marshaller;
+
+  /// <summary>
+  /// The interface all marshallers must support
+  /// </summary>
+  struct marshaller_base {
+    /// <summary>
+    /// Marshals the underlying type to a string value
+    /// </summary>
+    virtual std::string marshal(const void* ptr) const { return ""; }
+
+    /// <summary>
+    /// Converts the specified string value to the output type
+    /// </summary>
+    /// <param name="szValue">The string value to be converted</param>
+    /// <param name="ptr">A pointer to the memory region where the output will be stored</param>
+    virtual void unmarshal(void* ptr, const char* szValue) const = 0;
+  };
+
+  /// <summary>
+  /// Built-in marshaller, declared separately because it's a little more complicated
+  /// </summary>
+  template<typename T, typename>
+  struct builtin_marshaller :
+    invalid_marshal_base
+  {};
+
+  template<typename T>
+  struct builtin_marshaller<autowiring::observable<T>, void>:
+    marshaller_base
+  {
+    typedef autowiring::observable<T> type;
+
+    // Marshaller for the interior type
+    marshaller<T> interior;
+
+    std::string marshal(const void* ptr) const override {
+      return interior.marshal(&static_cast<const type*>(ptr)->get());
+    }
+
+    void unmarshal(void* ptr, const char* szValue) const override {
+      T value;
+      interior.unmarshal(&value, szValue);
+      *static_cast<type*>(ptr) = std::move(value);
+    }
+  };
+
+  template<typename T>
+  struct builtin_marshaller<std::atomic<T>, void>:
+    marshaller_base
+  {
+    typedef std::atomic<T> type;
+
+    // Marshaller for the interior type
+    marshaller<T> interior;
+
+    std::string marshal(const void* ptr) const override {
+      T value = static_cast<const type*>(ptr)->load();
+      return interior.marshal(&value);
+    }
+
+    void unmarshal(void* ptr, const char* szValue) const override {
+      T value;
+      interior.unmarshal(&value, szValue);
+      *static_cast<type*>(ptr) = std::move(value);
+    }
+  };
+
+  template<typename T>
+  struct builtin_marshaller<autowiring::config<T>, void>:
+    marshaller_base
+  {
+    typedef autowiring::config<T> type;
+
+    // Marshaller for the interior type
+    marshaller<T> interior;
+
+    std::string marshal(const void* ptr) const override {
+      return interior.marshal(&static_cast<const type*>(ptr)->get());
+    }
+
+    void unmarshal(void* ptr, const char* szValue) const override {
+      T value;
+      interior.unmarshal(&value, szValue);
+      *static_cast<type*>(ptr) = std::move(value);
+    }
+  };
+
+  template<>
+  struct builtin_marshaller<std::string, void> :
+    marshaller_base
+  {
+    typedef std::string type;
+
+    std::string marshal(const void* ptr) const override {
+      return *static_cast<const type*>(ptr);
+    }
+
+    void unmarshal(void* ptr, const char* szValue) const override {
+      *static_cast<std::string*>(ptr) = szValue;
+    }
+  };
+
+  template<>
+  struct builtin_marshaller<bool, void> :
+    marshaller_base
+  {
+    typedef bool type;
+
+    std::string marshal(const void* ptr) const override {
+      return *static_cast<const bool*>(ptr) ? "true" : "false";
+    }
+
+    void unmarshal(void* ptr, const char* szValue) const override {
+      if (!strcmp("true", szValue))
+        *static_cast<bool*>(ptr) = true;
+      else if (!strcmp("false", szValue))
+        *static_cast<bool*>(ptr) = false;
+      else
+        throw std::invalid_argument("Boolean unmarshaller expects true or false keyword");
+    }
+  };
+
+  template<>
+  struct builtin_marshaller<volatile bool, void> :
+    builtin_marshaller<bool, void>
+  {};
+
+  template<typename T>
+  struct builtin_marshaller<T, typename std::enable_if<std::is_integral<T>::value>::type> :
+    marshaller_base
+  {
+    typedef typename std::remove_volatile<T>::type type;
+
+    std::string marshal(const void* ptr) const override {
+      std::string retVal;
+      type val = *static_cast<const type*>(ptr);
+      bool pos = 0 < val;
+      for (; val; val /= 10) {
+        retVal.push_back(static_cast<char>(val % 10 + '0'));
+      }
+      if (!pos)
+        retVal.push_back('-');
+      std::reverse(retVal.begin(), retVal.end());
+      return retVal;
+    }
+
+    void unmarshal(void* ptr, const char* szValue) const override {
+      type& value = *static_cast<type*>(ptr);
+      bool negative = *szValue == '-';
+      if(negative) {
+        // Skip over the sign, verify we aren't assigning to the wrong field type
+        szValue++;
+        if (std::is_unsigned<type>::value)
+          throw std::range_error("Attempted to set a signed value on an unsigned calibration field");
+      }
+
+      for (value = 0; *szValue; szValue++) {
+        if (*szValue < '0' || '9' < *szValue)
+          throw std::invalid_argument("String value is not an integer");
+        value = *szValue - '0' + value * 10;
+      }
+      if(negative)
+        value *= -1;
+    }
+  };
+
+  template<typename T>
+  struct builtin_marshaller<T, typename std::enable_if<std::is_floating_point<T>::value>::type> :
+    marshaller_base
+  {
+    typedef typename std::remove_volatile<T>::type type;
+
+    std::string marshal(const void* ptr) const override {
+      std::string retVal;
+      type value = *static_cast<const type*>(ptr);
+      if (value == 0.0f)
+        return "0";
+
+      bool neg = value < 0.0f;
+      if (neg)
+        value *= -1.0f;
+
+      // Convert input value to scientific notation
+      int power = static_cast<int>(std::log10(value));
+
+      // We will be assembling the number backwards, need to keep track of the
+      // current digit
+      int curDigit = std::numeric_limits<type>::digits10 - power;
+
+      // We only want a certain number of digits, this digit count will fit in
+      // a large integer and elimintes the loss of precision we experience when
+      // using floating point math to try to do digit shifts
+      uint64_t digits = static_cast<uint64_t>(value * std::pow(10.0, curDigit));
+
+      // Trailing zero introduction
+      if (power > std::numeric_limits<type>::digits10)
+        retVal.append(power - std::numeric_limits<type>::digits10, '0');
+
+      // Trailing zero omission
+      while (0 < curDigit && 0 == (digits % 10)) {
+        digits /= 10;
+        curDigit--;
+      }
+
+      for(; digits; digits /= 10, curDigit--) {
+        char digit = static_cast<char>(digits % 10);
+
+        // String conversion step, straightforward mapping
+        retVal.push_back('0' + digit);
+        if (curDigit == 1)
+          retVal.push_back('.');
+
+        if (!digits)
+          // Short-circuit for precise representations
+          break;
+      }
+
+      // Zeroes before the decimal:
+      if (power < 0) {
+        retVal.append(-power, '0');
+        retVal.append(".0");
+      }
+
+      if (neg)
+        retVal.push_back('-');
+      std::reverse(retVal.begin(), retVal.end());
+      return retVal;
+    }
+
+    void unmarshal(void* ptr, const char* szValue) const override {
+      T& value = *static_cast<type*>(ptr);
+      bool negative = *szValue == '-';
+      if (negative)
+        szValue++;
+
+      uint64_t whole = 0;
+      for (; *szValue; szValue++) {
+        // Detect the decimal marker, switch to fractional part
+        if (*szValue == '.') {
+          szValue++;
+          break;
+        }
+        if (*szValue < '0' || '9' < *szValue)
+          throw std::invalid_argument("String value is not a decimal number");
+        whole = whole * 10 + *szValue - '0';
+      }
+
+      uint64_t fractional = 0;
+      size_t n = 0;
+      for (; szValue[n]; n++) {
+        if (szValue[n] < '0' || '9' < szValue[n])
+          throw std::invalid_argument("String value is not a decimal number");
+        fractional = fractional * 10 + szValue[n] - '0';
+      }
+      value = static_cast<type>(fractional);
+      while(n--)
+        value /= 10.0f;
+      value += static_cast<type>(whole);
+      if (negative)
+        value *= -1.0f;
+    }
+  };
+
+  /// <summary>
+  /// Default marshaller, a point of specialization for external users
+  /// </summary>
+  template<typename T>
+  struct marshaller :
+    builtin_marshaller<T, void>
+  {};
+
+  template<typename T>
+  struct marshal_holder {
+    static const marshaller<T> marshaller;
+  };
+  template<typename T>
+  const marshaller<T> marshal_holder<T>::marshaller;
+
+  struct config_field {
+    config_field(void) = default;
+
+    template<typename T, typename U, typename V>
+    config_field(const char* name, const char* desc, U T::* memptr, V&& default_value) :
+      name(name),
+      description(desc),
+      offset(reinterpret_cast<size_t>(&(static_cast<T*>(nullptr)->*memptr))),
+      default_value(std::make_shared<typename std::remove_cv<U>::type>())
+    {
+      // To fix this, specialize autowiring::marshal for your type
+      static_assert(
+        !std::is_base_of<invalid_marshal_base, autowiring::marshaller<U>>::value,
+        "Autowiring does not provide a built-in marshaller for type T"
+      );
+
+      // To fix this, ensure your specialization implements marshal_base
+      static_assert(
+        std::is_base_of<autowiring::marshaller_base, autowiring::marshaller<U>> ::value,
+        "Marshaller for type T does not implement the marshal_base interface"
+      );
+      marshaller = &marshal_holder<U>::marshaller;
+    }
+
+    template<typename T, typename U>
+    config_field(const char* name, U T::* memptr) :
+      name(name),
+      offset(reinterpret_cast<size_t>(&(static_cast<T*>(nullptr)->*memptr))),
+      default_value(std::make_shared<typename std::remove_cv<U>::type>())
+    {
+      marshaller = &marshal_holder<U>::marshaller;
+    }
+
+    // Name and optional description
+    const char* name = nullptr;
+    const char* description = nullptr;
+
+    // Offset from the base of the object to the member to be serialized
+    size_t offset = 0;
+
+    // Default value for this type, if one exists:
+    AnySharedPointer default_value;
+
+    // Pointer to the required marshaller singleton:
+    const marshaller_base* marshaller = nullptr;
+  };
+
+  struct string_hash {
+    size_t operator()(const char* p) const {
+      size_t rv = 5381;
+      for (; *p; p++)
+        rv += (rv << 5) + *p;
+      return rv;
+    }
+
+    bool operator()(const char* lhs, const char* rhs) const {
+      return !strcmp(lhs, rhs);
+    }
+  };
+
+  struct config_descriptor {
+    typedef std::unordered_map<const char*, config_field, string_hash, string_hash> t_mpType;
+
+    static t_mpType MakeFields(const std::initializer_list<config_field>& fields);
+
+    config_descriptor(std::initializer_list<config_field> fields) :
+      fields(MakeFields(fields))
+    {}
+
+    const t_mpType fields;
+  };
+}

--- a/src/autowiring/demangle.cpp
+++ b/src/autowiring/demangle.cpp
@@ -2,6 +2,8 @@
 #include "stdafx.h"
 #include "demangle.h"
 #include "AnySharedPointer.h"
+#include <sstream>
+#include <typeindex>
 
 #if __GNUG__ // Mac and linux
 #include <cxxabi.h>
@@ -16,7 +18,7 @@ static std::string demangle_name(const char* name) {
 
   if(status != 0)
     return std::string();
-  
+
   return std::string(res.get());
 }
 
@@ -36,7 +38,7 @@ static std::string demangle_name(const char* name) {
       name += 6;
       continue;
     }
-    
+
     if (strncmp(name, "struct ", 7) == 0) {
       name += 7;
       continue;

--- a/src/autowiring/demangle.h
+++ b/src/autowiring/demangle.h
@@ -1,10 +1,13 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <string>
-#include <typeindex>
 
 struct AnySharedPointer;
 struct auto_id;
+
+namespace std {
+  class type_index;
+}
 
 //
 // Demangle type names on mac and linux.

--- a/src/autowiring/demangle.h
+++ b/src/autowiring/demangle.h
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <string>
+#include <typeinfo>
 
 struct AnySharedPointer;
 struct auto_id;

--- a/src/autowiring/demangle.h
+++ b/src/autowiring/demangle.h
@@ -2,13 +2,10 @@
 #pragma once
 #include <string>
 #include <typeinfo>
+#include <typeindex>
 
 struct AnySharedPointer;
 struct auto_id;
-
-namespace std {
-  class type_index;
-}
 
 //
 // Demangle type names on mac and linux.

--- a/src/autowiring/has_getconfigdescriptor.h
+++ b/src/autowiring/has_getconfigdescriptor.h
@@ -1,10 +1,11 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "config_descriptor.h"
 #include TYPE_TRAITS_HEADER
 #include RVALUE_HEADER
 
 namespace autowiring {
+  struct config_descriptor;
+
   /// <summary>
   /// Utility helper structure for types which have a factory New routine
   /// </summary>

--- a/src/autowiring/has_getconfigdescriptor.h
+++ b/src/autowiring/has_getconfigdescriptor.h
@@ -1,0 +1,40 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "config_descriptor.h"
+#include TYPE_TRAITS_HEADER
+#include RVALUE_HEADER
+
+namespace autowiring {
+  /// <summary>
+  /// Utility helper structure for types which have a factory New routine
+  /// </summary>
+  /// <remarks>
+  /// A factory New routine is malformed when the return type is not implicitly castable to type T
+  /// </remarks>
+  template<class T, class Selector>
+  struct has_well_formed_getconfigdescriptor {
+    static const bool value =
+      std::is_convertible<
+        typename std::result_of<decltype(T::GetConfigDescriptor)&()>::type,
+        autowiring::config_descriptor
+      >::value &&
+      !std::is_member_function_pointer<decltype(&T::GetConfigDescriptor)>::value;
+  };
+
+  template<class T>
+  struct has_well_formed_getconfigdescriptor<T, std::false_type> {
+    static const bool value = false;
+  };
+
+  template<typename T>
+  struct has_getconfigdescriptor
+  {
+    template<class U>
+    static std::true_type select(decltype(U::GetConfigDescriptor)*);
+
+    template<class U>
+    static std::false_type select(...);
+
+    static const bool value = has_well_formed_getconfigdescriptor<T, decltype(select<T>(nullptr))>::value;
+  };
+}

--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -1,8 +1,10 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <initializer_list>
+#include <cmath>
 #include <stdexcept>
 #include <string>
+#include <string.h>
 #include TYPE_TRAITS_HEADER
 
 namespace autowiring {

--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -2,6 +2,7 @@
 #pragma once
 #include <initializer_list>
 #include <cmath>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <string.h>

--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -78,7 +78,13 @@ namespace autowiring {
       }
       if (!pos)
         retVal.push_back('-');
-      std::reverse(retVal.begin(), retVal.end());
+
+      for (
+        auto first = retVal.begin(), last = retVal.end();
+        (first != last) && (first != --last);
+        ++first
+      )
+        std::swap(*first, *last);
       return retVal;
     }
 
@@ -161,7 +167,12 @@ namespace autowiring {
 
       if (neg)
         retVal.push_back('-');
-      std::reverse(retVal.begin(), retVal.end());
+      for (
+        auto first = retVal.begin(), last = retVal.end();
+        (first != last) && (first != --last);
+        ++first
+      )
+        std::swap(*first, *last);
       return retVal;
     }
 

--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -1,0 +1,248 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include <initializer_list>
+#include <stdexcept>
+#include <string>
+#include TYPE_TRAITS_HEADER
+
+namespace autowiring {
+  struct invalid_marshal_base {};
+
+  template<typename T>
+  struct marshaller;
+
+  /// <summary>
+  /// The interface all marshallers must support
+  /// </summary>
+  struct marshaller_base {
+    /// <summary>
+    /// Marshals the underlying type to a string value
+    /// </summary>
+    virtual std::string marshal(const void* ptr) const { return ""; }
+
+    /// <summary>
+    /// Converts the specified string value to the output type
+    /// </summary>
+    /// <param name="szValue">The string value to be converted</param>
+    /// <param name="ptr">A pointer to the memory region where the output will be stored</param>
+    virtual void unmarshal(void* ptr, const char* szValue) const = 0;
+  };
+
+  /// <summary>
+  /// Built-in marshaller, declared separately because it's a little more complicated
+  /// </summary>
+  template<typename T, typename>
+  struct builtin_marshaller :
+    invalid_marshal_base
+  {};
+
+  template<>
+  struct builtin_marshaller<bool, void> :
+    marshaller_base
+  {
+    typedef bool type;
+
+    std::string marshal(const void* ptr) const override {
+      return *static_cast<const bool*>(ptr) ? "true" : "false";
+    }
+
+    void unmarshal(void* ptr, const char* szValue) const override {
+      if (!strcmp("true", szValue))
+        *static_cast<bool*>(ptr) = true;
+      else if (!strcmp("false", szValue))
+        *static_cast<bool*>(ptr) = false;
+      else
+        throw std::invalid_argument("Boolean unmarshaller expects true or false keyword");
+    }
+  };
+
+  template<>
+  struct builtin_marshaller<volatile bool, void> :
+    builtin_marshaller<bool, void>
+  {};
+
+  template<typename T>
+  struct builtin_marshaller<T, typename std::enable_if<std::is_integral<T>::value>::type> :
+    marshaller_base
+  {
+    typedef typename std::remove_volatile<T>::type type;
+
+    std::string marshal(const void* ptr) const override {
+      std::string retVal;
+      type val = *static_cast<const type*>(ptr);
+      bool pos = 0 < val;
+      for (; val; val /= 10) {
+        retVal.push_back(static_cast<char>(val % 10 + '0'));
+      }
+      if (!pos)
+        retVal.push_back('-');
+      std::reverse(retVal.begin(), retVal.end());
+      return retVal;
+    }
+
+    void unmarshal(void* ptr, const char* szValue) const override {
+      type& value = *static_cast<type*>(ptr);
+      bool negative = *szValue == '-';
+      if(negative) {
+        // Skip over the sign, verify we aren't assigning to the wrong field type
+        szValue++;
+        if (std::is_unsigned<type>::value)
+          throw std::range_error("Attempted to set a signed value on an unsigned calibration field");
+      }
+
+      for (value = 0; *szValue; szValue++) {
+        if (*szValue < '0' || '9' < *szValue)
+          throw std::invalid_argument("String value is not an integer");
+        value = *szValue - '0' + value * 10;
+      }
+      if(negative)
+        value *= -1;
+    }
+  };
+
+  template<typename T>
+  struct builtin_marshaller<T, typename std::enable_if<std::is_floating_point<T>::value>::type> :
+    marshaller_base
+  {
+    typedef typename std::remove_volatile<T>::type type;
+
+    std::string marshal(const void* ptr) const override {
+      std::string retVal;
+      type value = *static_cast<const type*>(ptr);
+      if (value == 0.0f)
+        return "0";
+
+      bool neg = value < 0.0f;
+      if (neg)
+        value *= -1.0f;
+
+      // Convert input value to scientific notation
+      int power = static_cast<int>(std::log10(value));
+
+      // We will be assembling the number backwards, need to keep track of the
+      // current digit
+      int curDigit = std::numeric_limits<type>::digits10 - power;
+
+      // We only want a certain number of digits, this digit count will fit in
+      // a large integer and elimintes the loss of precision we experience when
+      // using floating point math to try to do digit shifts
+      uint64_t digits = static_cast<uint64_t>(value * std::pow(10.0, curDigit));
+
+      // Trailing zero introduction
+      if (power > std::numeric_limits<type>::digits10)
+        retVal.append(power - std::numeric_limits<type>::digits10, '0');
+
+      // Trailing zero omission
+      while (0 < curDigit && 0 == (digits % 10)) {
+        digits /= 10;
+        curDigit--;
+      }
+
+      for(; digits; digits /= 10, curDigit--) {
+        char digit = static_cast<char>(digits % 10);
+
+        // String conversion step, straightforward mapping
+        retVal.push_back('0' + digit);
+        if (curDigit == 1)
+          retVal.push_back('.');
+
+        if (!digits)
+          // Short-circuit for precise representations
+          break;
+      }
+
+      // Zeroes before the decimal:
+      if (power < 0) {
+        retVal.append(-power, '0');
+        retVal.append(".0");
+      }
+
+      if (neg)
+        retVal.push_back('-');
+      std::reverse(retVal.begin(), retVal.end());
+      return retVal;
+    }
+
+    void unmarshal(void* ptr, const char* szValue) const override {
+      T& value = *static_cast<type*>(ptr);
+      bool negative = *szValue == '-';
+      if (negative)
+        szValue++;
+
+      uint64_t whole = 0;
+      for (; *szValue; szValue++) {
+        // Detect the decimal marker, switch to fractional part
+        if (*szValue == '.') {
+          szValue++;
+          break;
+        }
+        if (*szValue < '0' || '9' < *szValue)
+          throw std::invalid_argument("String value is not a decimal number");
+        whole = whole * 10 + *szValue - '0';
+      }
+
+      uint64_t fractional = 0;
+      size_t n = 0;
+      for (; szValue[n]; n++) {
+        if (szValue[n] < '0' || '9' < szValue[n])
+          throw std::invalid_argument("String value is not a decimal number");
+        fractional = fractional * 10 + szValue[n] - '0';
+      }
+      value = static_cast<type>(fractional);
+      while(n--)
+        value /= 10.0f;
+      value += static_cast<type>(whole);
+      if (negative)
+        value *= -1.0f;
+    }
+  };
+
+  /// <summary>
+  /// Default marshaller, a point of specialization for external users
+  /// </summary>
+  template<typename T>
+  struct marshaller :
+    builtin_marshaller<T, void>
+  {};
+
+  ///
+  /// Nonprimitive or full specializations follow from here.  Use these as examples when devising
+  /// your own marshallers.
+  ///
+
+  template<typename T>
+  struct marshaller<std::atomic<T>> :
+    marshaller_base
+  {
+    typedef std::atomic<T> type;
+
+    // Marshaller for the interior type
+    marshaller<T> interior;
+
+    std::string marshal(const void* ptr) const override {
+      T value = static_cast<const type*>(ptr)->load();
+      return interior.marshal(&value);
+    }
+
+    void unmarshal(void* ptr, const char* szValue) const override {
+      T value;
+      interior.unmarshal(&value, szValue);
+      *static_cast<type*>(ptr) = std::move(value);
+    }
+  };
+
+  template<>
+  struct marshaller<std::string> :
+    marshaller_base
+  {
+    typedef std::string type;
+
+    std::string marshal(const void* ptr) const override {
+      return *static_cast<const type*>(ptr);
+    }
+
+    void unmarshal(void* ptr, const char* szValue) const override {
+      *static_cast<std::string*>(ptr) = szValue;
+    }
+  };
+}

--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include <atomic>
 #include <initializer_list>
 #include <cmath>
 #include <limits>

--- a/src/autowiring/observable.h
+++ b/src/autowiring/observable.h
@@ -8,7 +8,7 @@ namespace autowiring {
 /// An unsynchronzied wrapper type that implements the observable pattern
 /// </summary>
 /// <remarks>
-/// 
+///
 /// </remarks>
 template<typename T>
 class observable {
@@ -38,10 +38,28 @@ private:
 public:
   operator const T&(void) const { return val; }
   const T& operator*(void) const { return val; }
+  const T& get(void) const { return val; }
+
+  /// <summary>
+  /// Retrieves the underlying value, without any protection
+  /// </summary>
+  /// <remarks>
+  /// Users should make use of this with caution.  Changes to the returned value will not cause
+  /// signals to be asserted at the correct time by this type; users are responsible for doing
+  /// this on their own.
+  /// </remarks>
+  T& get(void) { return val; }
 
   observable& operator=(const T& rhs) {
     onBeforeChanged(val, rhs);
     val = rhs;
+    onChanged();
+    return *this;
+  }
+
+  observable& operator=(T&& rhs) {
+    onBeforeChanged(val, rhs);
+    val = std::move(rhs);
     onChanged();
     return *this;
   }

--- a/src/autowiring/observable.h
+++ b/src/autowiring/observable.h
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "auto_signal.h"
+#include "marshaller.h"
+#include "signal.h"
 
 namespace autowiring {
 
@@ -62,6 +63,27 @@ public:
     val = std::move(rhs);
     onChanged();
     return *this;
+  }
+};
+
+
+template<typename T>
+struct marshaller<autowiring::observable<T>> :
+  marshaller_base
+{
+  typedef autowiring::observable<T> type;
+
+  // Marshaller for the interior type
+  marshaller<T> interior;
+
+  std::string marshal(const void* ptr) const override {
+    return interior.marshal(&static_cast<const type*>(ptr)->get());
+  }
+
+  void unmarshal(void* ptr, const char* szValue) const override {
+    T value;
+    interior.unmarshal(&value, szValue);
+    *static_cast<type*>(ptr) = std::move(value);
   }
 };
 

--- a/src/autowiring/once.h
+++ b/src/autowiring/once.h
@@ -4,6 +4,7 @@
 #include "callable.h"
 #include "signal_base.h"
 #include "spin_lock.h"
+#include <mutex>
 #include <vector>
 
 namespace autowiring {

--- a/src/autowiring/optional.h
+++ b/src/autowiring/optional.h
@@ -1,0 +1,145 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include <memory>
+#include <stdexcept>
+
+/// <summary>
+/// Implements the "optional" concept
+/// </summary>
+/// <remarks>
+/// TODO:  Replace this with a typedef to std::optional once the STL provides it
+/// </remarks>
+namespace autowiring {
+template<typename T>
+struct optional {
+public:
+  optional(void) = default;
+  optional(const optional& rhs) = default;
+  optional(optional&& rhs) :
+    m_valid(rhs.m_valid)
+  {
+    if (rhs) {
+      new(val) T{ std::move(rhs._value()) };
+      rhs._value().~T();
+      rhs.m_valid = false;
+    }
+  }
+  optional(T&& value):
+    m_valid(true)
+  {
+    new(val) T{ std::move(value) };
+  }
+
+  ~optional(void) {
+    if (m_valid)
+      reinterpret_cast<T*>(val)->~T();
+  }
+
+private:
+  bool m_valid = false;
+  uint8_t val[sizeof(T)];
+
+  T& _value(void) { return *reinterpret_cast<T*>(val); }
+  const T& _value(void) const { return *reinterpret_cast<const T*>(val); }
+
+public:
+  operator bool(void) const { return m_valid; }
+  T& value(void) {
+    if (!m_valid)
+      throw std::runtime_error("Attempted to access an uninitialized optional value");
+    return *reinterpret_cast<T*>(val);
+  }
+  const T& value(void) const { return const_cast<optional*>(this)->value(); }
+
+  // Indirection operators:
+  T* operator->(void) { return &value(); }
+  const T* operator->(void) const { return &value(); }
+  T& operator*(void) { return value(); }
+  const T& operator*(void) const { return value(); }
+
+  // Comparisons
+  bool operator==(const optional& rhs) const {
+    return
+      (!m_valid && !rhs.m_valid) ||
+      (m_valid && rhs.m_valid && _value() == rhs._value());
+  }
+  bool operator==(const T& rhs) const { return m_valid && _value() == rhs; }
+  bool operator!=(const optional& rhs) const { return !(*this == rhs); }
+  bool operator!=(const T& rhs) const { return !(*this == rhs); }
+
+  bool operator<(const optional& rhs) {
+    return
+      (!m_valid && !rhs.m_valid) ||
+      (m_valid && rhs.m_valid && _value() < rhs._value());
+  }
+  bool operator<(const T& rhs) { return m_valid && _value() < rhs; }
+
+  // Standard assignment
+  optional& operator=(optional&& rhs) {
+    if (rhs.m_valid)
+      *this = std::move(rhs._value());
+    else if (m_valid) {
+      // RHS is invalid, we need to invalidate ourselves
+      m_valid = false;
+      _value().~T();
+    }
+    return *this;
+  }
+  optional& operator=(const optional& rhs) {
+    if (rhs.m_valid)
+      *this = rhs._value();
+    else if(m_valid) {
+      m_valid = false;
+      _value().~T();
+    }
+    return *this;
+  }
+
+  template<typename U>
+  typename std::enable_if<
+    !std::is_same<typename std::decay<U>::type, optional>::value,
+    optional
+  >::type& operator=(U&& rhs) {
+    if (m_valid)
+      _value() = std::forward<U&&>(rhs);
+    else
+      new(val) T{ std::forward<U&&>(rhs) };
+    m_valid = true;
+    return *this;
+  }
+
+  void swap(optional& rhs) {
+    if (m_valid)
+      if (rhs.m_valid)
+        std::swap(_value(), rhs._value());
+      else {
+        new(rhs.val) T{ std::move(_value()) };
+        rhs.m_valid = true;
+        m_valid = false;
+        _value().~T();
+      }
+    else if (rhs.m_valid) {
+      new(val) T{ std::move(rhs._value()) };
+      m_valid = true;
+      rhs.m_valid = false;
+      rhs._value().~T();
+    }
+  }
+
+  template<typename... Args>
+  void emplace(Args&&... args) {
+    if (m_valid)
+      _value().~T();
+    else
+      m_valid = true;
+    new(val) T{ args... };
+  }
+};
+}
+
+namespace std {
+  template<typename T>
+  void swap(::autowiring::optional<T>& lhs, ::autowiring::optional<T>& rhs) {
+    lhs.swap(rhs);
+  }
+}

--- a/src/autowiring/signal.h
+++ b/src/autowiring/signal.h
@@ -12,10 +12,7 @@
 #include "spin_lock.h"
 #include <atomic>
 #include <functional>
-#include <list>
 #include <memory>
-#include <mutex>
-#include <unordered_map>
 #include TYPE_TRAITS_HEADER
 
 /// <summary>

--- a/src/autowiring/stdafx.h
+++ b/src/autowiring/stdafx.h
@@ -14,18 +14,14 @@
   #include <atomic>
   #include <chrono>
   #include <exception>
-  #include <functional>
   #include <iosfwd>
   #include <memory>
   #include <mutex>
   #include <queue>
   #include <set>
-  #include <sstream>
   #include <string>
   #include <thread>
-  #include <tuple>
   #include <type_traits>
-  #include <typeindex>
   #include <unordered_map>
   #include <vector>
 #endif

--- a/src/autowiring/stdafx.h
+++ b/src/autowiring/stdafx.h
@@ -11,15 +11,11 @@
     #define NOMINMAX
   #endif
 
-  #include <algorithm>
   #include <atomic>
   #include <chrono>
   #include <exception>
   #include <functional>
-  #include <future>
   #include <iosfwd>
-  #include <list>
-  #include <map>
   #include <memory>
   #include <mutex>
   #include <queue>
@@ -31,7 +27,6 @@
   #include <type_traits>
   #include <typeindex>
   #include <unordered_map>
-  #include <unordered_set>
   #include <vector>
 #endif
 

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -12,14 +12,14 @@ class AutoConfigTest:
 namespace {
   class MyConfigurableClass {
   public:
-    autowiring::config<std::string> a = "Hello world!";
-    std::atomic<int> b = 929;
-    std::atomic<unsigned int> bUnsigned = 92999;
+    autowiring::config<std::string> a{ "Hello world!" };
+    std::atomic<int> b{ 929 };
+    std::atomic<unsigned int> bUnsigned{ 92999 };
     volatile bool c = false;
     volatile float d = 1.0f;
     volatile double e = 99.2;
-    autowiring::observable<int> obs = 44;
-    autowiring::config<int> cfg = 929999;
+    autowiring::observable<int> obs{ 44 };
+    autowiring::config<int> cfg{ 929999 };
 
     static autowiring::config_descriptor GetConfigDescriptor(void) {
       return {
@@ -43,6 +43,11 @@ namespace {
 
 static_assert(autowiring::has_getconfigdescriptor<MyConfigurableClass>::value, "Static new not correctly detected");
 static_assert(!autowiring::has_getconfigdescriptor<BadClass>::value, "Bad class cannot have a configuration descriptor");
+
+TEST_F(AutoConfigTest, ConfigFieldAssign) {
+  autowiring::config<std::string> x{ "Hello world!" };
+  ASSERT_TRUE(x.is_dirty()) << "Config values are assumed to be initially dirty";
+}
 
 TEST_F(AutoConfigTest, String) {
   MyConfigurableClass c;
@@ -129,7 +134,8 @@ TEST_F(AutoConfigTest, Configurable) {
   AutoCurrentContext ctxt;
   AutoRequired<MyConfigurableClass> c;
 
-  ASSERT_FALSE(c->cfg.is_dirty()) << "Dirty flag set on a value that should not have been marked dirty";
+  ASSERT_TRUE(c->cfg.clear_dirty()) << "Dirty flag was not set on a value that should have been dirty";
+  ASSERT_FALSE(c->cfg.is_dirty());
   ctxt->ConfigSet("cfg", "888");
   ASSERT_TRUE(c->cfg.is_dirty()) << "Dirty flag not set correctly after being updated in configuration";
   ASSERT_TRUE(c->cfg.clear_dirty());

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -1,0 +1,153 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include <autowiring/config_descriptor.h>
+#include <autowiring/config.h>
+#include <autowiring/ConfigRegistry.h>
+#include <autowiring/observable.h>
+
+class AutoConfigTest:
+  public testing::Test
+{};
+
+namespace {
+  class MyConfigurableClass {
+  public:
+    autowiring::config<std::string> a = "Hello world!";
+    std::atomic<int> b = 929;
+    std::atomic<unsigned int> bUnsigned = 92999;
+    volatile bool c = false;
+    volatile float d = 1.0f;
+    volatile double e = 99.2;
+    autowiring::observable<int> obs = 44;
+    autowiring::config<int> cfg = 929999;
+
+    static autowiring::config_descriptor GetConfigDescriptor(void) {
+      return {
+        { "a", "Field A description", &MyConfigurableClass::a, "Hello world!" },
+        { "b", "Field B description", &MyConfigurableClass::b, 929 },
+        { "bUnsigned", &MyConfigurableClass::bUnsigned },
+        { "c", &MyConfigurableClass::c },
+        { "d", &MyConfigurableClass::d },
+        { "e", &MyConfigurableClass::e },
+        { "obs", &MyConfigurableClass::obs },
+        { "cfg", &MyConfigurableClass::cfg }
+      };
+    }
+  };
+
+  class BadClass {
+  public:
+    autowiring::config_descriptor GetConfigDescriptor(void) { return{}; }
+  };
+}
+
+static_assert(autowiring::has_getconfigdescriptor<MyConfigurableClass>::value, "Static new not correctly detected");
+static_assert(!autowiring::has_getconfigdescriptor<BadClass>::value, "Bad class cannot have a configuration descriptor");
+
+TEST_F(AutoConfigTest, String) {
+  MyConfigurableClass c;
+
+  autowiring::config_field cf("a", "Field A description", &MyConfigurableClass::a, std::string{ "Hello world!" });
+
+  std::string expected{ "Forescore and seven years ago" };
+  autowiring::ConfigSet("a", c, expected.c_str());
+  ASSERT_TRUE(c.a.clear_dirty());
+  ASSERT_STREQ(expected.c_str(), c.a->c_str()) << "String configuration value not assigned";
+}
+
+TEST_F(AutoConfigTest, Integer) {
+  MyConfigurableClass c;
+
+  autowiring::ConfigSet("b", c, "999");
+  ASSERT_EQ(c.b, 999) << "Integer configuration value not assigned";
+
+  autowiring::ConfigSet("b", c, "-999");
+  ASSERT_EQ(c.b, -999) << "Negative integer configuration value not assigned";
+}
+
+TEST_F(AutoConfigTest, IntegerUnsigned) {
+  MyConfigurableClass c;
+
+  c.bUnsigned = 10929;
+  std::string strVal = autowiring::ConfigGet("bUnsigned", c);
+  ASSERT_STREQ("10929", strVal.c_str());
+
+  autowiring::ConfigSet("bUnsigned", c, "999");
+  ASSERT_EQ(c.bUnsigned, 999) << "Integer configuration value not assigned";
+  ASSERT_ANY_THROW(autowiring::ConfigSet("bUnsigned", c, "-999")) << "Incorrectly assigned as signed value to an unsigned field";
+}
+
+TEST_F(AutoConfigTest, Bool) {
+  MyConfigurableClass c;
+
+  autowiring::ConfigSet("c", c, "true");
+  ASSERT_TRUE(c.c) << "Boolean configuration value not assigned";
+}
+
+TEST_F(AutoConfigTest, Float) {
+  MyConfigurableClass c;
+
+  c.d = 10929.4f;
+  std::string strVal = autowiring::ConfigGet("d", c);
+  ASSERT_STREQ("10929.4", strVal.c_str());
+
+  autowiring::ConfigSet("d", c, "123.4");
+  ASSERT_FLOAT_EQ(c.d, 123.4f) << "Float configuration value not assigned";
+}
+
+TEST_F(AutoConfigTest, Double) {
+  MyConfigurableClass c;
+  std::string strVal;
+
+  c.e = 10929.4423;
+  strVal = autowiring::ConfigGet("e", c);
+  ASSERT_STREQ("10929.4423", strVal.c_str());
+
+  c.e = 109290000000000;
+  strVal = autowiring::ConfigGet("e", c);
+  ASSERT_STREQ("109290000000000", strVal.c_str());
+
+  c.e = -0.0099291;
+  strVal = autowiring::ConfigGet("e", c);
+  ASSERT_STREQ("-0.0099291", strVal.c_str());
+
+  autowiring::ConfigSet("e", c, "77482.4");
+  ASSERT_DOUBLE_EQ(c.e, 77482.4) << "Double configuration value not assigned";
+}
+
+TEST_F(AutoConfigTest, Observable) {
+  MyConfigurableClass c;
+
+  bool hit = false;
+  c.obs.onChanged += [&hit] { hit = true; };
+  autowiring::ConfigSet("obs", c, "101");
+  ASSERT_EQ(101, c.obs) << "Value not properly assigned";
+  ASSERT_TRUE(hit) << "Observable signal not asserted";
+}
+
+TEST_F(AutoConfigTest, Configurable) {
+  AutoCurrentContext ctxt;
+  AutoRequired<MyConfigurableClass> c;
+
+  ASSERT_FALSE(c->cfg.is_dirty()) << "Dirty flag set on a value that should not have been marked dirty";
+  ctxt->ConfigSet("cfg", "888");
+  ASSERT_TRUE(c->cfg.is_dirty()) << "Dirty flag not set correctly after being updated in configuration";
+  ASSERT_TRUE(c->cfg.clear_dirty());
+  ASSERT_EQ(888, c->cfg);
+}
+
+TEST_F(AutoConfigTest, ContextSetSimple) {
+  AutoCurrentContext ctxt;
+  AutoRequired<MyConfigurableClass> mcc;
+
+  ctxt->ConfigSet("b", "1029");
+  ASSERT_EQ(mcc->b, 1029);
+}
+
+TEST_F(AutoConfigTest, ContextSetAfter) {
+  AutoCurrentContext ctxt;
+  ctxt->ConfigSet("b", "10442");
+
+  AutoRequired<MyConfigurableClass> mcc;
+  ASSERT_EQ(mcc->b, 10442);
+}

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -136,7 +136,7 @@ TEST_F(AutoConfigTest, Configurable) {
 
   ASSERT_TRUE(c->cfg.clear_dirty()) << "Dirty flag was not set on a value that should have been dirty";
   ASSERT_FALSE(c->cfg.is_dirty());
-  ctxt->ConfigSet("cfg", "888");
+  ctxt->Config.Set("cfg", "888");
   ASSERT_TRUE(c->cfg.is_dirty()) << "Dirty flag not set correctly after being updated in configuration";
   ASSERT_TRUE(c->cfg.clear_dirty());
   ASSERT_EQ(888, c->cfg);
@@ -146,13 +146,13 @@ TEST_F(AutoConfigTest, ContextSetSimple) {
   AutoCurrentContext ctxt;
   AutoRequired<MyConfigurableClass> mcc;
 
-  ctxt->ConfigSet("b", "1029");
+  ctxt->Config.Set("b", "1029");
   ASSERT_EQ(mcc->b, 1029);
 }
 
 TEST_F(AutoConfigTest, ContextSetAfter) {
   AutoCurrentContext ctxt;
-  ctxt->ConfigSet("b", "10442");
+  ctxt->Config.Set("b", "10442");
 
   AutoRequired<MyConfigurableClass> mcc;
   ASSERT_EQ(mcc->b, 10442);

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -2,6 +2,7 @@ set(AutowiringTest_SRCS
   AnySharedPointerTest.cpp
   ArgumentTypeTest.cpp
   AtomicListTest.cpp
+  AutoConfigTest.cpp
   AutoConstructTest.cpp
   AutoFilterAltitudeTest.cpp
   AutoFilterCollapseRulesTest.cpp


### PR DESCRIPTION
To start, this concept is self-contained and shows a way to set a string value by a string name, and how to define a descriptor on a type.  Eventually we will make contexts aware of this concept, and build out a way to set all configuration values found in a context to their respective values.

This is the initial work to implement this feature.  Metadata and scanner concepts still needs to be introduced.