### PR TITLE
Retroactive bolting for existing contexts

### DIFF
--- a/src/autonet/AutoNetServerImpl.cpp
+++ b/src/autonet/AutoNetServerImpl.cpp
@@ -243,7 +243,7 @@ void AutoNetServerImpl::NewObject(CoreContext& ctxt, const CoreObjectDescriptor&
     if(bolt) {
       Json::array sigils;
       for(auto cur = bolt->GetContextSigils(); *cur; cur++){
-        sigils.push_back(autowiring::demangle(**cur));
+        sigils.push_back(autowiring::demangle(*cur));
       }
       types["bolt"] = sigils;
     }

--- a/src/autowiring/Bolt.h
+++ b/src/autowiring/Bolt.h
@@ -17,12 +17,19 @@ class Bolt:
   public BoltBase
 {
 public:
-  const t_TypeInfoVector GetContextSigils(void) const override {
-    static const std::type_info* s_types[] = {
-      &typeid(Sigil)...,
-      nullptr
+  const auto_id* GetContextSigils(void) const override {
+    static const auto_id s_types[] = {
+      auto_id_t<Sigil>{}...,
+      auto_id_t<void>{}
     };
     return s_types;
+  }
+
+  bool Matches(auto_id id) const override {
+    for (auto cur : { auto_id{auto_id_t<Sigil>{}}... })
+      if(cur == id)
+        return true;
+    return false;
   }
 
   static_assert(!is_any_same<void, Sigil...>::value, "Can't use 'void' as a sigil type");
@@ -33,8 +40,10 @@ class Bolt<>:
   public BoltBase
 {
 public:
-  const t_TypeInfoVector GetContextSigils(void) const override {
-    static const std::type_info* s_types[] = {nullptr};
+  const auto_id* GetContextSigils(void) const override {
+    static const auto_id s_types[] = { {} };
     return s_types;
   }
+
+  virtual bool Matches(auto_id id) const override { return true; }
 };

--- a/src/autowiring/BoltBase.h
+++ b/src/autowiring/BoltBase.h
@@ -1,10 +1,8 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include <typeinfo>
+#include "auto_id.h"
 
 class CoreContext;
-
-typedef const std::type_info*const* t_TypeInfoVector;
 
 /// <summary>
 /// </summary>
@@ -18,15 +16,24 @@ public:
   virtual ~BoltBase(void);
 
   /// <summary>
-  /// Returns a null-termianted list of one (or more) sigil types that this bolt cares about
+  /// Returns a null-terminated list of one (or more) sigil types that this bolt cares about
   /// </summary>
-  virtual const t_TypeInfoVector GetContextSigils(void) const = 0;
+  virtual const auto_id* GetContextSigils(void) const = 0;
+
+  /// <returns>
+  /// True if the specified sigil type matches the types interesting to this bolt
+  /// </returns>
+  virtual bool Matches(auto_id id) const = 0;
 
   /// <summary>
   /// A notification broadcast when a context of the desired name has been created
   /// </summary>
   /// <remarks>
   /// The current context at the time of the call is guaranteed to be the newly created context.
+  ///
+  /// This method may potentially be called at an arbitrary time _after_ the context is created.
+  /// The created context may not yet be started, or it could be initiated, or it could be in a
+  /// teardown state, or any other state that is valid for a context.
   /// </remarks>
   virtual void ContextCreated(void) = 0;
 };

--- a/src/autowiring/ContextEnumerator.cpp
+++ b/src/autowiring/ContextEnumerator.cpp
@@ -11,6 +11,10 @@ ContextEnumerator::ContextEnumerator(const std::shared_ptr<CoreContext>& root) :
   m_root(root)
 {}
 
+ContextEnumerator::ContextEnumerator(std::shared_ptr<CoreContext>&& root) :
+  m_root(std::move(root))
+{}
+
 ContextEnumerator::~ContextEnumerator(void) {}
 
 ContextEnumerator::iterator::iterator(const std::shared_ptr<CoreContext>& root, const std::shared_ptr<CoreContext>& cur) :
@@ -23,7 +27,7 @@ ContextEnumerator::iterator::~iterator(void) {}
 void ContextEnumerator::iterator::_next(const std::shared_ptr<CoreContext>& start) {
   // First node to search
   std::shared_ptr<CoreContext> i = start;
-  
+
   // Continue until we find something and we haven't walked off the end:
   while(!i && m_cur) {
     // m_cur is ascending, we are right-traversing

--- a/src/autowiring/ContextEnumerator.h
+++ b/src/autowiring/ContextEnumerator.h
@@ -35,8 +35,10 @@ public:
   /// <summary>
   /// Constructs an enumerator which may enumerate all of the contexts rooted at the specified root
   /// </summary>
-  /// <param name="root">The root context, optionally null</param>
+  /// <param name="root">The root context, optionally null, in which case this type is instantiated as an end-iterator</param>
   ContextEnumerator(const std::shared_ptr<CoreContext>& root);
+
+  ContextEnumerator(std::shared_ptr<CoreContext>&& root);
   ~ContextEnumerator(void);
 
 protected:
@@ -70,7 +72,7 @@ public:
 
   public:
     const iterator& NextSibling(void);
-    
+
     // Operator overloads:
     const iterator& operator++(void);
     iterator operator++(int);

--- a/src/autowiring/CoreContext.h
+++ b/src/autowiring/CoreContext.h
@@ -107,7 +107,7 @@ class CoreContext:
 protected:
   typedef std::list<std::weak_ptr<CoreContext>> t_childList;
   CoreContext(const CoreContext&) = delete;
-  CoreContext(const std::shared_ptr<CoreContext>& pParent, t_childList::iterator backReference, const std::type_info& sigilType);
+  CoreContext(const std::shared_ptr<CoreContext>& pParent, t_childList::iterator backReference, auto_id sigilType);
 
 public:
   // Asserted whenever a child of this context is created.  This signal is asserted before
@@ -153,7 +153,7 @@ protected:
   const t_childList::iterator m_backReference;
 
   // Sigil type, used during bolting
-  const std::type_info& m_sigilType;
+  const auto_id m_sigilType;
 
   // State block for this context:
   std::shared_ptr<CoreContextStateBlock> m_stateBlock;
@@ -189,7 +189,7 @@ protected:
 
   // Lists of event receivers, by name.  The type index of "void" is reserved for
   // bolts for all context types.
-  typedef std::unordered_map<std::type_index, std::list<BoltBase*>> t_contextNameListeners;
+  typedef std::unordered_map<auto_id, std::vector<BoltBase*>> t_contextNameListeners;
   t_contextNameListeners m_nameListeners;
 
   /// \internal
@@ -272,7 +272,7 @@ protected:
   /// The broadcast is made without altering the current context.  Recipients expect that the current context will be the
   /// one about which they are being informed.
   /// </remarks>
-  void BroadcastContextCreationNotice(const std::type_info& sigil) const;
+  void BroadcastContextCreationNotice(auto_id sigil) const;
 
   /// \internal
   /// <summary>
@@ -417,7 +417,7 @@ public:
   /// The number of child contexts of this context.
   size_t GetChildCount(void) const;
   /// The type used as a sigil when creating this class, if any.
-  const std::type_info& GetSigilType(void) const { return m_sigilType; }
+  auto_id GetSigilType(void) const { return m_sigilType; }
   /// The Context iterator for the parent context's children, pointing to this context.
   t_childList::iterator GetBackReference(void) const { return m_backReference; }
   /// A shared reference to the parent context of this context.
@@ -434,7 +434,7 @@ public:
 
   /// True if the sigil type of this CoreContext matches the specified sigil type.
   template<class Sigil>
-  bool Is(void) const { return m_sigilType == typeid(Sigil); }
+  bool Is(void) const { return m_sigilType == auto_id_t<Sigil>{}; }
 
   /// <summary>
   /// The first child in the set of this context's children.
@@ -1012,8 +1012,10 @@ class CoreContextT:
 {
 public:
   CoreContextT(const std::shared_ptr<CoreContext>& pParent, t_childList::iterator backReference) :
-    CoreContext(pParent, backReference, typeid(T))
-  {}
+    CoreContext(pParent, backReference, auto_id_t<T>{})
+  {
+    (void)auto_id_t_init<T>::init;
+  }
 };
 
 std::ostream& operator<<(std::ostream& os, const CoreContext& context);

--- a/src/autowiring/auto_id.cpp
+++ b/src/autowiring/auto_id.cpp
@@ -2,9 +2,18 @@
 #include "stdafx.h"
 #include "auto_id.h"
 
+// Index that will be given to the next auto_id instance.  Zero is reserved.
 static int s_index = 1;
 
-const autowiring::auto_id_block auto_id_t<void>::s_block{};
+const autowiring::auto_id_block auto_id_t<void>::s_block{
+  0,
+  &typeid(void),
+  &typeid(autowiring::s<void>),
+  0,
+  0,
+  nullptr,
+  nullptr
+};
 
 int autowiring::CreateIndex(void) {
   return s_index++;

--- a/src/autowiring/auto_id.h
+++ b/src/autowiring/auto_id.h
@@ -58,7 +58,26 @@ namespace autowiring {
       )
     {}
 
-    // Index and underlying type
+    auto_id_block(
+      int index,
+      const std::type_info* ti,
+      const std::type_info* ti_synth,
+      size_t ncb,
+      size_t align,
+      std::shared_ptr<CoreObject>(*pToObj)(const std::shared_ptr<void>&),
+      std::shared_ptr<void>(*pFromObj)(const std::shared_ptr<CoreObject>&)
+    ):
+      index(index),
+      ti(ti),
+      ti_synth(ti_synth),
+      ncb(ncb),
+      align(align),
+      pToObj(pToObj),
+      pFromObj(pFromObj)
+    {}
+
+    // Index and underlying type.  Indexes are guaranteed to start at 1.  The index value of 0
+    // is reserved as the invalid index.
     int index;
     const std::type_info* ti;
 
@@ -109,7 +128,7 @@ namespace std {
   template<>
   struct hash<auto_id> {
     size_t operator()(const auto_id& id) const {
-      return id.block->index;
+      return id.block ? id.block->index : 0;
     }
   };
 }
@@ -198,6 +217,20 @@ class auto_id_t_init<T, false>
     new (ptr) autowiring::auto_id_block(ptr->index ? ptr->index : autowiring::CreateIndex(), typeid(autowiring::s<T>));
   }
 
+public:
+  static const auto_id_t_init init;
+};
+
+// Don't need to initialize void
+template<>
+class auto_id_t_init<void, true> {
+public:
+  static const auto_id_t_init init;
+};
+
+template<>
+class auto_id_t_init<void, false>
+{
 public:
   static const auto_id_t_init init;
 };

--- a/src/autowiring/test/SelfSelectingFixtureTest.cpp
+++ b/src/autowiring/test/SelfSelectingFixtureTest.cpp
@@ -53,7 +53,7 @@ TEST_F(SelfSelectingFixtureTest, ExteriorFixtureTest) {
   ASSERT_TRUE(created != nullptr) << "Created context was unexpectedly null";
 
   // Verify that the context has the name we gave to it:
-  ASSERT_EQ(typeid(SelfSelect), created->GetSigilType()) << "Context was incorrectly named";
+  ASSERT_EQ(auto_id_t<SelfSelect>{}, created->GetSigilType()) << "Context was incorrectly named";
 
   // Set the current context and detect the SelfSelectingFixture's presence
   CurrentContextPusher pshr(created);


### PR DESCRIPTION
Historically, bolts are only asserted for _new_ contexts which match the bolt pattern.  This should be changed so that a bolt will be asserted for any context which already exists at the time the bolt is introduced.

When a bolt is added to a context, it should be asserted for all parents and children that are already created which satisfy the bolt requirement.  This allows bolts to be added potentially at some point after a context is created and running, and allows a new order-independent pattern to be considered the standard behavior in broader parts of the system.

Also change the bolt system so that it internally uses `auto_id` instead, this type is faster and more flexible than the STL `type_info`, and fix the hashing routine so that `auto_id{}` may be hashed.