### PR TITLE
Fix transitive unsatisfiability defect

### DIFF
--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -349,11 +349,10 @@ void AutoPacket::UpdateSatisfactionUnsafe(std::unique_lock<std::mutex> lk, const
   // Mark all unsatisfiable output types
   for (auto unsatOutputArg : unsatOutputArgs) {
     // One more producer run, even though we couldn't attach any new decorations
-    auto& entry = m_decoration_map[DecorationKey{unsatOutputArg->id, 0}];
-    entry.m_nProducersRun++;
-
-    // Now recurse on this entry
-    UpdateSatisfactionUnsafe(std::unique_lock<std::mutex>{m_lock}, entry);
+    auto& disposition = m_decoration_map[DecorationKey{unsatOutputArg->id, 0}];
+    if(disposition.IncProducerCount())
+      // Recurse on this entry
+      UpdateSatisfactionUnsafe(std::unique_lock<std::mutex>{m_lock}, disposition);
   }
 }
 
@@ -440,26 +439,11 @@ void AutoPacket::DecorateNoPriors(const AnySharedPointer& ptr, DecorationKey key
     break;
   }
 
-  // Decoration attaches here
-  disposition->m_decorations.push_back(ptr);
-  disposition->m_nProducersRun++;
-
-  // Uniformly advance state:
-  switch (disposition->m_state) {
-  case DispositionState::Unsatisfied:
-  case DispositionState::PartlySatisfied:
-    // Permit a transition to another state
-    if (disposition->IsPublicationComplete()) {
-      disposition->m_state = DispositionState::Complete;
-      UpdateSatisfactionUnsafe(std::move(lk), *disposition);
-    }
-    else
-      disposition->m_state = DispositionState::PartlySatisfied;
-    break;
-  default:
-    // Do nothing, no advancing to any states from here
-    break;
-  }
+  // Decoration attaches here, if it is non-null
+  if(ptr)
+    disposition->m_decorations.push_back(ptr);
+  if(disposition->IncProducerCount())
+    UpdateSatisfactionUnsafe(std::move(lk), *disposition);
 }
 
 void AutoPacket::Decorate(const AnySharedPointer& ptr, DecorationKey key) {
@@ -544,10 +528,13 @@ bool AutoPacket::IsUnsatisfiable(const auto_id& id) const
 {
   const DecorationDisposition* pDisposition = GetDisposition(DecorationKey{ id, 0 });
   if (!pDisposition)
+    // We have never heard of this type
     return false;
   if (!pDisposition->m_decorations.empty())
+    // We have some actual decorations, we know this is not satisfiable
     return false;
   if (pDisposition->m_nProducersRun != pDisposition->m_publishers.size())
+    // Some producers have not yet run, we could still feasibly get a decoration back
     return false;
   return true;
 }

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -547,7 +547,7 @@ bool AutoPacket::IsUnsatisfiable(const auto_id& id) const
     return false;
   if (!pDisposition->m_decorations.empty())
     return false;
-  if (pDisposition->m_nProducersRun == pDisposition->m_publishers.size())
+  if (pDisposition->m_nProducersRun != pDisposition->m_publishers.size())
     return false;
   return true;
 }

--- a/src/autowiring/AutoPacket.h
+++ b/src/autowiring/AutoPacket.h
@@ -134,7 +134,7 @@ protected:
   /// Marks the specified entry as being unsatisfiable
   /// </summary>
   void MarkUnsatisfiable(const DecorationKey& key);
-  
+
   /// <summary>
   /// Marks timeshifted decorations on successor packets as unsatisfiable
   /// </summary>
@@ -471,18 +471,15 @@ public:
   template<class T>
   void Decorate(const std::shared_ptr<T>& ptr) {
     DecorationKey key(auto_id_t<T>{}, 0);
-    
+
     // We don't want to see this overload used on a const T
     static_assert(!std::is_const<T>::value, "Cannot decorate a shared pointer to const T with this overload");
 
     // Injunction to prevent existential loops:
     static_assert(!std::is_same<T, AutoPacket>::value, "Cannot decorate a packet with another packet");
 
-    // Either decorate, or prevent anyone from decorating
-    if (ptr)
-      Decorate(AnySharedPointer(ptr), key);
-    else
-      MarkUnsatisfiable(key);
+    // Either decorate or abdicate
+    Decorate(AnySharedPointer(ptr), key);
   }
 
   /// <summary>
@@ -777,7 +774,7 @@ public:
   template<typename Fx, typename... InArgs, typename... Outputs>
   void Call(Fx&& fx, void (Fx::*memfn)(InArgs...) const, Outputs&... outputs) {
     typedef typename make_index_tuple<Decompose<decltype(&Fx::operator())>::N>::type t_index;
-    
+
     // Completely unnecessary.  Call will avoid making unneeded copies, and this is guaranteed
     // by a unit test.  Dereference your shared pointers before passing them in.
     static_assert(

--- a/src/autowiring/AutoPacketGraph.cpp
+++ b/src/autowiring/AutoPacketGraph.cpp
@@ -6,6 +6,7 @@
 #include "demangle.h"
 #include "SatCounter.h"
 #include <algorithm>
+#include <cassert>
 #include <fstream>
 #include <string>
 #include <sstream>

--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -9,6 +9,7 @@
 #include "dispatch_aborted_exception.h"
 #include "GlobalCoreContext.h"
 #include "fast_pointer_cast.h"
+#include <cassert>
 #include ATOMIC_HEADER
 
 static auto mainTID = std::this_thread::get_id();

--- a/src/autowiring/CallExtractor.h
+++ b/src/autowiring/CallExtractor.h
@@ -121,7 +121,7 @@ struct CE<void (T::*)(Args...) const, index_tuple<N...>> :
 {
   typedef CESetup<Args...> t_ceSetup;
   static const bool deferred = false;
-  
+
   template<void(T::*memFn)(Args...) const>
   static void Call(const void* pObj, AutoPacket& packet) {
     // Extract, call, commit

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -11,6 +11,7 @@
 #include "NullPool.h"
 #include "SystemThreadPool.h"
 #include "thread_specific_ptr.h"
+#include <cassert>
 #include <sstream>
 #include <stdexcept>
 

--- a/src/autowiring/test/AutoFilterSatisfiabilityTest.cpp
+++ b/src/autowiring/test/AutoFilterSatisfiabilityTest.cpp
@@ -3,18 +3,18 @@
 #include <autowiring/autowiring.h>
 #include "TestFixtures/Decoration.hpp"
 
-class SatisfiabilityTest:
+class AutoFilterSatisfiabilityTest :
   public testing::Test
 {
 public:
-  SatisfiabilityTest(void) {
+  AutoFilterSatisfiabilityTest(void) {
     AutoCurrentContext()->Initiate();
   }
 
   AutoRequired<AutoPacketFactory> factory;
 };
 
-TEST_F(SatisfiabilityTest, MarkUnsatisfiableCalls) {
+TEST_F(AutoFilterSatisfiabilityTest, MarkUnsatisfiableCalls) {
   auto packet = factory->NewPacket();
 
   // This filter shouldn't be called, because it expects a reference as an input
@@ -31,7 +31,7 @@ TEST_F(SatisfiabilityTest, MarkUnsatisfiableCalls) {
   ASSERT_TRUE(bSharedPtrCalled) << "Shared pointer version should have been called as a result of Unsatisfiable";
 }
 
-TEST_F(SatisfiabilityTest, TransitiveUnsatisfiability) {
+TEST_F(AutoFilterSatisfiabilityTest, TransitiveUnsatisfiability) {
   // Set up the filter configuration that will create the transitive condition
   auto called0 = std::make_shared<bool>(false);
   *factory += [called0](Decoration<0> in, std::shared_ptr<Decoration<1>>& out) {

--- a/src/autowiring/test/AutoFilterSatisfiabilityTest.cpp
+++ b/src/autowiring/test/AutoFilterSatisfiabilityTest.cpp
@@ -33,7 +33,10 @@ TEST_F(SatisfiabilityTest, MarkUnsatisfiableCalls) {
 
 TEST_F(SatisfiabilityTest, TransitiveUnsatisfiability) {
   // Set up the filter configuration that will create the transitive condition
-  *factory += [](Decoration<0> in, std::shared_ptr<Decoration<1>>& out) { };
+  auto called0 = std::make_shared<bool>(false);
+  *factory += [called0](Decoration<0> in, std::shared_ptr<Decoration<1>>& out) {
+    *called0 = true;
+  };
 
   // This filter accepts Decoration<1> as an optional input argument.  It should be called
   // with this value set to nullptr.
@@ -43,7 +46,7 @@ TEST_F(SatisfiabilityTest, TransitiveUnsatisfiability) {
   };
 
   // This filter won't be called at all
-  *factory += [](Decoration<1>, Decoration<2>&) {};
+  *factory += [] (Decoration<1>, Decoration<2>&) {};
 
   // This verifies that we do have correct transitive unsatisfiability behavior
   auto called2 = std::make_shared<bool>(false);

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -12,6 +12,7 @@ set(AutowiringTest_SRCS
   AutoFilterFunctionTest.cpp
   AutoFilterMultiDecorateTest.cpp
   AutoFilterRvalueTest.cpp
+  AutoFilterSatisfiabilityTest.cpp
   AutoFilterSequencing.cpp
   AutoFilterTest.cpp
   AutoIDTest.cpp
@@ -54,7 +55,6 @@ set(AutowiringTest_SRCS
   SpinLockTest.cpp
   TeardownNotifierTest.cpp
   TypeRegistryTest.cpp
-  SatisfiabilityTest.cpp
   ScopeTest.cpp
   SnoopTest.cpp
   ThreadPoolTest.cpp


### PR DESCRIPTION
There is an issue where a filter producing an output will not have its outputs marked unsatisfiable if some of that filter's required input arguments are themselves unsatisfiable.  Add a test and correct the issue by implementing a transitive unsatisfiability scan.