### PR TITLE
fix xcode warning

### DIFF
--- a/src/autowiring/DispatchQueue.cpp
+++ b/src/autowiring/DispatchQueue.cpp
@@ -11,8 +11,8 @@ DispatchQueue::DispatchQueue(size_t dispatchCap):
 {}
 
 DispatchQueue::DispatchQueue(DispatchQueue&& q):
-  m_dispatchCap(q.m_dispatchCap),
-  onAborted(std::move(q.onAborted))
+  onAborted(std::move(q.onAborted)),
+  m_dispatchCap(q.m_dispatchCap)
 {
   if (!onAborted)
     *this += std::move(q);

--- a/src/autowiring/config_descriptor.h
+++ b/src/autowiring/config_descriptor.h
@@ -45,8 +45,8 @@ namespace autowiring {
     config_field(const char* name, U T::* memptr) :
       name(name),
       offset(reinterpret_cast<size_t>(&(static_cast<T*>(nullptr)->*memptr))),
-      marshaller{ &get_marshaller<U>() },
-      default_value(std::make_shared<typename std::remove_cv<U>::type>())
+      default_value(std::make_shared<typename std::remove_cv<U>::type>()),
+      marshaller{ &get_marshaller<U>() }
     {}
 
     // Name and optional description


### PR DESCRIPTION
Fix Xcode warning e.g. `Field 'm_dispatchCap' will be initialized after field 'onAborted'.