### PR TITLE
Add rvalue shared pointer support to AutoFilter

### DIFF
--- a/src/autowiring/AnySharedPointer.h
+++ b/src/autowiring/AnySharedPointer.h
@@ -71,6 +71,11 @@ public:
     return *reinterpret_cast<const std::shared_ptr<T>*>(&m_ptr);
   }
 
+  template<class T>
+  std::shared_ptr<T>& as(void) {
+    return *reinterpret_cast<std::shared_ptr<T>*>(&m_ptr);
+  }
+
   bool operator==(const AnySharedPointer& rhs) const {
     // Need to compare the control blocks, not the pointer values, because we could be pointing to
     // different spots in the same object.

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -114,7 +114,7 @@ void AutoPacket::AddSatCounterUnsafe(SatCounter& satCounter) {
       // otherwise insert it to the right position so that the modifiers vector is sorted by altitude
       auto it = entry.m_modifiers.begin();
       while (it != entry.m_modifiers.end()) {
-        if (it->altitude == satCounter.GetAltitude() && it->is_shared == pCur->is_shared) {
+        if (it->altitude == satCounter.GetAltitude()) {
           std::stringstream ss;
           ss << "Added multiple rvalue decorations with same altitudes for type " << autowiring::demangle(pCur->id);
           throw autowiring_error(ss.str());

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -114,7 +114,7 @@ void AutoPacket::AddSatCounterUnsafe(SatCounter& satCounter) {
       // otherwise insert it to the right position so that the modifiers vector is sorted by altitude
       auto it = entry.m_modifiers.begin();
       while (it != entry.m_modifiers.end()) {
-        if (it->altitude == satCounter.GetAltitude()) {
+        if (it->altitude == satCounter.GetAltitude() && it->is_shared == pCur->is_shared) {
           std::stringstream ss;
           ss << "Added multiple rvalue decorations with same altitudes for type " << autowiring::demangle(pCur->id);
           throw autowiring_error(ss.str());
@@ -539,7 +539,7 @@ bool AutoPacket::IsUnsatisfiable(const auto_id& id) const
     // We have never heard of this type
     return false;
   if (!pDisposition->m_decorations.empty())
-    // We have some actual decorations, we know this is not satisfiable
+    // We have some actual decorations, we know this is not unsatisfiable
     return false;
   if (pDisposition->m_nProducersRun != pDisposition->m_publishers.size())
     // Some producers have not yet run, we could still feasibly get a decoration back

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -339,6 +339,7 @@ void AutoPacket::UpdateSatisfactionUnsafe(std::unique_lock<std::mutex> lk, const
     break;
   case 1:
     {
+      // One unique decoration available.  We should be able to call everyone.
       for (auto modifier : disposition.m_modifiers) {
         auto& satCounter = *modifier.satCounter;
         if (!modifier.is_shared) {
@@ -346,7 +347,6 @@ void AutoPacket::UpdateSatisfactionUnsafe(std::unique_lock<std::mutex> lk, const
             callQueue.push_back(&satCounter);
         }
       }
-      // One unique decoration available.  We should be able to call everyone.
       for (auto subscriber : disposition.m_subscribers) {
         auto& satCounter = *subscriber.satCounter;
         if (satCounter.Decrement())

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -282,6 +282,8 @@ void AutoPacket::UpdateSatisfactionUnsafe(std::unique_lock<std::mutex> lk, const
   };
 
   for (auto modifier : disposition.m_modifiers) {
+    if (!modifier.satCounter)
+      continue;
     auto& satCounter = *modifier.satCounter;
     if (modifier.is_shared) {
       if (disposition.m_decorations.size() > 1)

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -275,6 +275,16 @@ void AutoPacket::UpdateSatisfactionUnsafe(std::unique_lock<std::mutex> lk, const
   switch (disposition.m_decorations.size()) {
   case 0:
     // No decorations here whatsoever.
+    for (auto modifier : disposition.m_modifiers) {
+      auto& satCounter = *modifier.satCounter;
+      if (modifier.is_shared) {
+          if (satCounter.Decrement())
+            callQueue.push_back(&satCounter);
+      } else {
+        // Mark unsatisfiable
+      }
+    }
+
     // Subscribers that cannot be invoked should have their outputs recursively marked unsatisfiable.
     // Subscribers that can be invoked should be.
     for (auto subscriber : disposition.m_subscribers) {

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -281,13 +281,14 @@ void AutoPacket::UpdateSatisfactionUnsafe(std::unique_lock<std::mutex> lk, const
     }
   };
 
+  if (!disposition.m_modifiers.empty() && disposition.m_decorations.size() > 1)
+    throw autowiring_error("An AutoFilter was detected which has single-decorate rvalue argument in a graph with multi-decorate outputs");
+
   for (auto modifier : disposition.m_modifiers) {
     if (!modifier.satCounter)
       continue;
     auto& satCounter = *modifier.satCounter;
     if (modifier.is_shared) {
-      if (disposition.m_decorations.size() > 1)
-        throw autowiring_error("An AutoFilter was detected which has single-decorate rvalue shared pointer argument in a graph with multi-decorate outputs");
       if (satCounter.Decrement()) {
         lk.unlock();
         callQueue.push_back(&satCounter);
@@ -309,6 +310,7 @@ void AutoPacket::UpdateSatisfactionUnsafe(std::unique_lock<std::mutex> lk, const
           callQueue.push_back(&satCounter);
         break;
       default:
+        // should not reach here
         throw autowiring_error("An AutoFilter was detected which has single-decorate rvalue argument in a graph with multi-decorate outputs");
       }
     }

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -140,8 +140,8 @@ void AutoPacket::AddSatCounterUnsafe(SatCounter& satCounter) {
       }
 
       if (pCur->is_output) {
-        if (!entry.m_publishers.empty())
-          for (const auto& subscriber : entry.m_subscribers)
+        if (!entry.m_publishers.empty()) {
+          for (const auto& subscriber : entry.m_subscribers) {
             for (auto pOther = subscriber.satCounter->GetAutoFilterArguments(); *pOther; pOther++) {
               if (pOther->id == pCur->id && !pOther->is_multi) {
                 std::stringstream ss;
@@ -149,6 +149,14 @@ void AutoPacket::AddSatCounterUnsafe(SatCounter& satCounter) {
                 throw autowiring_error(ss.str());
               }
             }
+          }
+
+          if (!entry.m_modifiers.empty()) {
+            std::stringstream ss;
+            ss << "Added identical data broadcasts of type " << autowiring::demangle(pCur->id) << " with existing modifier.";
+            throw autowiring_error(ss.str());
+          }
+        }
         entry.m_publishers.push_back(&satCounter);
       }
     }

--- a/src/autowiring/AutoPacket.h
+++ b/src/autowiring/AutoPacket.h
@@ -254,7 +254,7 @@ public:
     static_assert(!std::is_same<T, AnySharedPointer>::value, "AnySharedPointer is not permitted to be directly decorated on an AutoPacket");
 
     const T* retVal;
-    if (!Get(retVal, tshift))
+    if (!Get(retVal, tshift) || !retVal)
       ThrowNotDecoratedException(DecorationKey(auto_id_t<T>{}, tshift));
     return *retVal;
   }
@@ -373,7 +373,7 @@ public:
     static_assert(!std::is_same<T, AnySharedPointer>::value, "AnySharedPointer is not permitted to be directly decorated on an AutoPacket");
 
     const T* retVal;
-    if (!Get(retVal, tshift))
+    if (!Get(retVal, tshift) || !retVal)
       ThrowNotDecoratedException(DecorationKey(auto_id_t<T>{}, tshift));
     return std::move(const_cast<T&>(*retVal));
   }

--- a/src/autowiring/AutoPacket.h
+++ b/src/autowiring/AutoPacket.h
@@ -171,6 +171,9 @@ protected:
   /// <summary>Runtime counterpart to Decorate</summary>
   void Decorate(const AnySharedPointer& ptr, DecorationKey key);
 
+  /// <summary>Runtime counterpart to RemoveDecoration</summary>
+  void RemoveDecoration(DecorationKey key);
+
   /// <summary>
   /// The portion of Successor that must run under a lock
   /// </summary>
@@ -611,6 +614,15 @@ public:
       );
     }),
     PulseSatisfactionUnsafe(std::move(lk), pTypeSubs, 1 + sizeof...(Ts));
+  }
+
+  /// <summary>
+  /// Remove decorations on this packet with a particular type
+  /// </summary>
+  template<class T>
+  void RemoveDecoration(void) {
+    DecorationKey key(auto_id_t<T>{}, 0);
+    RemoveDecoration(key);
   }
 
   /// <summary>

--- a/src/autowiring/AutoPacket.h
+++ b/src/autowiring/AutoPacket.h
@@ -376,7 +376,7 @@ public:
   }
 
   /// <returns>
-  /// The Rvalue decoration for the specified type and time shift, or throws an exception if such a type cannot be found
+  /// The Rvalue shared pointer decoration for the specified type and time shift, or nullptr if such a type cannot be found
   /// </returns>
   template<class T>
   std::shared_ptr<T>&& GetRvalueShared(int tshift = 0) const {

--- a/src/autowiring/AutoPacket.h
+++ b/src/autowiring/AutoPacket.h
@@ -375,6 +375,18 @@ public:
     return std::move(const_cast<T&>(*retVal));
   }
 
+  /// <returns>
+  /// The Rvalue decoration for the specified type and time shift, or throws an exception if such a type cannot be found
+  /// </returns>
+  template<class T>
+  std::shared_ptr<T>&& GetRvalueShared(int tshift = 0) const {
+    static_assert(!std::is_same<T, AnySharedPointer>::value, "AnySharedPointer is not permitted to be directly decorated on an AutoPacket");
+
+    const std::shared_ptr<const T>* retVal;
+    Get(retVal, tshift);
+    return std::move(std::const_pointer_cast<T>(*retVal));
+  }
+
   /// <summary>
   /// Returns a null-terminated buffer containing all decorations
   /// </summary>

--- a/src/autowiring/AutoPacket.h
+++ b/src/autowiring/AutoPacket.h
@@ -384,7 +384,7 @@ public:
 
     const std::shared_ptr<const T>* retVal;
     Get(retVal, tshift);
-    return std::move(std::const_pointer_cast<T>(*retVal));
+    return retVal ? std::move(std::const_pointer_cast<T>(*retVal)) : std::move(nullptr);
   }
 
   /// <summary>

--- a/src/autowiring/AutoPacketGraph.cpp
+++ b/src/autowiring/AutoPacketGraph.cpp
@@ -73,7 +73,7 @@ void AutoPacketGraph::AutoFilter(AutoPacket& packet) {
       auto type = cur.first.id;
 
       for (auto& modifier : decoration.m_modifiers)
-        if (!modifier.satCounter->remaining)
+        if (modifier.satCounter && !modifier.satCounter->remaining)
           RecordDelivery(type, *modifier.satCounter, DeliveryEdge::ArgType::Rvalue);
 
       for (auto& publisher : decoration.m_publishers)

--- a/src/autowiring/AutoPacketGraph.cpp
+++ b/src/autowiring/AutoPacketGraph.cpp
@@ -73,7 +73,7 @@ void AutoPacketGraph::AutoFilter(AutoPacket& packet) {
       auto type = cur.first.id;
 
       for (auto& modifier : decoration.m_modifiers)
-        if (modifier.satCounter->remaining)
+        if (!modifier.satCounter->remaining)
           RecordDelivery(type, *modifier.satCounter, DeliveryEdge::ArgType::Rvalue);
 
       for (auto& publisher : decoration.m_publishers)

--- a/src/autowiring/AutoPacketGraph.cpp
+++ b/src/autowiring/AutoPacketGraph.cpp
@@ -73,8 +73,8 @@ void AutoPacketGraph::AutoFilter(AutoPacket& packet) {
       auto type = cur.first.id;
 
       for (auto& modifier : decoration.m_modifiers)
-        if (!modifier->remaining)
-          RecordDelivery(type, *modifier, DeliveryEdge::ArgType::Rvalue);
+        if (modifier.satCounter->remaining)
+          RecordDelivery(type, *modifier.satCounter, DeliveryEdge::ArgType::Rvalue);
 
       for (auto& publisher : decoration.m_publishers)
         if (!publisher->remaining)

--- a/src/autowiring/DecorationDisposition.h
+++ b/src/autowiring/DecorationDisposition.h
@@ -87,19 +87,16 @@ struct DecorationDisposition
 
     Modifier(const Modifier& rhs) = default;
 
-    Modifier& operator=(Modifier rhs) {
-      std::swap(*this, rhs);
-      return *this;
-    }
+    Modifier& operator=(const Modifier& rhs) = default;
 
     // True if a shared pointer will be taken, false otherwise
-    const bool is_shared;
+    bool is_shared;
 
     // The altitude of the satisfaction counter
-    const autowiring::altitude altitude;
+    autowiring::altitude altitude;
 
     // The pointer to the satisfaction counter, it should never be nullptr
-    SatCounter* const satCounter;
+    SatCounter* satCounter;
   };
 
   // Modifiers of this decoration, ordered by altitude.

--- a/src/autowiring/DecorationDisposition.h
+++ b/src/autowiring/DecorationDisposition.h
@@ -68,13 +68,42 @@ struct DecorationDisposition
   // Valid if and only if is_shared is true.
   const void* m_pImmediate = nullptr;
 
-  // Modifiers of this decoration, ordered by altitude.
-  std::vector<SatCounter*> m_modifiers;
-
   // Providers for this decoration, where it can be statically inferred.  Note that a provider for
   // this decoration may exist even if this value is null, in the event that dynamic decoration is
   // taking place.
   std::vector<SatCounter*> m_publishers;
+
+  struct Modifier {
+    Modifier(void) = default;
+
+    Modifier(bool is_shared, autowiring::altitude altitude, SatCounter* satCounter) :
+      is_shared{is_shared},
+      altitude{altitude},
+      satCounter{satCounter}
+    {
+      if (satCounter == nullptr)
+        throw std::runtime_error("Cannot initialize Modifier with nullptr to SatCounter.");
+    }
+
+    Modifier(const Modifier& rhs) = default;
+
+    Modifier& operator=(Modifier rhs) {
+      std::swap(*this, rhs);
+      return *this;
+    }
+
+    // True if a shared pointer will be taken, false otherwise
+    const bool is_shared;
+
+    // The altitude of the satisfaction counter
+    const autowiring::altitude altitude;
+
+    // The pointer to the satisfaction counter, it should never be nullptr
+    SatCounter* const satCounter;
+  };
+
+  // Modifiers of this decoration, ordered by altitude.
+  std::vector<Modifier> m_modifiers;
 
   struct Subscriber {
     enum class Type {

--- a/src/autowiring/auto_arg.h
+++ b/src/autowiring/auto_arg.h
@@ -167,7 +167,8 @@ public:
 
   template<class C>
   static void Commit(C& packet, std::shared_ptr<T> val) {
-    // Do nothing. Modify val in place, no need to commit
+    if (!val)
+      packet.template RemoveDecoration<T>();
   }
 };
 

--- a/src/autowiring/auto_arg.h
+++ b/src/autowiring/auto_arg.h
@@ -143,6 +143,35 @@ class auto_arg<const std::shared_ptr<const T>&>:
 {};
 
 /// <summary>
+/// Specialization for "std::shared_ptr<T>&&" ~ auto_in<T&&> and auto_out<T&&>.
+/// </summary>
+template<class T>
+class auto_arg<std::shared_ptr<T>&&>
+{
+public:
+  typedef std::shared_ptr<T>&& type;
+  typedef type arg_type;
+  typedef auto_id_t<T> id_type;
+  static const bool is_input = true;
+  static const bool is_output = true;
+  static const bool is_rvalue = true;
+  static const bool is_shared = true;
+  static const bool is_multi = false;
+  static const int tshift = 0;
+
+  template<class C>
+  static std::shared_ptr<T>&& arg(C& packet) {
+    (void) auto_id_t_init<T, false>::init;
+    return packet.template GetRvalueShared<T>();
+  }
+
+  template<class C>
+  static void Commit(C& packet, std::shared_ptr<T> val) {
+    // Do nothing. Modify val in place, no need to commit
+  }
+};
+
+/// <summary>
 /// Specialization for "T*" ~ auto_in<T*>.  T must be const-qualified in order to be an input parameter.
 /// </summary>
 template<class T>
@@ -253,7 +282,7 @@ public:
 };
 
 /// <summary>
-/// Specialization for "std::shared_ptr<T>&" ~ auto_in<T>
+/// Specialization for "std::shared_ptr<T>&" ~ auto_out<T>
 /// </summary>
 template<class T>
 class auto_arg<std::shared_ptr<T>&>:

--- a/src/autowiring/test/AutoFilterRvalueTest.cpp
+++ b/src/autowiring/test/AutoFilterRvalueTest.cpp
@@ -178,3 +178,53 @@ TEST_F(AutoFilterRvalueTest, SharedPtrTest) {
   const Decoration<1>& dec1 = packet->Get<Decoration<1>>();
   ASSERT_EQ(1, dec1.i) << "R-value shared pointer AutoFilter was not able to modify a decoration value before passing on to the next Autofilter";
 }
+
+TEST_F(AutoFilterRvalueTest, SharedPtrAltitudeTest) {
+  int called = 0;
+  int results[] = {-1, -1, -1, -1, -1, -1};
+
+  // This should get called first
+  *factory += [&] (Decoration<0> in, std::shared_ptr<Decoration<1>>& out) {
+    out.reset(new Decoration<1>);
+    out->i = called;
+    results[called++] = out->i;
+  };
+
+  // This should get called third
+  *factory += autowiring::altitude::Dispatch, [&](std::shared_ptr<Decoration<1>>&& sp) {
+    sp.reset(new Decoration<1>);
+    sp->i = called;
+    results[called++] = sp->i;
+  };
+
+  // This should get called forth
+  *factory += autowiring::altitude::Realtime, [&](Decoration<1>&& dec1) {
+    dec1.i = called;
+    results[called++] = dec1.i;
+  };
+
+  // This should get called second
+  *factory += autowiring::altitude::Highest, [&](Decoration<1>&& dec1) {
+    dec1.i = called;
+    results[called++] = dec1.i;
+  };
+
+  // This should get called fifth
+  *factory += [&] (std::shared_ptr<Decoration<1>>&& sp) {
+    sp.reset();
+    called++;
+  };
+
+  // This should never gets called because of the reset above
+  *factory += autowiring::altitude::Lowest, [&](Decoration<1> in) {
+    results[called++] = in.i;
+  };
+
+  auto packet = factory->NewPacket();
+  packet->Decorate(Decoration<0>());
+  ASSERT_EQ(5, called);
+
+  int expected[] = {0, 2, 3, 1, -1, -1};
+  for (int i = 0; i < 6; i++)
+    ASSERT_EQ(expected[i], results[i]);
+}

--- a/src/autowiring/test/AutoFilterRvalueTest.cpp
+++ b/src/autowiring/test/AutoFilterRvalueTest.cpp
@@ -152,13 +152,27 @@ TEST_F(AutoFilterRvalueTest, RecipientRemovalTest) {
 }
 
 TEST_F(AutoFilterRvalueTest, SharedPtrTest) {
-  auto called = std::make_shared<bool>(false);
-  *factory += [called](std::shared_ptr<Decoration<1>>&& sp) {
-    //sp.reset(new Decoration<1>);
-    *called = true;
+  auto called0 = std::make_shared<bool>(false);
+  *factory += [called0] (Decoration<0> in, std::shared_ptr<Decoration<1>>& out) {
+    out.reset(new Decoration<1>);
+    out->i = in.i;
+    *called0 = true;
   };
 
+  auto called1 = std::make_shared<bool>(false);
+  *factory += [called1] (std::shared_ptr<Decoration<1>>&& sp) {
+    sp.reset();
+    *called1 = true;
+  };
+
+//  auto called2 = std::make_shared<bool>(false);
+//  *factory += [called2] (Decoration<1> in) {
+//    *called2 = true;
+//  };
+
   auto packet = factory->NewPacket();
-  packet->MarkUnsatisfiable<Decoration<1>>();
-  ASSERT_TRUE(*called);
+  packet->Decorate(Decoration<0>());
+  ASSERT_TRUE(*called0);
+  ASSERT_TRUE(*called1);
+//  ASSERT_FALSE(*called2);
 }

--- a/src/autowiring/test/AutoFilterRvalueTest.cpp
+++ b/src/autowiring/test/AutoFilterRvalueTest.cpp
@@ -154,7 +154,7 @@ TEST_F(AutoFilterRvalueTest, RecipientRemovalTest) {
 TEST_F(AutoFilterRvalueTest, SharedPtrTest) {
   auto called = std::make_shared<bool>(false);
   *factory += [called](std::shared_ptr<Decoration<1>>&& sp) {
-    sp.reset(new Decoration<1>);
+    //sp.reset(new Decoration<1>);
     *called = true;
   };
 

--- a/src/autowiring/test/AutoFilterRvalueTest.cpp
+++ b/src/autowiring/test/AutoFilterRvalueTest.cpp
@@ -161,18 +161,20 @@ TEST_F(AutoFilterRvalueTest, SharedPtrTest) {
 
   auto called1 = std::make_shared<bool>(false);
   *factory += [called1] (std::shared_ptr<Decoration<1>>&& sp) {
-    sp.reset();
+    sp.reset(new Decoration<1>);
     *called1 = true;
   };
 
-//  auto called2 = std::make_shared<bool>(false);
-//  *factory += [called2] (Decoration<1> in) {
-//    *called2 = true;
-//  };
+  auto called2 = std::make_shared<bool>(false);
+  *factory += [called2] (Decoration<1> in) {
+    *called2 = true;
+  };
 
   auto packet = factory->NewPacket();
   packet->Decorate(Decoration<0>());
   ASSERT_TRUE(*called0);
   ASSERT_TRUE(*called1);
-//  ASSERT_FALSE(*called2);
+  ASSERT_TRUE(*called2);
+  const Decoration<1>& dec1 = packet->Get<Decoration<1>>();
+  ASSERT_EQ(1, dec1.i) << "R-value shared pointer AutoFilter was not able to modify a decoration value before passing on to the next Autofilter";
 }

--- a/src/autowiring/test/AutoFilterRvalueTest.cpp
+++ b/src/autowiring/test/AutoFilterRvalueTest.cpp
@@ -152,29 +152,13 @@ TEST_F(AutoFilterRvalueTest, RecipientRemovalTest) {
 }
 
 TEST_F(AutoFilterRvalueTest, SharedPtrTest) {
-//  auto called0 = std::make_shared<bool>(false);
-//  *factory += [called0](Decoration<0> in, std::shared_ptr<Decoration<1>>& out) {
-//    out.reset(new Decoration<1>);
-//    *called0 = true;
-//  };
-//
-  auto called1 = std::make_shared<bool>(false);
-  *factory += [called1](std::shared_ptr<Decoration<1>>&& r) {
-    r.reset();
-    *called1 = true;
+  auto called = std::make_shared<bool>(false);
+  *factory += [called](std::shared_ptr<Decoration<1>>&& sp) {
+    sp.reset(new Decoration<1>);
+    *called = true;
   };
-//
-//  auto called2 = std::make_shared<bool>(false);
-//  *factory += [called2] (std::shared_ptr<const Decoration<1>> in, std::shared_ptr<Decoration<2>>& out) {
-//    out = in;
-//    *called2 = true;
-//  };
-//
+
   auto packet = factory->NewPacket();
-//  packet->Decorate(Decoration<1>{});
-//  ASSERT_TRUE(*called0);
-  ASSERT_TRUE(*called1);
-//  ASSERT_TRUE(*called2);
-//  const Decoration<2>& dec2 = packet->Get<Decoration<2>>();
-//  ASSERT_EQ(999, dec2.i) << "AutoFilters was not called in the correct order when there are multiple R-value AutoFilter with different altitude";
+  packet->MarkUnsatisfiable<Decoration<1>>();
+  ASSERT_TRUE(*called);
 }

--- a/src/autowiring/test/AutoFilterRvalueTest.cpp
+++ b/src/autowiring/test/AutoFilterRvalueTest.cpp
@@ -186,26 +186,26 @@ TEST_F(AutoFilterRvalueTest, SharedPtrAltitudeTest) {
   // This should get called first
   *factory += [&] (Decoration<0> in, std::shared_ptr<Decoration<1>>& out) {
     out.reset(new Decoration<1>);
-    out->i = called;
+    out->i = 0;
     results[called++] = out->i;
   };
 
   // This should get called third
   *factory += autowiring::altitude::Dispatch, [&](std::shared_ptr<Decoration<1>>&& sp) {
     sp.reset(new Decoration<1>);
-    sp->i = called;
+    sp->i = 1;
     results[called++] = sp->i;
   };
 
   // This should get called forth
   *factory += autowiring::altitude::Realtime, [&](Decoration<1>&& dec1) {
-    dec1.i = called;
+    dec1.i = 2;
     results[called++] = dec1.i;
   };
 
   // This should get called second
   *factory += autowiring::altitude::Highest, [&](Decoration<1>&& dec1) {
-    dec1.i = called;
+    dec1.i = 3;
     results[called++] = dec1.i;
   };
 
@@ -224,7 +224,7 @@ TEST_F(AutoFilterRvalueTest, SharedPtrAltitudeTest) {
   packet->Decorate(Decoration<0>());
   ASSERT_EQ(5, called);
 
-  int expected[] = {0, 2, 3, 1, -1, -1};
+  int expected[] = {0, 3, 1, 2, -1, -1};
   for (int i = 0; i < 6; i++)
     ASSERT_EQ(expected[i], results[i]);
 }

--- a/src/autowiring/test/AutoFilterSatisfiabilityTest.cpp
+++ b/src/autowiring/test/AutoFilterSatisfiabilityTest.cpp
@@ -63,21 +63,27 @@ TEST_F(AutoFilterSatisfiabilityTest, TransitiveUnsatisfiability) {
 }
 
 TEST_F(AutoFilterSatisfiabilityTest, RvalueMarkUnsatisfiableTest) {
-  auto refCalled = std::make_shared<bool>(false);
-  *factory += autowiring::altitude::Lowest, [refCalled] (Decoration<1>&& ref) {
-    *refCalled = true;
+  auto called0 = std::make_shared<bool>(false);
+  *factory += autowiring::altitude::Lowest, [called0] (Decoration<1>&& ref) {
+    *called0 = true;
   };
 
-  auto sharedCalled = std::make_shared<bool>(false);
-  *factory += [sharedCalled] (std::shared_ptr<Decoration<1>>&& sp) {
+  auto called1 = std::make_shared<bool>(false);
+  *factory += [called1] (std::shared_ptr<Decoration<1>>&& sp) {
     sp.reset(new Decoration<1>);
-    *sharedCalled = true;
+    *called1 = true;
+  };
+
+  auto called2 = std::make_shared<bool>(false);
+  *factory += autowiring::altitude::Highest, [called2] (Decoration<1>&& ref) {
+    *called2 = true;
   };
 
   auto packet = factory->NewPacket();
   packet->MarkUnsatisfiable<Decoration<1>>();
-  ASSERT_FALSE(*refCalled);
-  ASSERT_TRUE(*sharedCalled);
+  ASSERT_TRUE(*called0);
+  ASSERT_TRUE(*called1);
+  ASSERT_FALSE(*called2);
 }
 
 TEST_F(AutoFilterSatisfiabilityTest, RvalueTransitiveUnsatisfiability) {

--- a/src/autowiring/test/AutoFilterSatisfiabilityTest.cpp
+++ b/src/autowiring/test/AutoFilterSatisfiabilityTest.cpp
@@ -61,3 +61,34 @@ TEST_F(AutoFilterSatisfiabilityTest, TransitiveUnsatisfiability) {
   ASSERT_TRUE(packet->IsUnsatisfiable<Decoration<2>>());
   ASSERT_TRUE(*called2);
 }
+
+//TEST_F(AutoFilterSatisfiabilityTest, RvalueTransitiveUnsatisfiability) {
+//  // Set up the filter configuration that will create the transitive condition
+//  auto called0 = std::make_shared<bool>(false);
+//  *factory += [called0](Decoration<0> in, std::shared_ptr<Decoration<1>>& out) {
+//    *called0 = true;
+//  };
+//
+//  // This filter accepts Decoration<1> as an optional input argument.  It should be called
+//  // with this value set to nullptr.
+//  auto called1 = std::make_shared<bool>(false);
+//  *factory += [called1](std::shared_ptr<Decoration<1>&&> r) {
+//    *called1 = true;
+//  };
+//
+//  // This filter won't be called at all
+//  *factory += [] (Decoration<1>&&, Decoration<2>&) {};
+//
+//  // This verifies that we do have correct transitive unsatisfiability behavior
+//  auto called2 = std::make_shared<bool>(false);
+//  *factory += [called2] (std::shared_ptr<Decoration<2>&&> r) {
+//    *called2 = true;
+//  };
+//
+//  auto packet = factory->NewPacket();
+//  packet->Decorate(Decoration<0>{});
+//  ASSERT_TRUE(packet->IsUnsatisfiable<Decoration<1>>());
+//  ASSERT_TRUE(*called1);
+//  ASSERT_TRUE(packet->IsUnsatisfiable<Decoration<2>>());
+//  ASSERT_TRUE(*called2);
+//}

--- a/src/autowiring/test/AutoFilterSatisfiabilityTest.cpp
+++ b/src/autowiring/test/AutoFilterSatisfiabilityTest.cpp
@@ -62,6 +62,24 @@ TEST_F(AutoFilterSatisfiabilityTest, TransitiveUnsatisfiability) {
   ASSERT_TRUE(*called2);
 }
 
+TEST_F(AutoFilterSatisfiabilityTest, RvalueMarkUnsatisfiableTest) {
+  auto refCalled = std::make_shared<bool>(false);
+  *factory += [refCalled] (Decoration<1>&& ref) {
+    *refCalled = true;
+  };
+
+  auto sharedCalled = std::make_shared<bool>(false);
+  *factory += [sharedCalled] (std::shared_ptr<Decoration<1>>&& sp) {
+    sp.reset(new Decoration<1>);
+    *sharedCalled = true;
+  };
+
+  auto packet = factory->NewPacket();
+  packet->MarkUnsatisfiable<Decoration<1>>();
+  ASSERT_FALSE(*refCalled);
+  ASSERT_TRUE(*sharedCalled);
+}
+
 //TEST_F(AutoFilterSatisfiabilityTest, RvalueTransitiveUnsatisfiability) {
 //  // Set up the filter configuration that will create the transitive condition
 //  auto called0 = std::make_shared<bool>(false);

--- a/src/autowiring/test/AutoFilterSatisfiabilityTest.cpp
+++ b/src/autowiring/test/AutoFilterSatisfiabilityTest.cpp
@@ -64,7 +64,7 @@ TEST_F(AutoFilterSatisfiabilityTest, TransitiveUnsatisfiability) {
 
 TEST_F(AutoFilterSatisfiabilityTest, RvalueMarkUnsatisfiableTest) {
   auto refCalled = std::make_shared<bool>(false);
-  *factory += [refCalled] (Decoration<1>&& ref) {
+  *factory += autowiring::altitude::Lowest, [refCalled] (Decoration<1>&& ref) {
     *refCalled = true;
   };
 
@@ -102,7 +102,7 @@ TEST_F(AutoFilterSatisfiabilityTest, RvalueTransitiveUnsatisfiability) {
 
   // This verifies that we do have correct transitive unsatisfiability behavior
   auto called3 = std::make_shared<bool>(false);
-  *factory += [called3] (std::shared_ptr<Decoration<2>>&&) {
+  *factory += [called3] (std::shared_ptr<const Decoration<2>>) {
     *called3 = true;
   };
 


### PR DESCRIPTION
Add support for rvalue shared pointer arguments for AutoFilter. It would make it possible to replace or remove a decoration in place.