### PR TITLE
future is only supported by android64 gcc 4.9

### DIFF
--- a/src/autowiring/C++11/cpp11.h
+++ b/src/autowiring/C++11/cpp11.h
@@ -127,7 +127,7 @@
 /*********************
  * future availability
  *********************/
-#if (_MSC_VER >= 1700 || (STL11_ALLOWED)) && (!__ANDROID__ || GCC_CHECK(4, 9))
+#if (_MSC_VER >= 1700 || (STL11_ALLOWED)) && (!__ANDROID__ || (GCC_CHECK(4, 9) && __aarch64__))
   #define FUTURE_HEADER <future>
 #else
   // As of NDK r10, we still don't have an implementation of "future" for Android


### PR DESCRIPTION
Unfortunately, Android32 gcc 4.9 does not support future.
This is required to upgrade android32 gcc4.8 to gcc 4.9. 