### PR TITLE
Tests should not be touching `std::cout`

### DIFF
--- a/src/autowiring/test/AutowiringDebugTest.cpp
+++ b/src/autowiring/test/AutowiringDebugTest.cpp
@@ -107,7 +107,6 @@ TEST_F(AutowiringDebugTest, FilterInfoTest) {
   AutoRequired<IntModifier> filter4;
 
   auto text = autowiring::dbg::AutoFilterInfo("IntInFloatIn");
-  std::cout << text << std::endl;
   ASSERT_NE(std::string{"Filter not found"}, text) << "Debug helper routine did not find a named filter in the current context as expected";
 }
 


### PR DESCRIPTION
Looks like this crept in awhile back, remove it--tests should leave `cout` clean and allow the test framework itself to decide what to report to the user.