### PR TITLE
Eliminate all lingering references to `Object`

### DIFF
--- a/src/autowiring/CoreObject.h
+++ b/src/autowiring/CoreObject.h
@@ -10,6 +10,3 @@ public:
   CoreObject(void);
   virtual ~CoreObject(void);
 };
-
-// Temporarily typedef to old name of 'CoreObject' until all users of Autowiring have been updated
-typedef CoreObject Object;

--- a/src/autowiring/test/FactoryTest.cpp
+++ b/src/autowiring/test/FactoryTest.cpp
@@ -157,7 +157,7 @@ TEST_F(FactoryTest, VerifyCanAutowireActualType) {
 }
 
 class AcceptsString:
-  public Object
+  public CoreObject
 {
 public:
   AcceptsString(const char* str) :


### PR DESCRIPTION
This name is a legacy name from a more innocent time, when Autowiring was just a module inside platform.  All downstream consumers have stopped using this name, and so it is time that we stop advertising it, ourselves.