### PR TITLE
Add cancellation to DispatchQueue

### DIFF
--- a/src/autowiring/DispatchQueue.cpp
+++ b/src/autowiring/DispatchQueue.cpp
@@ -38,7 +38,7 @@ bool DispatchQueue::PromoteReadyDispatchersUnsafe(void) {
     m_delayedQueue.pop()
   ) {
     // Update tail if head is already set, otherwise update head:
-    auto thunk = m_delayedQueue.top().Release();
+    auto thunk = m_delayedQueue.top().GetThunk().release();
     if (m_pHead)
       m_pTail->m_pFlink = thunk;
     else
@@ -122,6 +122,28 @@ void DispatchQueue::Abort(void) {
 
   // Wake up anyone who is still waiting:
   m_queueUpdated.notify_all();
+}
+
+bool DispatchQueue::Cancel(void) {
+  // Holds the cancelled thunk, declared here so that we delete it out of the lock
+  std::unique_ptr<DispatchThunkBase> thunk;
+
+  std::lock_guard<std::mutex> lk(m_dispatchLock);
+  if(m_pHead) {
+    // Found a ready thunk, run from here:
+    thunk.reset(m_pHead);
+    m_pHead = thunk->m_pFlink;
+  }
+  else if (!m_delayedQueue.empty()) {
+    auto& f = m_delayedQueue.top();
+    thunk = std::move(f.GetThunk());
+    m_delayedQueue.pop();
+  }
+  else
+    // Nothing to cancel!
+    return false;
+
+  return true;
 }
 
 void DispatchQueue::WakeAllWaitingThreads(void) {
@@ -339,7 +361,7 @@ void DispatchQueue::operator+=(DispatchQueue&& rhs) {
   // Append delayed thunks
   while (!rhs.m_delayedQueue.empty()) {
     const auto& top = rhs.m_delayedQueue.top();
-    m_delayedQueue.emplace(top.GetReadyTime(), top.Release());
+    m_delayedQueue.emplace(top.GetReadyTime(), top.GetThunk().release());
     rhs.m_delayedQueue.pop();
   }
 

--- a/src/autowiring/DispatchQueue.h
+++ b/src/autowiring/DispatchQueue.h
@@ -145,6 +145,21 @@ public:
   void Abort(void);
 
   /// <summary>
+  /// Causes the very first lambda on the dispatch queue to be deleted without running it
+  /// </summary>
+  /// <returns>
+  /// True if a lambda was cancelled, false if the queue was empty when the cancellation attempt was made
+  /// </returns>
+  /// <remarks>
+  /// This method cannot cancel lambdas that are already being dispatched.  As a result, it's possible for
+  /// this function to return zero even if the dispatch queue length is nonzero before and after the call.
+  ///
+  /// Lambdas are cancelled in the order they are pended.  If there are no lambdas ready to execute, then
+  /// deferred lambdas will be cancelled in the order they are scheduled to run.
+  /// </remarks>
+  bool Cancel(void);
+
+  /// <summary>
   /// Causes all calls to WaitForEvent to return control to their callers
   /// </summary>
   /// <remarks>

--- a/src/autowiring/DispatchThunk.h
+++ b/src/autowiring/DispatchThunk.h
@@ -56,7 +56,7 @@ public:
     m_readyAt(rhs.m_readyAt),
     m_thunk(std::move(rhs.m_thunk))
   {}
-  
+
 private:
   // The time when the thunk becomes ready-to-execute
   std::chrono::steady_clock::time_point m_readyAt;
@@ -65,11 +65,7 @@ private:
 public:
   // Accessor methods:
   std::chrono::steady_clock::time_point GetReadyTime(void) const { return m_readyAt; }
-
-  /// <summary>
-  /// Extracts the underlying thunk
-  /// </summary>
-  DispatchThunkBase* Release(void) const { return m_thunk.release(); }
+  std::unique_ptr<DispatchThunkBase>& GetThunk(void) const { return m_thunk; }
 
   /// <summary>
   /// Operator overload, used to sequence delayed dispatch thunks


### PR DESCRIPTION
This allows users to invoke `DispatchQueue::Cancel` in order to cause dispatchers to be removed from the front of the queue without executing them.