### PR TITLE
Add a tweakable concept

### DIFF
--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -160,6 +160,7 @@ set(Autowiring_SRCS
   ThreadPool.h
   ThreadPool.cpp
   TypeIdentifier.h
+  tweak.h
   TypeRegistry.cpp
   TypeRegistry.h
   TypeUnifier.h

--- a/src/autowiring/config.h
+++ b/src/autowiring/config.h
@@ -101,7 +101,7 @@ namespace autowiring {
   struct marshaller<config<T>> :
     marshaller_base
   {
-    typedef autowiring::config<T> type;
+    typedef config<T> type;
 
     // Marshaller for the interior type
     marshaller<T> interior;

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -59,6 +59,7 @@ set(AutowiringTest_SRCS
   SnoopTest.cpp
   ThreadPoolTest.cpp
   TupleTest.cpp
+  TweakTest.cpp
   TestFixtures/custom_exception.hpp
   TestFixtures/ExitRaceThreaded.hpp
   TestFixtures/SimpleInterface.hpp

--- a/src/autowiring/test/TweakTest.cpp
+++ b/src/autowiring/test/TweakTest.cpp
@@ -34,6 +34,6 @@ namespace {
 TEST(TweakTest, Value) {
   aw::marshaller<aw::tweak<int>> marshaller;
   aw::tweak<int> value = 787;
-  std::string v = marshaller.marshal(&value);
+  std::string v = marshaller.marshal(std::addressof(value));
   ASSERT_STREQ("787", v.c_str());
 }

--- a/src/autowiring/test/TweakTest.cpp
+++ b/src/autowiring/test/TweakTest.cpp
@@ -1,0 +1,38 @@
+#include "stdafx.h"
+#include <autowiring/tweak.h>
+#include <gtest/gtest.h>
+
+namespace aw = autowiring;
+
+TEST(TweakTest, Initial) {
+  autowiring::tweak<int> x;
+  ASSERT_EQ(0, x) << "Tweak value was supposed to be zero-initialized";
+  ASSERT_FALSE(x.is_dirty()) << "Value should have been initially dirty";
+}
+
+TEST(TweakTest, Dirty) {
+  autowiring::tweak<int> x;
+  x = 10;
+  ASSERT_TRUE(x.is_dirty());
+  ASSERT_TRUE(x.clear_dirty());
+}
+
+namespace {
+  class SimpleStruct {
+  public:
+    autowiring::tweak<int> v;
+
+    autowiring::config_descriptor GetDescriptor(void) {
+      return {
+        { "Abcd", &SimpleStruct::v }
+      };
+    }
+  };
+}
+
+TEST(TweakTest, Value) {
+  aw::marshaller<aw::tweak<int>> marshaller;
+  aw::tweak<int> value = 787;
+  std::string v = marshaller.marshal(&value);
+  ASSERT_STREQ("787", v.c_str());
+}

--- a/src/autowiring/test/TweakTest.cpp
+++ b/src/autowiring/test/TweakTest.cpp
@@ -1,3 +1,4 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/tweak.h>
 #include <gtest/gtest.h>

--- a/src/autowiring/tweak.h
+++ b/src/autowiring/tweak.h
@@ -1,3 +1,4 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <atomic>
 #include <type_traits>

--- a/src/autowiring/tweak.h
+++ b/src/autowiring/tweak.h
@@ -59,6 +59,9 @@ namespace autowiring {
     operator T(void) volatile const {
       return value;
     }
+    volatile T* operator&(void) volatile {
+      return &value;
+    }
   };
 
   template<typename T>

--- a/src/autowiring/tweak.h
+++ b/src/autowiring/tweak.h
@@ -1,0 +1,83 @@
+#pragma once
+#include <atomic>
+#include <type_traits>
+
+namespace autowiring {
+  template<typename T>
+  struct tweak {
+    static_assert(std::is_arithmetic<T>::value, "Cannot define a tweakable value that is not arithmetic");
+
+    tweak(void) = default;
+    tweak(const tweak& rhs) = default;
+    tweak(T value) :
+      value(value),
+      last_observed(value)
+    {}
+
+  private:
+    // Current value, advertised both outside and updated
+    volatile T value = T{};
+
+    // Last observed value
+    volatile T last_observed = T{};
+
+  public:
+    // Accessor methods:
+    T get(void) const volatile { return value; }
+    volatile T& get(void) volatile { return value; }
+
+    /// <returns>
+    /// True if the entry is dirty
+    /// </returns>
+    bool is_dirty(void) const volatile {
+      return value != last_observed;
+    }
+
+    /// <summary>
+    /// Updates the assignment version, clearing the dirty flag
+    /// </summary>
+    /// <returns>
+    /// True if this instance was dirty
+    /// </returns>
+    bool clear_dirty(void) volatile {
+      if(value == last_observed)
+        return false;
+      last_observed = value;
+      return true;
+    }
+
+    // Operator overloads:
+    volatile tweak& operator=(T rhs) volatile {
+      value = rhs;
+      return *this;
+    }
+    volatile tweak& operator=(const tweak& rhs) volatile {
+      value = rhs.value;
+      return *this;
+    }
+    operator T(void) volatile const {
+      return value;
+    }
+  };
+
+  template<typename T>
+  struct marshaller<tweak<T>> :
+    marshaller_base
+  {
+    typedef tweak<T> type;
+
+    // Marshaller for the interior type
+    marshaller<T> interior;
+
+    std::string marshal(const void* ptr) const override {
+      T value = static_cast<const type*>(ptr)->get();
+      return interior.marshal(&value);
+    }
+
+    void unmarshal(void* ptr, const char* szValue) const override {
+      T value;
+      interior.unmarshal(&value, szValue);
+      *static_cast<type*>(ptr) = std::move(value);
+    }
+  };
+}


### PR DESCRIPTION
Tweakable is different from config in that the modified value is also the accessed value.  Only atomic types can be considered here as a result, because asynchronous modification is possible, and therefore these members are necessarily considered `volatile`.