### PR TITLE
Add C++11 support for filesystem

### DIFF
--- a/contrib/autoboost/autoboost/filesystem.hpp
+++ b/contrib/autoboost/autoboost/filesystem.hpp
@@ -1,0 +1,21 @@
+//  autoboost/filesystem.hpp  --------------------------------------------------------------//
+
+//  Copyright Beman Dawes 2010
+
+//  Distributed under the Boost Software License, Version 1.0.
+//  See http://www.boost.org/LICENSE_1_0.txt
+
+//  Library home page: http://www.boost.org/libs/filesystem
+
+//--------------------------------------------------------------------------------------//
+
+#ifndef AUTOBOOST_FILESYSTEM_FILESYSTEM_HPP
+#define AUTOBOOST_FILESYSTEM_FILESYSTEM_HPP
+
+#  include <autoboost/filesystem/config.hpp>
+#  include <autoboost/filesystem/path.hpp>
+#  include <autoboost/filesystem/operations.hpp>
+#  include <autoboost/filesystem/convenience.hpp>
+#  include <autoboost/filesystem/string_file.hpp>
+
+#endif  // AUTOBOOST_FILESYSTEM_FILESYSTEM_HPP

--- a/contrib/autoboost/autoboost/filesystem/config.hpp
+++ b/contrib/autoboost/autoboost/filesystem/config.hpp
@@ -1,0 +1,89 @@
+//  autoboost/filesystem/v3/config.hpp  ----------------------------------------------------//
+
+//  Copyright Beman Dawes 2003
+
+//  Distributed under the Boost Software License, Version 1.0.
+//  See http://www.boost.org/LICENSE_1_0.txt
+
+//  Library home page: http://www.boost.org/libs/filesystem
+
+//--------------------------------------------------------------------------------------//
+
+#ifndef AUTOBOOST_FILESYSTEM3_CONFIG_HPP
+#define AUTOBOOST_FILESYSTEM3_CONFIG_HPP
+
+# if defined(AUTOBOOST_FILESYSTEM_VERSION) && AUTOBOOST_FILESYSTEM_VERSION != 3
+#   error Compiling Filesystem version 3 file with AUTOBOOST_FILESYSTEM_VERSION defined != 3
+# endif
+
+# if !defined(AUTOBOOST_FILESYSTEM_VERSION)
+#   define AUTOBOOST_FILESYSTEM_VERSION 3
+# endif
+
+#define AUTOBOOST_FILESYSTEM_I18N  // aid users wishing to compile several versions
+
+// This header implements separate compilation features as described in
+// http://www.boost.org/more/separate_compilation.html
+
+#include <autoboost/config.hpp>
+#include <autoboost/system/api_config.hpp>  // for AUTOBOOST_POSIX_API or AUTOBOOST_WINDOWS_API
+#include <autoboost/detail/workaround.hpp>
+
+//  AUTOBOOST_FILESYSTEM_DEPRECATED needed for source compiles -----------------------------//
+
+# ifdef AUTOBOOST_FILESYSTEM_SOURCE
+#   define AUTOBOOST_FILESYSTEM_DEPRECATED
+#   undef AUTOBOOST_FILESYSTEM_NO_DEPRECATED   // fixes #9454, src bld fails if NO_DEP defined
+# endif
+
+//  throw an exception  ----------------------------------------------------------------//
+//
+//  Exceptions were originally thrown via autoboost::throw_exception().
+//  As throw_exception() became more complex, it caused user error reporting
+//  to be harder to interpret, since the exception reported became much more complex.
+//  The immediate fix was to throw directly, wrapped in a macro to make any later change
+//  easier.
+
+#define AUTOBOOST_FILESYSTEM_THROW(EX) throw EX
+
+# if defined( AUTOBOOST_NO_STD_WSTRING )
+#   error Configuration not supported: Boost.Filesystem V3 and later requires std::wstring support
+# endif
+
+//  This header implements separate compilation features as described in
+//  http://www.boost.org/more/separate_compilation.html
+
+//  normalize macros  ------------------------------------------------------------------//
+
+#if !defined(AUTOBOOST_FILESYSTEM_DYN_LINK) && !defined(AUTOBOOST_FILESYSTEM_STATIC_LINK) \
+  && !defined(AUTOBOOST_ALL_DYN_LINK) && !defined(AUTOBOOST_ALL_STATIC_LINK)
+# define AUTOBOOST_FILESYSTEM_STATIC_LINK
+#endif
+
+#if defined(AUTOBOOST_ALL_DYN_LINK) && !defined(AUTOBOOST_FILESYSTEM_DYN_LINK)
+# define AUTOBOOST_FILESYSTEM_DYN_LINK
+#elif defined(AUTOBOOST_ALL_STATIC_LINK) && !defined(AUTOBOOST_FILESYSTEM_STATIC_LINK)
+# define AUTOBOOST_FILESYSTEM_STATIC_LINK
+#endif
+
+#if defined(AUTOBOOST_FILESYSTEM_DYN_LINK) && defined(AUTOBOOST_FILESYSTEM_STATIC_LINK)
+# error Must not define both AUTOBOOST_FILESYSTEM_DYN_LINK and AUTOBOOST_FILESYSTEM_STATIC_LINK
+#endif
+
+#if defined(AUTOBOOST_ALL_NO_LIB) && !defined(AUTOBOOST_FILESYSTEM_NO_LIB)
+# define AUTOBOOST_FILESYSTEM_NO_LIB
+#endif
+
+//  enable dynamic linking  ------------------------------------------------------------//
+
+#if defined(AUTOBOOST_ALL_DYN_LINK) || defined(AUTOBOOST_FILESYSTEM_DYN_LINK)
+# if defined(AUTOBOOST_FILESYSTEM_SOURCE)
+#   define AUTOBOOST_FILESYSTEM_DECL AUTOBOOST_SYMBOL_EXPORT
+# else
+#   define AUTOBOOST_FILESYSTEM_DECL AUTOBOOST_SYMBOL_IMPORT
+# endif
+#else
+# define AUTOBOOST_FILESYSTEM_DECL
+#endif
+
+#endif // AUTOBOOST_FILESYSTEM3_CONFIG_HPP

--- a/contrib/autoboost/autoboost/filesystem/convenience.hpp
+++ b/contrib/autoboost/autoboost/filesystem/convenience.hpp
@@ -1,0 +1,58 @@
+//  autoboost/filesystem/convenience.hpp  ----------------------------------------//
+
+//  Copyright Beman Dawes, 2002-2005
+//  Copyright Vladimir Prus, 2002
+//  Use, modification, and distribution is subject to the Boost Software
+//  License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+//  See library home page at http://www.boost.org/libs/filesystem
+
+//----------------------------------------------------------------------------// 
+
+#ifndef AUTOBOOST_FILESYSTEM3_CONVENIENCE_HPP
+#define AUTOBOOST_FILESYSTEM3_CONVENIENCE_HPP
+
+#include <autoboost/config.hpp>
+
+# if defined( AUTOBOOST_NO_STD_WSTRING )
+#   error Configuration not supported: Boost.Filesystem V3 and later requires std::wstring support
+# endif
+
+#include <autoboost/filesystem/operations.hpp>
+#include <autoboost/system/error_code.hpp>
+
+#include <autoboost/config/abi_prefix.hpp> // must be the last #include
+
+namespace autoboost
+{
+  namespace filesystem
+  {
+
+# ifndef AUTOBOOST_FILESYSTEM_NO_DEPRECATED
+
+    inline std::string extension(const path & p)
+    {
+      return p.extension().string();
+    }
+
+    inline std::string basename(const path & p)
+    {
+      return p.stem().string();
+    }
+
+    inline path change_extension( const path & p, const path & new_extension )
+    { 
+      path new_p( p );
+      new_p.replace_extension( new_extension );
+      return new_p;
+    }
+
+# endif
+
+
+  } // namespace filesystem
+} // namespace autoboost
+
+#include <autoboost/config/abi_suffix.hpp> // pops abi_prefix.hpp pragmas
+#endif // AUTOBOOST_FILESYSTEM3_CONVENIENCE_HPP

--- a/contrib/autoboost/autoboost/filesystem/detail/utf8_codecvt_facet.hpp
+++ b/contrib/autoboost/autoboost/filesystem/detail/utf8_codecvt_facet.hpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2001 Ronald Garcia, Indiana University (garcia@osl.iu.edu)
+// Andrew Lumsdaine, Indiana University (lums@osl.iu.edu).
+
+// Distributed under the Boost Software License, Version 1.0.
+// (See http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef AUTOBOOST_FILESYSTEM_UTF8_CODECVT_FACET_HPP
+#define AUTOBOOST_FILESYSTEM_UTF8_CODECVT_FACET_HPP
+
+#include <autoboost/filesystem/config.hpp>
+
+#define AUTOBOOST_UTF8_BEGIN_NAMESPACE \
+     namespace autoboost { namespace filesystem { namespace detail {
+
+#define AUTOBOOST_UTF8_END_NAMESPACE }}}
+#define AUTOBOOST_UTF8_DECL AUTOBOOST_FILESYSTEM_DECL
+
+#include <autoboost/detail/utf8_codecvt_facet.hpp>
+
+#undef AUTOBOOST_UTF8_BEGIN_NAMESPACE
+#undef AUTOBOOST_UTF8_END_NAMESPACE
+#undef AUTOBOOST_UTF8_DECL
+
+#endif

--- a/contrib/autoboost/autoboost/filesystem/exception.hpp
+++ b/contrib/autoboost/autoboost/filesystem/exception.hpp
@@ -1,0 +1,9 @@
+//  autoboost/filesystem/exception.hpp  -----------------------------------------------------//
+
+//  Copyright Beman Dawes 2003
+//  Use, modification, and distribution is subject to the Boost Software
+//  License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+//  This header is no longer used. The contents have been moved to path.hpp.
+//  It is provided so that user code #includes do not have to be changed.

--- a/contrib/autoboost/autoboost/filesystem/fstream.hpp
+++ b/contrib/autoboost/autoboost/filesystem/fstream.hpp
@@ -1,0 +1,182 @@
+//  autoboost/filesystem/fstream.hpp  ------------------------------------------------------//
+
+//  Copyright Beman Dawes 2002
+
+//  Distributed under the Boost Software License, Version 1.0.
+//  See http://www.boost.org/LICENSE_1_0.txt
+
+//  Library home page: http://www.boost.org/libs/filesystem
+
+//--------------------------------------------------------------------------------------// 
+
+#ifndef AUTOBOOST_FILESYSTEM3_FSTREAM_HPP
+#define AUTOBOOST_FILESYSTEM3_FSTREAM_HPP
+
+#include <autoboost/config.hpp>
+
+# if defined( AUTOBOOST_NO_STD_WSTRING )
+#   error Configuration not supported: Boost.Filesystem V3 and later requires std::wstring support
+# endif
+
+#include <autoboost/filesystem/path.hpp>
+#include <iosfwd>
+#include <fstream>
+
+#include <autoboost/config/abi_prefix.hpp> // must be the last #include
+
+//  on Windows, except for standard libaries known to have wchar_t overloads for
+//  file stream I/O, use path::string() to get a narrow character c_str()
+#if defined(AUTOBOOST_WINDOWS_API) \
+  && (!defined(_CPPLIB_VER) || _CPPLIB_VER < 405 || defined(_STLPORT_VERSION))
+  // !Dinkumware || early Dinkumware || STLPort masquerading as Dinkumware
+# define AUTOBOOST_FILESYSTEM_C_STR string().c_str()  // use narrow, since wide not available
+#else  // use the native c_str, which will be narrow on POSIX, wide on Windows
+# define AUTOBOOST_FILESYSTEM_C_STR c_str()
+#endif
+
+namespace autoboost
+{
+namespace filesystem
+{
+
+//--------------------------------------------------------------------------------------//
+//                                  basic_filebuf                                       //
+//--------------------------------------------------------------------------------------//
+
+  template < class charT, class traits = std::char_traits<charT> >
+  class basic_filebuf : public std::basic_filebuf<charT,traits>
+  {
+  private: // disallow copying
+    basic_filebuf(const basic_filebuf&);
+    const basic_filebuf& operator=(const basic_filebuf&);
+
+  public:
+    basic_filebuf() {}
+    virtual ~basic_filebuf() {}
+
+    basic_filebuf<charT,traits>*
+      open(const path& p, std::ios_base::openmode mode) 
+    {
+      return std::basic_filebuf<charT,traits>::open(p.AUTOBOOST_FILESYSTEM_C_STR, mode)
+        ? this : 0;
+    }
+  };
+
+//--------------------------------------------------------------------------------------//
+//                                 basic_ifstream                                       //
+//--------------------------------------------------------------------------------------//
+
+  template < class charT, class traits = std::char_traits<charT> >
+  class basic_ifstream : public std::basic_ifstream<charT,traits>
+  {
+  private: // disallow copying
+    basic_ifstream(const basic_ifstream&);
+    const basic_ifstream& operator=(const basic_ifstream&);
+
+  public:
+    basic_ifstream() {}
+
+    // use two signatures, rather than one signature with default second
+    // argument, to workaround VC++ 7.1 bug (ID VSWhidbey 38416)
+
+    explicit basic_ifstream(const path& p)
+      : std::basic_ifstream<charT,traits>(p.AUTOBOOST_FILESYSTEM_C_STR, std::ios_base::in) {}
+
+    basic_ifstream(const path& p, std::ios_base::openmode mode)
+      : std::basic_ifstream<charT,traits>(p.AUTOBOOST_FILESYSTEM_C_STR, mode) {}
+
+    void open(const path& p)
+      { std::basic_ifstream<charT,traits>::open(p.AUTOBOOST_FILESYSTEM_C_STR, std::ios_base::in); }
+
+    void open(const path& p, std::ios_base::openmode mode)
+      { std::basic_ifstream<charT,traits>::open(p.AUTOBOOST_FILESYSTEM_C_STR, mode); }
+
+    virtual ~basic_ifstream() {}
+  };
+
+//--------------------------------------------------------------------------------------//
+//                                 basic_ofstream                                       //
+//--------------------------------------------------------------------------------------//
+
+  template < class charT, class traits = std::char_traits<charT> >
+  class basic_ofstream : public std::basic_ofstream<charT,traits>
+  {
+  private: // disallow copying
+    basic_ofstream(const basic_ofstream&);
+    const basic_ofstream& operator=(const basic_ofstream&);
+
+  public:
+    basic_ofstream() {}
+
+    // use two signatures, rather than one signature with default second
+    // argument, to workaround VC++ 7.1 bug (ID VSWhidbey 38416)
+
+    explicit basic_ofstream(const path& p)
+      : std::basic_ofstream<charT,traits>(p.AUTOBOOST_FILESYSTEM_C_STR, std::ios_base::out) {}
+
+    basic_ofstream(const path& p, std::ios_base::openmode mode)
+      : std::basic_ofstream<charT,traits>(p.AUTOBOOST_FILESYSTEM_C_STR, mode) {}
+
+    void open(const path& p)
+      { std::basic_ofstream<charT,traits>::open(p.AUTOBOOST_FILESYSTEM_C_STR, std::ios_base::out); }
+
+    void open(const path& p, std::ios_base::openmode mode)
+      { std::basic_ofstream<charT,traits>::open(p.AUTOBOOST_FILESYSTEM_C_STR, mode); }
+
+    virtual ~basic_ofstream() {}
+  };
+
+//--------------------------------------------------------------------------------------//
+//                                  basic_fstream                                       //
+//--------------------------------------------------------------------------------------//
+
+  template < class charT, class traits = std::char_traits<charT> >
+  class basic_fstream : public std::basic_fstream<charT,traits>
+  {
+  private: // disallow copying
+    basic_fstream(const basic_fstream&);
+    const basic_fstream & operator=(const basic_fstream&);
+
+  public:
+    basic_fstream() {}
+
+    // use two signatures, rather than one signature with default second
+    // argument, to workaround VC++ 7.1 bug (ID VSWhidbey 38416)
+
+    explicit basic_fstream(const path& p)
+      : std::basic_fstream<charT,traits>(p.AUTOBOOST_FILESYSTEM_C_STR,
+          std::ios_base::in | std::ios_base::out) {}
+
+    basic_fstream(const path& p, std::ios_base::openmode mode)
+      : std::basic_fstream<charT,traits>(p.AUTOBOOST_FILESYSTEM_C_STR, mode) {}
+
+    void open(const path& p)
+      { std::basic_fstream<charT,traits>::open(p.AUTOBOOST_FILESYSTEM_C_STR,
+          std::ios_base::in | std::ios_base::out); }
+
+    void open(const path& p, std::ios_base::openmode mode)
+      { std::basic_fstream<charT,traits>::open(p.AUTOBOOST_FILESYSTEM_C_STR, mode); }
+
+    virtual ~basic_fstream() {}
+
+  };
+
+//--------------------------------------------------------------------------------------//
+//                                    typedefs                                          //
+//--------------------------------------------------------------------------------------//
+
+  typedef basic_filebuf<char> filebuf;
+  typedef basic_ifstream<char> ifstream;
+  typedef basic_ofstream<char> ofstream;
+  typedef basic_fstream<char> fstream;
+
+  typedef basic_filebuf<wchar_t> wfilebuf;
+  typedef basic_ifstream<wchar_t> wifstream;
+  typedef basic_ofstream<wchar_t> wofstream;
+  typedef basic_fstream<wchar_t> wfstream;
+  
+} // namespace filesystem
+} // namespace autoboost
+
+#include <autoboost/config/abi_suffix.hpp> // pops abi_prefix.hpp pragmas
+#endif  // AUTOBOOST_FILESYSTEM3_FSTREAM_HPP

--- a/contrib/autoboost/autoboost/filesystem/operations.hpp
+++ b/contrib/autoboost/autoboost/filesystem/operations.hpp
@@ -1,0 +1,1346 @@
+//  autoboost/filesystem/operations.hpp  ---------------------------------------------------//
+
+//  Copyright Beman Dawes 2002-2009
+//  Copyright Jan Langer 2002
+//  Copyright Dietmar Kuehl 2001
+//  Copyright Vladimir Prus 2002
+
+//  Distributed under the Boost Software License, Version 1.0.
+//  See http://www.boost.org/LICENSE_1_0.txt
+
+//  Library home page: http://www.boost.org/libs/filesystem
+
+//--------------------------------------------------------------------------------------//
+
+#ifndef AUTOBOOST_FILESYSTEM3_OPERATIONS_HPP
+#define AUTOBOOST_FILESYSTEM3_OPERATIONS_HPP
+
+#include <autoboost/config.hpp>
+
+# if defined( AUTOBOOST_NO_STD_WSTRING )
+#   error Configuration not supported: Boost.Filesystem V3 and later requires std::wstring support
+# endif
+
+#include <autoboost/filesystem/config.hpp>
+#include <autoboost/filesystem/path.hpp>
+
+#include <autoboost/detail/scoped_enum_emulation.hpp>
+#include <autoboost/detail/bitmask.hpp>
+#include <autoboost/system/error_code.hpp>
+#include <autoboost/system/system_error.hpp>
+#include <autoboost/shared_ptr.hpp>
+#include <autoboost/utility/enable_if.hpp>
+#include <autoboost/type_traits/is_same.hpp>
+#include <autoboost/cstdint.hpp>
+#include <autoboost/range/mutable_iterator.hpp>
+#include <autoboost/range/const_iterator.hpp>
+#include <autoboost/assert.hpp>
+#include <string>
+#include <utility> // for pair
+#include <ctime>
+#include <vector>
+#include <stack>
+
+#ifdef AUTOBOOST_WINDOWS_API
+#  include <fstream>
+#endif
+
+#include <autoboost/config/abi_prefix.hpp> // must be the last #include
+
+//--------------------------------------------------------------------------------------//
+
+namespace autoboost
+{
+  namespace filesystem
+  {
+
+    //--------------------------------------------------------------------------------------//
+    //                                                                                      //
+    //                            class filesystem_error                                    //
+    //                                                                                      //
+    //--------------------------------------------------------------------------------------//
+
+    class AUTOBOOST_SYMBOL_VISIBLE filesystem_error : public system::system_error
+    {
+      // see http://www.boost.org/more/error_handling.html for design rationale
+
+      // all functions are inline to avoid issues with crossing dll boundaries
+
+      // functions previously throw() are now AUTOBOOST_NOEXCEPT_OR_NOTHROW
+      // functions previously without throw() are now AUTOBOOST_NOEXCEPT
+
+    public:
+      // compiler generates copy constructor and copy assignment
+
+      filesystem_error(
+        const std::string & what_arg, system::error_code ec) AUTOBOOST_NOEXCEPT
+        : system::system_error(ec, what_arg)
+      {
+        try
+        {
+          m_imp_ptr.reset(new m_imp);
+        }
+        catch (...) { m_imp_ptr.reset(); }
+      }
+
+      filesystem_error(
+        const std::string & what_arg, const path& path1_arg,
+        system::error_code ec) AUTOBOOST_NOEXCEPT
+        : system::system_error(ec, what_arg)
+      {
+        try
+        {
+          m_imp_ptr.reset(new m_imp);
+          m_imp_ptr->m_path1 = path1_arg;
+        }
+        catch (...) { m_imp_ptr.reset(); }
+      }
+
+      filesystem_error(
+        const std::string & what_arg, const path& path1_arg,
+        const path& path2_arg, system::error_code ec) AUTOBOOST_NOEXCEPT
+        : system::system_error(ec, what_arg)
+      {
+        try
+        {
+          m_imp_ptr.reset(new m_imp);
+          m_imp_ptr->m_path1 = path1_arg;
+          m_imp_ptr->m_path2 = path2_arg;
+        }
+        catch (...) { m_imp_ptr.reset(); }
+      }
+
+      ~filesystem_error() AUTOBOOST_NOEXCEPT_OR_NOTHROW{}
+
+        const path& path1() const AUTOBOOST_NOEXCEPT
+      {
+        static const path empty_path;
+        return m_imp_ptr.get() ? m_imp_ptr->m_path1 : empty_path;
+      }
+        const path& path2() const  AUTOBOOST_NOEXCEPT
+      {
+        static const path empty_path;
+        return m_imp_ptr.get() ? m_imp_ptr->m_path2 : empty_path;
+      }
+
+        const char* what() const AUTOBOOST_NOEXCEPT_OR_NOTHROW
+      {
+        if (!m_imp_ptr.get())
+        return system::system_error::what();
+
+        try
+        {
+          if (m_imp_ptr->m_what.empty())
+          {
+            m_imp_ptr->m_what = system::system_error::what();
+            if (!m_imp_ptr->m_path1.empty())
+            {
+              m_imp_ptr->m_what += ": \"";
+              m_imp_ptr->m_what += m_imp_ptr->m_path1.string();
+              m_imp_ptr->m_what += "\"";
+            }
+            if (!m_imp_ptr->m_path2.empty())
+            {
+              m_imp_ptr->m_what += ", \"";
+              m_imp_ptr->m_what += m_imp_ptr->m_path2.string();
+              m_imp_ptr->m_what += "\"";
+            }
+          }
+          return m_imp_ptr->m_what.c_str();
+        }
+        catch (...)
+        {
+          return system::system_error::what();
+        }
+      }
+
+    private:
+      struct m_imp
+      {
+        path         m_path1; // may be empty()
+        path         m_path2; // may be empty()
+        std::string  m_what;  // not built until needed
+      };
+      autoboost::shared_ptr<m_imp> m_imp_ptr;
+    };
+
+//--------------------------------------------------------------------------------------//
+//                                     file_type                                        //
+//--------------------------------------------------------------------------------------//
+
+  enum file_type
+  {
+    status_error,
+#   ifndef AUTOBOOST_FILESYSTEM_NO_DEPRECATED
+    status_unknown = status_error,
+#   endif
+    file_not_found,
+    regular_file,
+    directory_file,
+    // the following may not apply to some operating systems or file systems
+    symlink_file,
+    block_file,
+    character_file,
+    fifo_file,
+    socket_file,
+    reparse_file,  // Windows: FILE_ATTRIBUTE_REPARSE_POINT that is not a symlink
+    type_unknown,  // file does exist, but isn't one of the above types or
+                   // we don't have strong enough permission to find its type
+
+    _detail_directory_symlink  // internal use only; never exposed to users
+  };
+
+//--------------------------------------------------------------------------------------//
+//                                       perms                                          //
+//--------------------------------------------------------------------------------------//
+
+  enum perms
+  {
+    no_perms = 0,       // file_not_found is no_perms rather than perms_not_known
+
+    // POSIX equivalent macros given in comments.
+    // Values are from POSIX and are given in octal per the POSIX standard.
+
+    // permission bits
+
+    owner_read = 0400,  // S_IRUSR, Read permission, owner
+    owner_write = 0200, // S_IWUSR, Write permission, owner
+    owner_exe = 0100,   // S_IXUSR, Execute/search permission, owner
+    owner_all = 0700,   // S_IRWXU, Read, write, execute/search by owner
+
+    group_read = 040,   // S_IRGRP, Read permission, group
+    group_write = 020,  // S_IWGRP, Write permission, group
+    group_exe = 010,    // S_IXGRP, Execute/search permission, group
+    group_all = 070,    // S_IRWXG, Read, write, execute/search by group
+
+    others_read = 04,   // S_IROTH, Read permission, others
+    others_write = 02,  // S_IWOTH, Write permission, others
+    others_exe = 01,    // S_IXOTH, Execute/search permission, others
+    others_all = 07,    // S_IRWXO, Read, write, execute/search by others
+
+    all_all = 0777,     // owner_all|group_all|others_all
+
+    // other POSIX bits
+
+    set_uid_on_exe = 04000, // S_ISUID, Set-user-ID on execution
+    set_gid_on_exe = 02000, // S_ISGID, Set-group-ID on execution
+    sticky_bit     = 01000, // S_ISVTX,
+                            // (POSIX XSI) On directories, restricted deletion flag
+                            // (V7) 'sticky bit': save swapped text even after use
+                            // (SunOS) On non-directories: don't cache this file
+                            // (SVID-v4.2) On directories: restricted deletion flag
+                            // Also see http://en.wikipedia.org/wiki/Sticky_bit
+
+    perms_mask = 07777,     // all_all|set_uid_on_exe|set_gid_on_exe|sticky_bit
+
+    perms_not_known = 0xFFFF, // present when directory_entry cache not loaded
+
+    // options for permissions() function
+
+    add_perms = 0x1000,     // adds the given permission bits to the current bits
+    remove_perms = 0x2000,  // removes the given permission bits from the current bits;
+                            // choose add_perms or remove_perms, not both; if neither add_perms
+                            // nor remove_perms is given, replace the current bits with
+                            // the given bits.
+
+    symlink_perms = 0x4000  // on POSIX, don't resolve symlinks; implied on Windows
+  };
+
+  AUTOBOOST_BITMASK(perms)
+
+//--------------------------------------------------------------------------------------//
+//                                    file_status                                       //
+//--------------------------------------------------------------------------------------//
+
+  class AUTOBOOST_FILESYSTEM_DECL file_status
+  {
+  public:
+             file_status() AUTOBOOST_NOEXCEPT
+               : m_value(status_error), m_perms(perms_not_known) {}
+    explicit file_status(file_type v) AUTOBOOST_NOEXCEPT
+               : m_value(v), m_perms(perms_not_known)  {}
+             file_status(file_type v, perms prms) AUTOBOOST_NOEXCEPT
+               : m_value(v), m_perms(prms) {}
+
+  //  As of October 2015 the interaction between noexcept and =default is so troublesome
+  //  for VC++, GCC, and probably other compilers, that =default is not used with noexcept
+  //  functions. GCC is not even consistent for the same release on different platforms.
+
+    file_status(const file_status& rhs) AUTOBOOST_NOEXCEPT
+      : m_value(rhs.m_value), m_perms(rhs.m_perms) {}
+    file_status& operator=(const file_status& rhs) AUTOBOOST_NOEXCEPT
+    {
+      m_value = rhs.m_value;
+      m_perms = rhs.m_perms;
+      return *this;
+    }
+
+# if !defined(AUTOBOOST_NO_CXX11_RVALUE_REFERENCES)
+    file_status(file_status&& rhs) AUTOBOOST_NOEXCEPT
+    {
+      m_value = std::move(rhs.m_value);
+      m_perms = std::move(rhs.m_perms);
+    }
+    file_status& operator=(file_status&& rhs) AUTOBOOST_NOEXCEPT
+    {
+      m_value = std::move(rhs.m_value);
+      m_perms = std::move(rhs.m_perms);
+      return *this;
+    }
+# endif
+
+
+    // observers
+    file_type  type() const AUTOBOOST_NOEXCEPT            { return m_value; }
+    perms      permissions() const AUTOBOOST_NOEXCEPT     { return m_perms; }
+
+    // modifiers
+    void       type(file_type v) AUTOBOOST_NOEXCEPT       { m_value = v; }
+    void       permissions(perms prms) AUTOBOOST_NOEXCEPT { m_perms = prms; }
+
+    bool operator==(const file_status& rhs) const AUTOBOOST_NOEXCEPT
+      { return type() == rhs.type() &&
+        permissions() == rhs.permissions(); }
+    bool operator!=(const file_status& rhs) const AUTOBOOST_NOEXCEPT
+      { return !(*this == rhs); }
+
+  private:
+    file_type   m_value;
+    enum perms  m_perms;
+  };
+
+  inline bool type_present(file_status f) AUTOBOOST_NOEXCEPT
+                                          { return f.type() != status_error; }
+  inline bool permissions_present(file_status f) AUTOBOOST_NOEXCEPT
+                                          {return f.permissions() != perms_not_known;}
+  inline bool status_known(file_status f) AUTOBOOST_NOEXCEPT
+                                          { return type_present(f) && permissions_present(f); }
+  inline bool exists(file_status f) AUTOBOOST_NOEXCEPT
+                                          { return f.type() != status_error
+                                                && f.type() != file_not_found; }
+  inline bool is_regular_file(file_status f) AUTOBOOST_NOEXCEPT
+                                          { return f.type() == regular_file; }
+  inline bool is_directory(file_status f) AUTOBOOST_NOEXCEPT
+                                          { return f.type() == directory_file; }
+  inline bool is_symlink(file_status f) AUTOBOOST_NOEXCEPT
+                                          { return f.type() == symlink_file; }
+  inline bool is_other(file_status f) AUTOBOOST_NOEXCEPT
+                                          { return exists(f) && !is_regular_file(f)
+                                                && !is_directory(f) && !is_symlink(f); }
+
+# ifndef AUTOBOOST_FILESYSTEM_NO_DEPRECATED
+  inline bool is_regular(file_status f) AUTOBOOST_NOEXCEPT { return f.type() == regular_file; }
+# endif
+
+  struct space_info
+  {
+    // all values are byte counts
+    autoboost::uintmax_t capacity;
+    autoboost::uintmax_t free;      // <= capacity
+    autoboost::uintmax_t available; // <= free
+  };
+
+  AUTOBOOST_SCOPED_ENUM_START(copy_option)
+    {none=0, fail_if_exists = none, overwrite_if_exists};
+  AUTOBOOST_SCOPED_ENUM_END
+
+//--------------------------------------------------------------------------------------//
+//                             implementation details                                   //
+//--------------------------------------------------------------------------------------//
+
+  namespace detail
+  {
+    //  We cannot pass a AUTOBOOST_SCOPED_ENUM to a compled function because it will result
+    //  in an undefined reference if the library is compled with -std=c++0x but the use
+    //  is compiled in C++03 mode, or visa versa. See tickets 6124, 6779, 10038.
+    enum copy_option {none=0, fail_if_exists = none, overwrite_if_exists};
+
+    AUTOBOOST_FILESYSTEM_DECL
+    file_status status(const path&p, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    file_status symlink_status(const path& p, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    bool is_empty(const path& p, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    path initial_path(system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    path canonical(const path& p, const path& base, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    void copy(const path& from, const path& to, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    void copy_directory(const path& from, const path& to, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    void copy_file(const path& from, const path& to,  // See ticket #2925
+                    detail::copy_option option, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    void copy_symlink(const path& existing_symlink, const path& new_symlink, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    bool create_directories(const path& p, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    bool create_directory(const path& p, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    void create_directory_symlink(const path& to, const path& from,
+                                  system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    void create_hard_link(const path& to, const path& from, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    void create_symlink(const path& to, const path& from, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    path current_path(system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    void current_path(const path& p, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    bool equivalent(const path& p1, const path& p2, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    autoboost::uintmax_t file_size(const path& p, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    autoboost::uintmax_t hard_link_count(const path& p, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    std::time_t last_write_time(const path& p, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    void last_write_time(const path& p, const std::time_t new_time,
+                         system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    void permissions(const path& p, perms prms, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    path read_symlink(const path& p, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    path relative(const path& p, const path& base, system::error_code* ec = 0);
+    AUTOBOOST_FILESYSTEM_DECL
+    bool remove(const path& p, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    autoboost::uintmax_t remove_all(const path& p, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    void rename(const path& old_p, const path& new_p, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    void resize_file(const path& p, uintmax_t size, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    space_info space(const path& p, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    path system_complete(const path& p, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    path temp_directory_path(system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    path unique_path(const path& p, system::error_code* ec=0);
+    AUTOBOOST_FILESYSTEM_DECL
+    path weakly_canonical(const path& p, system::error_code* ec = 0);
+  }  // namespace detail
+
+//--------------------------------------------------------------------------------------//
+//                                                                                      //
+//                             status query functions                                   //
+//                                                                                      //
+//--------------------------------------------------------------------------------------//
+
+  inline
+  file_status status(const path& p)    {return detail::status(p);}
+  inline
+  file_status status(const path& p, system::error_code& ec)
+                                       {return detail::status(p, &ec);}
+  inline
+  file_status symlink_status(const path& p) {return detail::symlink_status(p);}
+  inline
+  file_status symlink_status(const path& p, system::error_code& ec)
+                                       {return detail::symlink_status(p, &ec);}
+  inline
+  bool exists(const path& p)           {return exists(detail::status(p));}
+  inline
+  bool exists(const path& p, system::error_code& ec)
+                                       {return exists(detail::status(p, &ec));}
+  inline
+  bool is_directory(const path& p)     {return is_directory(detail::status(p));}
+  inline
+  bool is_directory(const path& p, system::error_code& ec)
+                                       {return is_directory(detail::status(p, &ec));}
+  inline
+  bool is_regular_file(const path& p)  {return is_regular_file(detail::status(p));}
+  inline
+  bool is_regular_file(const path& p, system::error_code& ec)
+                                       {return is_regular_file(detail::status(p, &ec));}
+  inline
+  bool is_other(const path& p)         {return is_other(detail::status(p));}
+  inline
+  bool is_other(const path& p, system::error_code& ec)
+                                       {return is_other(detail::status(p, &ec));}
+  inline
+  bool is_symlink(const path& p)       {return is_symlink(detail::symlink_status(p));}
+  inline
+  bool is_symlink(const path& p, system::error_code& ec)
+                                       {return is_symlink(detail::symlink_status(p, &ec));}
+# ifndef AUTOBOOST_FILESYSTEM_NO_DEPRECATED
+  inline
+  bool is_regular(const path& p)       {return is_regular(detail::status(p));}
+  inline
+  bool is_regular(const path& p, system::error_code& ec)
+                                       {return is_regular(detail::status(p, &ec));}
+# endif
+
+  inline
+  bool is_empty(const path& p)         {return detail::is_empty(p);}
+  inline
+  bool is_empty(const path& p, system::error_code& ec)
+                                       {return detail::is_empty(p, &ec);}
+
+//--------------------------------------------------------------------------------------//
+//                                                                                      //
+//                             operational functions                                    //
+//                  in alphabetical order, unless otherwise noted                       //
+//                                                                                      //
+//--------------------------------------------------------------------------------------//
+
+  //  forward declarations
+  path current_path();  // fwd declaration
+  path initial_path();
+
+  AUTOBOOST_FILESYSTEM_DECL
+  path absolute(const path& p, const path& base=current_path());
+  //  If base.is_absolute(), throws nothing. Thus no need for ec argument
+
+  inline
+  path canonical(const path& p, const path& base=current_path())
+                                       {return detail::canonical(p, base);}
+  inline
+  path canonical(const path& p, system::error_code& ec)
+                                       {return detail::canonical(p, current_path(), &ec);}
+  inline
+  path canonical(const path& p, const path& base, system::error_code& ec)
+                                       {return detail::canonical(p, base, &ec);}
+
+# ifndef AUTOBOOST_FILESYSTEM_NO_DEPRECATED
+  inline
+  path complete(const path& p)
+  {
+    return absolute(p, initial_path());
+  }
+
+  inline
+  path complete(const path& p, const path& base)
+  {
+    return absolute(p, base);
+  }
+# endif
+
+  inline
+  void copy(const path& from, const path& to) {detail::copy(from, to);}
+
+  inline
+  void copy(const path& from, const path& to, system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {detail::copy(from, to, &ec);}
+  inline
+  void copy_directory(const path& from, const path& to)
+                                       {detail::copy_directory(from, to);}
+  inline
+  void copy_directory(const path& from, const path& to, system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {detail::copy_directory(from, to, &ec);}
+  inline
+  void copy_file(const path& from, const path& to,   // See ticket #2925
+                 AUTOBOOST_SCOPED_ENUM(copy_option) option)
+  {
+    detail::copy_file(from, to, static_cast<detail::copy_option>(option));
+  }
+  inline
+  void copy_file(const path& from, const path& to)
+  {
+    detail::copy_file(from, to, detail::fail_if_exists);
+  }
+  inline
+  void copy_file(const path& from, const path& to,   // See ticket #2925
+                 AUTOBOOST_SCOPED_ENUM(copy_option) option, system::error_code& ec) AUTOBOOST_NOEXCEPT
+  {
+    detail::copy_file(from, to, static_cast<detail::copy_option>(option), &ec);
+  }
+  inline
+  void copy_file(const path& from, const path& to, system::error_code& ec) AUTOBOOST_NOEXCEPT
+  {
+    detail::copy_file(from, to, detail::fail_if_exists, &ec);
+  }
+  inline
+  void copy_symlink(const path& existing_symlink,
+                    const path& new_symlink) {detail::copy_symlink(existing_symlink, new_symlink);}
+
+  inline
+  void copy_symlink(const path& existing_symlink, const path& new_symlink,
+                    system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {detail::copy_symlink(existing_symlink, new_symlink, &ec);}
+  inline
+  bool create_directories(const path& p) {return detail::create_directories(p);}
+
+  inline
+  bool create_directories(const path& p, system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {return detail::create_directories(p, &ec);}
+  inline
+  bool create_directory(const path& p) {return detail::create_directory(p);}
+
+  inline
+  bool create_directory(const path& p, system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {return detail::create_directory(p, &ec);}
+  inline
+  void create_directory_symlink(const path& to, const path& from)
+                                       {detail::create_directory_symlink(to, from);}
+  inline
+  void create_directory_symlink(const path& to, const path& from, system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {detail::create_directory_symlink(to, from, &ec);}
+  inline
+  void create_hard_link(const path& to, const path& new_hard_link) {detail::create_hard_link(to, new_hard_link);}
+
+  inline
+  void create_hard_link(const path& to, const path& new_hard_link, system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {detail::create_hard_link(to, new_hard_link, &ec);}
+  inline
+  void create_symlink(const path& to, const path& new_symlink) {detail::create_symlink(to, new_symlink);}
+
+  inline
+  void create_symlink(const path& to, const path& new_symlink, system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {detail::create_symlink(to, new_symlink, &ec);}
+  inline
+  path current_path()                  {return detail::current_path();}
+
+  inline
+  path current_path(system::error_code& ec) AUTOBOOST_NOEXCEPT {return detail::current_path(&ec);}
+
+  inline
+  void current_path(const path& p)     {detail::current_path(p);}
+
+  inline
+  void current_path(const path& p, system::error_code& ec) AUTOBOOST_NOEXCEPT {detail::current_path(p, &ec);}
+
+  inline
+  bool equivalent(const path& p1, const path& p2) {return detail::equivalent(p1, p2);}
+
+  inline
+  bool equivalent(const path& p1, const path& p2, system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {return detail::equivalent(p1, p2, &ec);}
+  inline
+  autoboost::uintmax_t file_size(const path& p) {return detail::file_size(p);}
+
+  inline
+  autoboost::uintmax_t file_size(const path& p, system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {return detail::file_size(p, &ec);}
+  inline
+  autoboost::uintmax_t hard_link_count(const path& p) {return detail::hard_link_count(p);}
+
+  inline
+  autoboost::uintmax_t hard_link_count(const path& p, system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {return detail::hard_link_count(p, &ec);}
+  inline
+  path initial_path()                  {return detail::initial_path();}
+
+  inline
+  path initial_path(system::error_code& ec) {return detail::initial_path(&ec);}
+
+  template <class Path>
+  path initial_path() {return initial_path();}
+  template <class Path>
+  path initial_path(system::error_code& ec) {return detail::initial_path(&ec);}
+
+  inline
+  std::time_t last_write_time(const path& p) {return detail::last_write_time(p);}
+
+  inline
+  std::time_t last_write_time(const path& p, system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {return detail::last_write_time(p, &ec);}
+  inline
+  void last_write_time(const path& p, const std::time_t new_time)
+                                       {detail::last_write_time(p, new_time);}
+  inline
+  void last_write_time(const path& p, const std::time_t new_time,
+                       system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {detail::last_write_time(p, new_time, &ec);}
+  inline
+  void permissions(const path& p, perms prms)
+                                       {detail::permissions(p, prms);}
+  inline
+  void permissions(const path& p, perms prms, system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {detail::permissions(p, prms, &ec);}
+
+  inline
+  path read_symlink(const path& p)     {return detail::read_symlink(p);}
+
+  inline
+  path read_symlink(const path& p, system::error_code& ec)
+                                       {return detail::read_symlink(p, &ec);}
+  inline
+    // For standardization, if the committee doesn't like "remove", consider "eliminate"
+  bool remove(const path& p)           {return detail::remove(p);}
+
+  inline
+  bool remove(const path& p, system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {return detail::remove(p, &ec);}
+
+  inline
+  autoboost::uintmax_t remove_all(const path& p) {return detail::remove_all(p);}
+
+  inline
+  autoboost::uintmax_t remove_all(const path& p, system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {return detail::remove_all(p, &ec);}
+  inline
+  void rename(const path& old_p, const path& new_p) {detail::rename(old_p, new_p);}
+
+  inline
+  void rename(const path& old_p, const path& new_p, system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {detail::rename(old_p, new_p, &ec);}
+  inline  // name suggested by Scott McMurray
+  void resize_file(const path& p, uintmax_t size) {detail::resize_file(p, size);}
+
+  inline
+  void resize_file(const path& p, uintmax_t size, system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {detail::resize_file(p, size, &ec);}
+  inline
+  path relative(const path& p, const path& base=current_path())
+                                       {return detail::relative(p, base);}
+  inline
+  path relative(const path& p, system::error_code& ec)
+                                       {return detail::relative(p, current_path(), &ec);}
+  inline
+  path relative(const path& p, const path& base, system::error_code& ec)
+                                       {return detail::relative(p, base, &ec);}
+  inline
+  space_info space(const path& p)      {return detail::space(p);}
+
+  inline
+  space_info space(const path& p, system::error_code& ec) AUTOBOOST_NOEXCEPT
+                                       {return detail::space(p, &ec);}
+
+# ifndef AUTOBOOST_FILESYSTEM_NO_DEPRECATED
+  inline bool symbolic_link_exists(const path& p)
+                                       { return is_symlink(symlink_status(p)); }
+# endif
+
+  inline
+  path system_complete(const path& p)  {return detail::system_complete(p);}
+
+  inline
+  path system_complete(const path& p, system::error_code& ec)
+                                       {return detail::system_complete(p, &ec);}
+  inline
+  path temp_directory_path()           {return detail::temp_directory_path();}
+
+  inline
+  path temp_directory_path(system::error_code& ec)
+                                       {return detail::temp_directory_path(&ec);}
+  inline
+  path unique_path(const path& p="%%%%-%%%%-%%%%-%%%%")
+                                       {return detail::unique_path(p);}
+  inline
+  path unique_path(const path& p, system::error_code& ec)
+                                       {return detail::unique_path(p, &ec);}
+  inline
+  path weakly_canonical(const path& p)   {return detail::weakly_canonical(p);}
+
+  inline
+  path weakly_canonical(const path& p, system::error_code& ec)
+                                       {return detail::weakly_canonical(p, &ec);}
+
+//--------------------------------------------------------------------------------------//
+//                                                                                      //
+//                                 directory_entry                                      //
+//                                                                                      //
+//--------------------------------------------------------------------------------------//
+
+//  GCC has a problem with a member function named path within a namespace or
+//  sub-namespace that also has a class named path. The workaround is to always
+//  fully qualify the name path when it refers to the class name.
+
+class AUTOBOOST_FILESYSTEM_DECL directory_entry
+{
+public:
+  typedef autoboost::filesystem::path::value_type value_type;   // enables class path ctor taking directory_entry
+
+  directory_entry() AUTOBOOST_NOEXCEPT {}
+  explicit directory_entry(const autoboost::filesystem::path& p)
+    : m_path(p), m_status(file_status()), m_symlink_status(file_status())
+    {}
+  directory_entry(const autoboost::filesystem::path& p,
+    file_status st, file_status symlink_st = file_status())
+    : m_path(p), m_status(st), m_symlink_status(symlink_st) {}
+
+  directory_entry(const directory_entry& rhs)
+    : m_path(rhs.m_path), m_status(rhs.m_status), m_symlink_status(rhs.m_symlink_status){}
+
+  directory_entry& operator=(const directory_entry& rhs)
+  {
+    m_path = rhs.m_path;
+    m_status = rhs.m_status;
+    m_symlink_status = rhs.m_symlink_status;
+    return *this;
+  }
+
+  //  As of October 2015 the interaction between noexcept and =default is so troublesome
+  //  for VC++, GCC, and probably other compilers, that =default is not used with noexcept
+  //  functions. GCC is not even consistent for the same release on different platforms.
+
+#if !defined(AUTOBOOST_NO_CXX11_RVALUE_REFERENCES)
+  directory_entry(directory_entry&& rhs) AUTOBOOST_NOEXCEPT
+  {
+    m_path = std::move(rhs.m_path);
+    m_status = std::move(rhs.m_status);
+    m_symlink_status = std::move(rhs.m_symlink_status);
+  }
+  directory_entry& operator=(directory_entry&& rhs) AUTOBOOST_NOEXCEPT
+  {
+    m_path = std::move(rhs.m_path);
+    m_status = std::move(rhs.m_status);
+    m_symlink_status = std::move(rhs.m_symlink_status);
+    return *this;
+  }
+#endif
+
+  void assign(const autoboost::filesystem::path& p,
+    file_status st = file_status(), file_status symlink_st = file_status())
+    { m_path = p; m_status = st; m_symlink_status = symlink_st; }
+
+  void replace_filename(const autoboost::filesystem::path& p,
+    file_status st = file_status(), file_status symlink_st = file_status())
+  {
+    m_path.remove_filename();
+    m_path /= p;
+    m_status = st;
+    m_symlink_status = symlink_st;
+  }
+
+# ifndef AUTOBOOST_FILESYSTEM_NO_DEPRECATED
+  void replace_leaf(const autoboost::filesystem::path& p,
+    file_status st, file_status symlink_st)
+      { replace_filename(p, st, symlink_st); }
+# endif
+
+  const autoboost::filesystem::path&  path() const AUTOBOOST_NOEXCEPT {return m_path;}
+  operator const autoboost::filesystem::path&() const AUTOBOOST_NOEXCEPT
+                                                              {return m_path;}
+  file_status   status() const                                {return m_get_status();}
+  file_status   status(system::error_code& ec) const AUTOBOOST_NOEXCEPT
+                                                              {return m_get_status(&ec); }
+  file_status   symlink_status() const                        {return m_get_symlink_status();}
+  file_status   symlink_status(system::error_code& ec) const AUTOBOOST_NOEXCEPT
+                                                              {return m_get_symlink_status(&ec); }
+
+  bool operator==(const directory_entry& rhs) const AUTOBOOST_NOEXCEPT {return m_path == rhs.m_path; }
+  bool operator!=(const directory_entry& rhs) const AUTOBOOST_NOEXCEPT {return m_path != rhs.m_path;}
+  bool operator< (const directory_entry& rhs) const AUTOBOOST_NOEXCEPT {return m_path < rhs.m_path;}
+  bool operator<=(const directory_entry& rhs) const AUTOBOOST_NOEXCEPT {return m_path <= rhs.m_path;}
+  bool operator> (const directory_entry& rhs) const AUTOBOOST_NOEXCEPT {return m_path > rhs.m_path;}
+  bool operator>=(const directory_entry& rhs) const AUTOBOOST_NOEXCEPT {return m_path >= rhs.m_path;}
+
+private:
+  autoboost::filesystem::path   m_path;
+  mutable file_status       m_status;           // stat()-like
+  mutable file_status       m_symlink_status;   // lstat()-like
+
+  file_status m_get_status(system::error_code* ec=0) const;
+  file_status m_get_symlink_status(system::error_code* ec=0) const;
+}; // directory_entry
+
+//--------------------------------------------------------------------------------------//
+//                                                                                      //
+//                            directory_iterator helpers                                //
+//                                                                                      //
+//--------------------------------------------------------------------------------------//
+
+class directory_iterator;
+
+namespace detail
+{
+  AUTOBOOST_FILESYSTEM_DECL
+    system::error_code dir_itr_close(// never throws()
+    void *& handle
+#   if     defined(AUTOBOOST_POSIX_API)
+    , void *& buffer
+#   endif
+  );
+
+  struct dir_itr_imp
+  {
+    directory_entry  dir_entry;
+    void*            handle;
+
+#   ifdef AUTOBOOST_POSIX_API
+    void*            buffer;  // see dir_itr_increment implementation
+#   endif
+
+    dir_itr_imp() : handle(0)
+#   ifdef AUTOBOOST_POSIX_API
+      , buffer(0)
+#   endif
+    {}
+
+    ~dir_itr_imp() // never throws
+    {
+      dir_itr_close(handle
+#       if defined(AUTOBOOST_POSIX_API)
+         , buffer
+#       endif
+    );
+    }
+  };
+
+  // see path::iterator: comment below
+  AUTOBOOST_FILESYSTEM_DECL void directory_iterator_construct(directory_iterator& it,
+    const path& p, system::error_code* ec);
+  AUTOBOOST_FILESYSTEM_DECL void directory_iterator_increment(directory_iterator& it,
+    system::error_code* ec);
+
+}  // namespace detail
+
+//--------------------------------------------------------------------------------------//
+//                                                                                      //
+//                                directory_iterator                                    //
+//                                                                                      //
+//--------------------------------------------------------------------------------------//
+
+  class directory_iterator
+    : public autoboost::iterator_facade< directory_iterator,
+                                     directory_entry,
+                                     autoboost::single_pass_traversal_tag >
+  {
+  public:
+
+    directory_iterator() AUTOBOOST_NOEXCEPT {}  // creates the "end" iterator
+
+    // iterator_facade derived classes don't seem to like implementations in
+    // separate translation unit dll's, so forward to detail functions
+    explicit directory_iterator(const path& p)
+        : m_imp(new detail::dir_itr_imp)
+          { detail::directory_iterator_construct(*this, p, 0); }
+
+    directory_iterator(const path& p, system::error_code& ec) AUTOBOOST_NOEXCEPT
+        : m_imp(new detail::dir_itr_imp)
+          { detail::directory_iterator_construct(*this, p, &ec); }
+
+   ~directory_iterator() {}
+
+    directory_iterator& increment(system::error_code& ec) AUTOBOOST_NOEXCEPT
+    {
+      detail::directory_iterator_increment(*this, &ec);
+      return *this;
+    }
+
+  private:
+    friend struct detail::dir_itr_imp;
+    friend AUTOBOOST_FILESYSTEM_DECL void detail::directory_iterator_construct(directory_iterator& it,
+      const path& p, system::error_code* ec);
+    friend AUTOBOOST_FILESYSTEM_DECL void detail::directory_iterator_increment(directory_iterator& it,
+      system::error_code* ec);
+
+    // shared_ptr provides shallow-copy semantics required for InputIterators.
+    // m_imp.get()==0 indicates the end iterator.
+    autoboost::shared_ptr< detail::dir_itr_imp >  m_imp;
+
+    friend class autoboost::iterator_core_access;
+
+    autoboost::iterator_facade<
+      directory_iterator,
+      directory_entry,
+      autoboost::single_pass_traversal_tag >::reference dereference() const
+    {
+      AUTOBOOST_ASSERT_MSG(m_imp.get(), "attempt to dereference end iterator");
+      return m_imp->dir_entry;
+    }
+
+    void increment() { detail::directory_iterator_increment(*this, 0); }
+
+    bool equal(const directory_iterator& rhs) const
+      { return m_imp == rhs.m_imp; }
+
+  };  // directory_iterator
+
+  //  enable directory_iterator C++11 range-base for statement use  --------------------//
+
+  //  begin() and end() are only used by a range-based for statement in the context of
+  //  auto - thus the top-level const is stripped - so returning const is harmless and
+  //  emphasizes begin() is just a pass through.
+  inline
+  const directory_iterator& begin(const directory_iterator& iter) AUTOBOOST_NOEXCEPT
+    {return iter;}
+  inline
+  directory_iterator end(const directory_iterator&) AUTOBOOST_NOEXCEPT
+    {return directory_iterator();}
+
+  //  enable directory_iterator AUTOBOOST_FOREACH  -----------------------------------------//
+
+  inline
+  directory_iterator& range_begin(directory_iterator& iter) AUTOBOOST_NOEXCEPT
+    {return iter;}
+  inline
+  directory_iterator range_begin(const directory_iterator& iter) AUTOBOOST_NOEXCEPT
+    {return iter;}
+  inline
+  directory_iterator range_end(const directory_iterator&) AUTOBOOST_NOEXCEPT
+    {return directory_iterator();}
+  }  // namespace filesystem
+
+  //  namespace autoboost template specializations
+  template<>
+  struct range_mutable_iterator<autoboost::filesystem::directory_iterator>
+    { typedef autoboost::filesystem::directory_iterator type; };
+  template<>
+  struct range_const_iterator <autoboost::filesystem::directory_iterator>
+    { typedef autoboost::filesystem::directory_iterator type; };
+
+namespace filesystem
+{
+
+//--------------------------------------------------------------------------------------//
+//                                                                                      //
+//                      recursive_directory_iterator helpers                            //
+//                                                                                      //
+//--------------------------------------------------------------------------------------//
+
+  AUTOBOOST_SCOPED_ENUM_START(symlink_option)
+  {
+    none,
+    no_recurse = none,         // don't follow directory symlinks (default behavior)
+    recurse,                   // follow directory symlinks
+    _detail_no_push = recurse << 1  // internal use only
+  };
+  AUTOBOOST_SCOPED_ENUM_END
+
+  AUTOBOOST_BITMASK(AUTOBOOST_SCOPED_ENUM(symlink_option))
+
+  namespace detail
+  {
+    struct recur_dir_itr_imp
+    {
+      typedef directory_iterator element_type;
+      std::stack< element_type, std::vector< element_type > > m_stack;
+      int  m_level;
+      AUTOBOOST_SCOPED_ENUM(symlink_option) m_options;
+
+      recur_dir_itr_imp() : m_level(0), m_options(symlink_option::none) {}
+
+      void increment(system::error_code* ec);  // ec == 0 means throw on error
+
+      bool push_directory(system::error_code& ec) AUTOBOOST_NOEXCEPT;
+
+      void pop();
+
+    };
+
+    //  Implementation is inline to avoid dynamic linking difficulties with m_stack:
+    //  Microsoft warning C4251, m_stack needs to have dll-interface to be used by
+    //  clients of struct 'autoboost::filesystem::detail::recur_dir_itr_imp'
+
+    inline
+    bool recur_dir_itr_imp::push_directory(system::error_code& ec) AUTOBOOST_NOEXCEPT
+    // Returns: true if push occurs, otherwise false. Always returns false on error.
+    {
+      ec.clear();
+
+      //  Discover if the iterator is for a directory that needs to be recursed into,
+      //  taking symlinks and options into account.
+
+      if ((m_options & symlink_option::_detail_no_push) == symlink_option::_detail_no_push)
+        m_options &= ~symlink_option::_detail_no_push;
+
+      else
+      {
+        // Logic for following predicate was contributed by Daniel Aarno to handle cyclic
+        // symlinks correctly and efficiently, fixing ticket #5652.
+        //   if (((m_options & symlink_option::recurse) == symlink_option::recurse
+        //         || !is_symlink(m_stack.top()->symlink_status()))
+        //       && is_directory(m_stack.top()->status())) ...
+        // The predicate code has since been rewritten to pass error_code arguments,
+        // per ticket #5653.
+
+        file_status symlink_stat;
+
+        if ((m_options & symlink_option::recurse) != symlink_option::recurse)
+        {
+          symlink_stat = m_stack.top()->symlink_status(ec);
+          if (ec)
+            return false;
+        }
+
+        if ((m_options & symlink_option::recurse) == symlink_option::recurse
+          || !is_symlink(symlink_stat))
+        {
+          file_status stat = m_stack.top()->status(ec);
+          if (ec || !is_directory(stat))
+            return false;
+
+          directory_iterator next(m_stack.top()->path(), ec);
+          if (!ec && next != directory_iterator())
+          {
+            m_stack.push(next);
+            ++m_level;
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+
+    inline
+    void recur_dir_itr_imp::increment(system::error_code* ec)
+    // ec == 0 means throw on error
+    //
+    // Invariant: On return, the top of the iterator stack is the next valid (possibly
+    // end) iterator, regardless of whether or not an error is reported, and regardless of
+    // whether any error is reported by exception or error code. In other words, progress
+    // is always made so a loop on the iterator will always eventually terminate
+    // regardless of errors.
+    {
+      system::error_code ec_push_directory;
+
+      //  if various conditions are met, push a directory_iterator into the iterator stack
+      if (push_directory(ec_push_directory))
+      {
+        if (ec)
+          ec->clear();
+        return;
+      }
+
+      //  Do the actual increment operation on the top iterator in the iterator
+      //  stack, popping the stack if necessary, until either the stack is empty or a
+      //  non-end iterator is reached.
+      while (!m_stack.empty() && ++m_stack.top() == directory_iterator())
+      {
+        m_stack.pop();
+        --m_level;
+      }
+
+      // report errors if any
+      if (ec_push_directory)
+      {
+        if (ec)
+          *ec = ec_push_directory;
+        else
+        {
+          AUTOBOOST_FILESYSTEM_THROW(filesystem_error(
+            "filesystem::recursive_directory_iterator directory error",
+            ec_push_directory));
+        }
+      }
+      else if (ec)
+        ec->clear();
+    }
+
+    inline
+    void recur_dir_itr_imp::pop()
+    {
+      AUTOBOOST_ASSERT_MSG(m_level > 0,
+        "pop() on recursive_directory_iterator with level < 1");
+
+      do
+      {
+        m_stack.pop();
+        --m_level;
+      }
+      while (!m_stack.empty() && ++m_stack.top() == directory_iterator());
+    }
+  } // namespace detail
+
+//--------------------------------------------------------------------------------------//
+//                                                                                      //
+//                           recursive_directory_iterator                               //
+//                                                                                      //
+//--------------------------------------------------------------------------------------//
+
+  class recursive_directory_iterator
+    : public autoboost::iterator_facade<
+        recursive_directory_iterator,
+        directory_entry,
+        autoboost::single_pass_traversal_tag >
+  {
+  public:
+
+    recursive_directory_iterator() AUTOBOOST_NOEXCEPT {}  // creates the "end" iterator
+
+    explicit recursive_directory_iterator(const path& dir_path)  // throws if !exists()
+      : m_imp(new detail::recur_dir_itr_imp)
+    {
+      m_imp->m_options = symlink_option::none;
+      m_imp->m_stack.push(directory_iterator(dir_path));
+      if (m_imp->m_stack.top() == directory_iterator())
+        { m_imp.reset(); }
+    }
+
+    recursive_directory_iterator(const path& dir_path,
+      AUTOBOOST_SCOPED_ENUM(symlink_option) opt)  // throws if !exists()
+      : m_imp(new detail::recur_dir_itr_imp)
+    {
+      m_imp->m_options = opt;
+      m_imp->m_stack.push(directory_iterator(dir_path));
+      if (m_imp->m_stack.top() == directory_iterator())
+        { m_imp.reset (); }
+    }
+
+    recursive_directory_iterator(const path& dir_path,
+      AUTOBOOST_SCOPED_ENUM(symlink_option) opt,
+      system::error_code & ec) AUTOBOOST_NOEXCEPT
+    : m_imp(new detail::recur_dir_itr_imp)
+    {
+      m_imp->m_options = opt;
+      m_imp->m_stack.push(directory_iterator(dir_path, ec));
+      if (m_imp->m_stack.top() == directory_iterator())
+        { m_imp.reset (); }
+    }
+
+    recursive_directory_iterator(const path& dir_path,
+      system::error_code & ec) AUTOBOOST_NOEXCEPT
+    : m_imp(new detail::recur_dir_itr_imp)
+    {
+      m_imp->m_options = symlink_option::none;
+      m_imp->m_stack.push(directory_iterator(dir_path, ec));
+      if (m_imp->m_stack.top() == directory_iterator())
+        { m_imp.reset (); }
+    }
+
+    recursive_directory_iterator& increment(system::error_code& ec) AUTOBOOST_NOEXCEPT
+    {
+      AUTOBOOST_ASSERT_MSG(m_imp.get(),
+        "increment() on end recursive_directory_iterator");
+      m_imp->increment(&ec);
+      if (m_imp->m_stack.empty())
+        m_imp.reset(); // done, so make end iterator
+      return *this;
+    }
+
+    int depth() const AUTOBOOST_NOEXCEPT
+    {
+      AUTOBOOST_ASSERT_MSG(m_imp.get(),
+        "depth() on end recursive_directory_iterator");
+      return m_imp->m_level;
+    }
+
+    int level() const AUTOBOOST_NOEXCEPT { return depth(); }
+
+    bool recursion_pending() const AUTOBOOST_NOEXCEPT
+    {
+      AUTOBOOST_ASSERT_MSG(m_imp.get(),
+        "is_no_push_requested() on end recursive_directory_iterator");
+      return (m_imp->m_options & symlink_option::_detail_no_push)
+        == symlink_option::_detail_no_push;
+    }
+
+    bool no_push_pending() const AUTOBOOST_NOEXCEPT { return recursion_pending(); }
+
+#   ifndef AUTOBOOST_FILESYSTEM_NO_DEPRECATED
+    bool no_push_request() const AUTOBOOST_NOEXCEPT { return no_push_pending(); }
+#   endif
+
+    void pop()
+    {
+      AUTOBOOST_ASSERT_MSG(m_imp.get(),
+        "pop() on end recursive_directory_iterator");
+      m_imp->pop();
+      if (m_imp->m_stack.empty()) m_imp.reset(); // done, so make end iterator
+    }
+
+    void disable_recursion_pending(bool value=true) AUTOBOOST_NOEXCEPT
+    {
+      AUTOBOOST_ASSERT_MSG(m_imp.get(),
+        "no_push() on end recursive_directory_iterator");
+      if (value)
+        m_imp->m_options |= symlink_option::_detail_no_push;
+      else
+        m_imp->m_options &= ~symlink_option::_detail_no_push;
+    }
+
+    void no_push(bool value=true) AUTOBOOST_NOEXCEPT { disable_recursion_pending(value); }
+
+    file_status status() const
+    {
+      AUTOBOOST_ASSERT_MSG(m_imp.get(),
+        "status() on end recursive_directory_iterator");
+      return m_imp->m_stack.top()->status();
+    }
+
+    file_status symlink_status() const
+    {
+      AUTOBOOST_ASSERT_MSG(m_imp.get(),
+        "symlink_status() on end recursive_directory_iterator");
+      return m_imp->m_stack.top()->symlink_status();
+    }
+
+  private:
+
+    // shared_ptr provides shallow-copy semantics required for InputIterators.
+    // m_imp.get()==0 indicates the end iterator.
+    autoboost::shared_ptr< detail::recur_dir_itr_imp >  m_imp;
+
+    friend class autoboost::iterator_core_access;
+
+    autoboost::iterator_facade<
+      recursive_directory_iterator,
+      directory_entry,
+      autoboost::single_pass_traversal_tag >::reference
+    dereference() const
+    {
+      AUTOBOOST_ASSERT_MSG(m_imp.get(),
+        "dereference of end recursive_directory_iterator");
+      return *m_imp->m_stack.top();
+    }
+
+    void increment()
+    {
+      AUTOBOOST_ASSERT_MSG(m_imp.get(),
+        "increment of end recursive_directory_iterator");
+      m_imp->increment(0);
+      if (m_imp->m_stack.empty())
+        m_imp.reset(); // done, so make end iterator
+    }
+
+    bool equal(const recursive_directory_iterator& rhs) const
+      { return m_imp == rhs.m_imp; }
+
+  };  // recursive directory iterator
+
+  //  enable recursive directory iterator C++11 range-base for statement use  ----------//
+
+  //  begin() and end() are only used by a range-based for statement in the context of
+  //  auto - thus the top-level const is stripped - so returning const is harmless and
+  //  emphasizes begin() is just a pass through.
+  inline
+  const recursive_directory_iterator&
+    begin(const recursive_directory_iterator& iter) AUTOBOOST_NOEXCEPT
+                                                  {return iter;}
+  inline
+  recursive_directory_iterator end(const recursive_directory_iterator&) AUTOBOOST_NOEXCEPT
+                                                  {return recursive_directory_iterator();}
+
+  //  enable recursive directory iterator AUTOBOOST_FOREACH  -------------------------------//
+
+  inline
+  recursive_directory_iterator&
+    range_begin(recursive_directory_iterator& iter) AUTOBOOST_NOEXCEPT
+                                                   {return iter;}
+  inline
+  recursive_directory_iterator
+    range_begin(const recursive_directory_iterator& iter) AUTOBOOST_NOEXCEPT
+                                                   {return iter;}
+  inline
+  recursive_directory_iterator range_end(const recursive_directory_iterator&) AUTOBOOST_NOEXCEPT
+                                                  {return recursive_directory_iterator();}
+  }  // namespace filesystem
+
+  //  namespace autoboost template specializations
+  template<>
+  struct range_mutable_iterator<autoboost::filesystem::recursive_directory_iterator>
+                        { typedef autoboost::filesystem::recursive_directory_iterator type; };
+  template<>
+  struct range_const_iterator <autoboost::filesystem::recursive_directory_iterator>
+                        { typedef autoboost::filesystem::recursive_directory_iterator type; };
+
+namespace filesystem
+{
+
+# if !defined(AUTOBOOST_FILESYSTEM_NO_DEPRECATED)
+  typedef recursive_directory_iterator wrecursive_directory_iterator;
+# endif
+
+//  test helper  -----------------------------------------------------------------------//
+
+//  Not part of the documented interface since false positives are possible;
+//  there is no law that says that an OS that has large stat.st_size
+//  actually supports large file sizes.
+
+  namespace detail
+  {
+    AUTOBOOST_FILESYSTEM_DECL bool possible_large_file_size_support();
+  }
+
+  } // namespace filesystem
+} // namespace autoboost
+
+#include <autoboost/config/abi_suffix.hpp> // pops abi_prefix.hpp pragmas
+#endif // AUTOBOOST_FILESYSTEM3_OPERATIONS_HPP

--- a/contrib/autoboost/autoboost/filesystem/path.hpp
+++ b/contrib/autoboost/autoboost/filesystem/path.hpp
@@ -1,0 +1,1014 @@
+//  filesystem path.hpp  ---------------------------------------------------------------//
+
+//  Copyright Beman Dawes 2002-2005, 2009
+//  Copyright Vladimir Prus 2002
+
+//  Distributed under the Boost Software License, Version 1.0.
+//  See http://www.boost.org/LICENSE_1_0.txt
+
+//  Library home page: http://www.boost.org/libs/filesystem
+
+//  path::stem(), extension(), and replace_extension() are based on
+//  basename(), extension(), and change_extension() from the original
+//  filesystem/convenience.hpp header by Vladimir Prus.
+
+#ifndef AUTOBOOST_FILESYSTEM_PATH_HPP
+#define AUTOBOOST_FILESYSTEM_PATH_HPP
+
+#include <autoboost/config.hpp>
+
+# if defined( AUTOBOOST_NO_STD_WSTRING )
+#   error Configuration not supported: Boost.Filesystem V3 and later requires std::wstring support
+# endif
+
+#include <autoboost/filesystem/config.hpp>
+#include <autoboost/filesystem/path_traits.hpp>  // includes <cwchar>
+#include <autoboost/system/error_code.hpp>
+#include <autoboost/system/system_error.hpp>
+#include <autoboost/iterator/iterator_facade.hpp>
+#include <autoboost/shared_ptr.hpp>
+#include <autoboost/io/detail/quoted_manip.hpp>
+#include <autoboost/static_assert.hpp>
+#include <autoboost/functional/hash_fwd.hpp>
+#include <autoboost/type_traits/is_integral.hpp>
+#include <string>
+#include <iterator>
+#include <cstring>
+#include <iosfwd>
+#include <stdexcept>
+#include <cassert>
+#include <locale>
+#include <algorithm>
+
+#include <autoboost/config/abi_prefix.hpp> // must be the last #include
+
+namespace autoboost
+{
+namespace filesystem
+{
+
+  //------------------------------------------------------------------------------------//
+  //                                                                                    //
+  //                                    class path                                      //
+  //                                                                                    //
+  //------------------------------------------------------------------------------------//
+
+  class AUTOBOOST_FILESYSTEM_DECL path
+  {
+  public:
+
+    //  value_type is the character type used by the operating system API to
+    //  represent paths.
+
+# ifdef AUTOBOOST_WINDOWS_API
+    typedef wchar_t                        value_type;
+    AUTOBOOST_STATIC_CONSTEXPR value_type      separator = L'/';
+    AUTOBOOST_STATIC_CONSTEXPR value_type      preferred_separator = L'\\';
+    AUTOBOOST_STATIC_CONSTEXPR value_type      dot = L'.';
+# else 
+    typedef char                           value_type;
+    AUTOBOOST_STATIC_CONSTEXPR value_type      separator = '/';
+    AUTOBOOST_STATIC_CONSTEXPR value_type      preferred_separator = '/';
+    AUTOBOOST_STATIC_CONSTEXPR value_type      dot = '.';
+# endif
+    typedef std::basic_string<value_type>  string_type;  
+    typedef std::codecvt<wchar_t, char,
+                         std::mbstate_t>   codecvt_type;
+
+
+    //  ----- character encoding conversions -----
+
+    //  Following the principle of least astonishment, path input arguments
+    //  passed to or obtained from the operating system via objects of
+    //  class path behave as if they were directly passed to or
+    //  obtained from the O/S API, unless conversion is explicitly requested.
+    //
+    //  POSIX specfies that path strings are passed unchanged to and from the
+    //  API. Note that this is different from the POSIX command line utilities,
+    //  which convert according to a locale.
+    //
+    //  Thus for POSIX, char strings do not undergo conversion.  wchar_t strings
+    //  are converted to/from char using the path locale or, if a conversion
+    //  argument is given, using a conversion object modeled on
+    //  std::wstring_convert.
+    //
+    //  The path locale, which is global to the thread, can be changed by the
+    //  imbue() function. It is initialized to an implementation defined locale.
+    //  
+    //  For Windows, wchar_t strings do not undergo conversion. char strings
+    //  are converted using the "ANSI" or "OEM" code pages, as determined by
+    //  the AreFileApisANSI() function, or, if a conversion argument is given,
+    //  using a conversion object modeled on std::wstring_convert.
+    //
+    //  See m_pathname comments for further important rationale.
+
+    //  TODO: rules needed for operating systems that use / or .
+    //  differently, or format directory paths differently from file paths. 
+    //
+    //  **********************************************************************************
+    //
+    //  More work needed: How to handle an operating system that may have
+    //  slash characters or dot characters in valid filenames, either because
+    //  it doesn't follow the POSIX standard, or because it allows MBCS
+    //  filename encodings that may contain slash or dot characters. For
+    //  example, ISO/IEC 2022 (JIS) encoding which allows switching to
+    //  JIS x0208-1983 encoding. A valid filename in this set of encodings is
+    //  0x1B 0x24 0x42 [switch to X0208-1983] 0x24 0x2F [U+304F Kiragana letter KU]
+    //                                             ^^^^
+    //  Note that 0x2F is the ASCII slash character
+    //
+    //  **********************************************************************************
+
+    //  Supported source arguments: half-open iterator range, container, c-array,
+    //  and single pointer to null terminated string.
+
+    //  All source arguments except pointers to null terminated byte strings support
+    //  multi-byte character strings which may have embedded nulls. Embedded null
+    //  support is required for some Asian languages on Windows.
+
+    //  "const codecvt_type& cvt=codecvt()" default arguments are not used because this
+    //  limits the impact of locale("") initialization failures on POSIX systems to programs
+    //  that actually depend on locale(""). It further ensures that exceptions thrown
+    //  as a result of such failues occur after main() has started, so can be caught. 
+
+    //  -----  constructors  -----
+
+    path() AUTOBOOST_NOEXCEPT {}                                          
+    path(const path& p) : m_pathname(p.m_pathname) {}
+
+    template <class Source>
+    path(Source const& source,
+      typename autoboost::enable_if<path_traits::is_pathable<
+        typename autoboost::decay<Source>::type> >::type* =0)
+    {
+      path_traits::dispatch(source, m_pathname);
+    }
+
+    path(const value_type* s) : m_pathname(s) {}
+    path(value_type* s) : m_pathname(s) {}
+    path(const string_type& s) : m_pathname(s) {}
+    path(string_type& s) : m_pathname(s) {}
+
+  //  As of October 2015 the interaction between noexcept and =default is so troublesome
+  //  for VC++, GCC, and probably other compilers, that =default is not used with noexcept
+  //  functions. GCC is not even consistent for the same release on different platforms.
+
+# if !defined(AUTOBOOST_NO_CXX11_RVALUE_REFERENCES)
+    path(path&& p) AUTOBOOST_NOEXCEPT { m_pathname = std::move(p.m_pathname); }
+    path& operator=(path&& p) AUTOBOOST_NOEXCEPT
+      { m_pathname = std::move(p.m_pathname); return *this; }
+# endif
+
+    template <class Source>
+    path(Source const& source, const codecvt_type& cvt)
+    {
+      path_traits::dispatch(source, m_pathname, cvt);
+    }
+
+    template <class InputIterator>
+    path(InputIterator begin, InputIterator end)
+    { 
+      if (begin != end)
+      {
+        // convert requires contiguous string, so copy
+        std::basic_string<typename std::iterator_traits<InputIterator>::value_type>
+          seq(begin, end);
+        path_traits::convert(seq.c_str(), seq.c_str()+seq.size(), m_pathname);
+      }
+    }
+
+    template <class InputIterator>
+    path(InputIterator begin, InputIterator end, const codecvt_type& cvt)
+    { 
+      if (begin != end)
+      {
+        // convert requires contiguous string, so copy
+        std::basic_string<typename std::iterator_traits<InputIterator>::value_type>
+          seq(begin, end);
+        path_traits::convert(seq.c_str(), seq.c_str()+seq.size(), m_pathname, cvt);
+      }
+    }
+
+    //  -----  assignments  -----
+
+    path& operator=(const path& p)
+    {
+      m_pathname = p.m_pathname;
+      return *this;
+    }
+
+    template <class Source>
+      typename autoboost::enable_if<path_traits::is_pathable<
+        typename autoboost::decay<Source>::type>, path&>::type
+    operator=(Source const& source)
+    {
+      m_pathname.clear();
+      path_traits::dispatch(source, m_pathname);
+      return *this;
+    }
+
+    //  value_type overloads
+
+    path& operator=(const value_type* ptr)  // required in case ptr overlaps *this
+                                          {m_pathname = ptr; return *this;}
+    path& operator=(value_type* ptr)  // required in case ptr overlaps *this
+                                          {m_pathname = ptr; return *this;}
+    path& operator=(const string_type& s) {m_pathname = s; return *this;}
+    path& operator=(string_type& s)       {m_pathname = s; return *this;}
+
+    path& assign(const value_type* ptr, const codecvt_type&)  // required in case ptr overlaps *this
+                                          {m_pathname = ptr; return *this;}
+    template <class Source>
+    path& assign(Source const& source, const codecvt_type& cvt)
+    {
+      m_pathname.clear();
+      path_traits::dispatch(source, m_pathname, cvt);
+      return *this;
+    }
+
+    template <class InputIterator>
+    path& assign(InputIterator begin, InputIterator end)
+    {
+      m_pathname.clear();
+      if (begin != end)
+      {
+        std::basic_string<typename std::iterator_traits<InputIterator>::value_type>
+          seq(begin, end);
+        path_traits::convert(seq.c_str(), seq.c_str()+seq.size(), m_pathname);
+      }
+      return *this;
+    }
+
+    template <class InputIterator>
+    path& assign(InputIterator begin, InputIterator end, const codecvt_type& cvt)
+    { 
+      m_pathname.clear();
+      if (begin != end)
+      {
+        std::basic_string<typename std::iterator_traits<InputIterator>::value_type>
+          seq(begin, end);
+        path_traits::convert(seq.c_str(), seq.c_str()+seq.size(), m_pathname, cvt);
+      }
+      return *this;
+    }
+
+    //  -----  concatenation  -----
+
+    template <class Source>
+      typename autoboost::enable_if<path_traits::is_pathable<
+        typename autoboost::decay<Source>::type>, path&>::type
+    operator+=(Source const& source)
+    {
+      return concat(source);
+    }
+
+    //  value_type overloads. Same rationale as for constructors above
+    path& operator+=(const path& p)         { m_pathname += p.m_pathname; return *this; }
+    path& operator+=(const value_type* ptr) { m_pathname += ptr; return *this; }
+    path& operator+=(value_type* ptr)       { m_pathname += ptr; return *this; }
+    path& operator+=(const string_type& s)  { m_pathname += s; return *this; }
+    path& operator+=(string_type& s)        { m_pathname += s; return *this; }
+    path& operator+=(value_type c)          { m_pathname += c; return *this; }
+
+    template <class CharT>
+      typename autoboost::enable_if<is_integral<CharT>, path&>::type
+    operator+=(CharT c)
+    {
+      CharT tmp[2];
+      tmp[0] = c;
+      tmp[1] = 0;
+      return concat(tmp);
+    }
+
+    template <class Source>
+    path& concat(Source const& source)
+    {
+      path_traits::dispatch(source, m_pathname);
+      return *this;
+    }
+
+    template <class Source>
+    path& concat(Source const& source, const codecvt_type& cvt)
+    {
+      path_traits::dispatch(source, m_pathname, cvt);
+      return *this;
+    }
+
+    template <class InputIterator>
+    path& concat(InputIterator begin, InputIterator end)
+    { 
+      if (begin == end)
+        return *this;
+      std::basic_string<typename std::iterator_traits<InputIterator>::value_type>
+        seq(begin, end);
+      path_traits::convert(seq.c_str(), seq.c_str()+seq.size(), m_pathname);
+      return *this;
+    }
+
+    template <class InputIterator>
+    path& concat(InputIterator begin, InputIterator end, const codecvt_type& cvt)
+    { 
+      if (begin == end)
+        return *this;
+      std::basic_string<typename std::iterator_traits<InputIterator>::value_type>
+        seq(begin, end);
+      path_traits::convert(seq.c_str(), seq.c_str()+seq.size(), m_pathname, cvt);
+      return *this;
+    }
+
+    //  -----  appends  -----
+
+    //  if a separator is added, it is the preferred separator for the platform;
+    //  slash for POSIX, backslash for Windows
+
+    path& operator/=(const path& p);
+
+    template <class Source>
+      typename autoboost::enable_if<path_traits::is_pathable<
+        typename autoboost::decay<Source>::type>, path&>::type
+    operator/=(Source const& source)
+    {
+      return append(source);
+    }
+
+    path& operator/=(const value_type* ptr);
+    path& operator/=(value_type* ptr)
+    {
+      return this->operator/=(const_cast<const value_type*>(ptr));
+    }
+    path& operator/=(const string_type& s) { return this->operator/=(path(s)); }
+    path& operator/=(string_type& s)       { return this->operator/=(path(s)); }
+
+    path& append(const value_type* ptr)  // required in case ptr overlaps *this
+    {
+      this->operator/=(ptr);
+      return *this;
+    }
+
+    path& append(const value_type* ptr, const codecvt_type&)  // required in case ptr overlaps *this
+    {
+      this->operator/=(ptr);
+      return *this;
+    }
+
+    template <class Source>
+    path& append(Source const& source);
+
+    template <class Source>
+    path& append(Source const& source, const codecvt_type& cvt);
+
+    template <class InputIterator>
+    path& append(InputIterator begin, InputIterator end);
+
+    template <class InputIterator>
+    path& append(InputIterator begin, InputIterator end, const codecvt_type& cvt);
+
+    //  -----  modifiers  -----
+
+    void   clear() AUTOBOOST_NOEXCEPT             { m_pathname.clear(); }
+    path&  make_preferred()
+#   ifdef AUTOBOOST_POSIX_API
+      { return *this; }  // POSIX no effect
+#   else // AUTOBOOST_WINDOWS_API
+      ;  // change slashes to backslashes
+#   endif
+    path&  remove_filename();
+    path&  remove_trailing_separator();
+    path&  replace_extension(const path& new_extension = path());
+    void   swap(path& rhs) AUTOBOOST_NOEXCEPT     { m_pathname.swap(rhs.m_pathname); }
+
+    //  -----  observers  -----
+  
+    //  For operating systems that format file paths differently than directory
+    //  paths, return values from observers are formatted as file names unless there
+    //  is a trailing separator, in which case returns are formatted as directory
+    //  paths. POSIX and Windows make no such distinction.
+
+    //  Implementations are permitted to return const values or const references.
+
+    //  The string or path returned by an observer are specified as being formatted
+    //  as "native" or "generic".
+    //
+    //  For POSIX, these are all the same format; slashes and backslashes are as input and
+    //  are not modified.
+    //
+    //  For Windows,   native:    as input; slashes and backslashes are not modified;
+    //                            this is the format of the internally stored string.
+    //                 generic:   backslashes are converted to slashes
+
+    //  -----  native format observers  -----
+
+    const string_type&  native() const AUTOBOOST_NOEXCEPT  { return m_pathname; }
+    const value_type*   c_str() const AUTOBOOST_NOEXCEPT   { return m_pathname.c_str(); }
+    string_type::size_type size() const AUTOBOOST_NOEXCEPT { return m_pathname.size(); }
+
+    template <class String>
+    String string() const;
+
+    template <class String>
+    String string(const codecvt_type& cvt) const;
+
+#   ifdef AUTOBOOST_WINDOWS_API
+    const std::string string() const
+    {
+      std::string tmp;
+      if (!m_pathname.empty())
+        path_traits::convert(&*m_pathname.begin(), &*m_pathname.begin()+m_pathname.size(),
+        tmp);
+      return tmp;
+    }
+    const std::string string(const codecvt_type& cvt) const
+    { 
+      std::string tmp;
+      if (!m_pathname.empty())
+        path_traits::convert(&*m_pathname.begin(), &*m_pathname.begin()+m_pathname.size(),
+          tmp, cvt);
+      return tmp;
+    }
+    
+    //  string_type is std::wstring, so there is no conversion
+    const std::wstring&  wstring() const { return m_pathname; }
+    const std::wstring&  wstring(const codecvt_type&) const { return m_pathname; }
+
+#   else   // AUTOBOOST_POSIX_API
+    //  string_type is std::string, so there is no conversion
+    const std::string&  string() const { return m_pathname; }
+    const std::string&  string(const codecvt_type&) const { return m_pathname; }
+
+    const std::wstring  wstring() const
+    {
+      std::wstring tmp;
+      if (!m_pathname.empty())
+        path_traits::convert(&*m_pathname.begin(), &*m_pathname.begin()+m_pathname.size(),
+          tmp);
+      return tmp;
+    }
+    const std::wstring  wstring(const codecvt_type& cvt) const
+    { 
+      std::wstring tmp;
+      if (!m_pathname.empty())
+        path_traits::convert(&*m_pathname.begin(), &*m_pathname.begin()+m_pathname.size(),
+          tmp, cvt);
+      return tmp;
+    }
+
+#   endif
+
+    //  -----  generic format observers  -----
+
+    //  Experimental generic function returning generic formatted path (i.e. separators
+    //  are forward slashes). Motivation: simpler than a family of generic_*string
+    //  functions.
+    path generic() const
+    {
+#   ifdef AUTOBOOST_WINDOWS_API
+      path tmp;
+      std::replace_copy(m_pathname.begin(), m_pathname.end(),
+        std::back_inserter(tmp.m_pathname), L'\\', L'/');
+      return tmp;
+#   else
+      return path(*this);
+#   endif
+    }
+
+    template <class String>
+    String generic_string() const;
+
+    template <class String>
+    String generic_string(const codecvt_type& cvt) const;
+
+#   ifdef AUTOBOOST_WINDOWS_API
+    const std::string   generic_string() const; 
+    const std::string   generic_string(const codecvt_type& cvt) const; 
+    const std::wstring  generic_wstring() const;
+    const std::wstring  generic_wstring(const codecvt_type&) const { return generic_wstring(); };
+
+#   else // AUTOBOOST_POSIX_API
+    //  On POSIX-like systems, the generic format is the same as the native format
+    const std::string&  generic_string() const  { return m_pathname; }
+    const std::string&  generic_string(const codecvt_type&) const  { return m_pathname; }
+    const std::wstring  generic_wstring() const { return wstring(); }
+    const std::wstring  generic_wstring(const codecvt_type& cvt) const { return wstring(cvt); }
+
+#   endif
+
+    //  -----  compare  -----
+
+    int compare(const path& p) const AUTOBOOST_NOEXCEPT;  // generic, lexicographical
+    int compare(const std::string& s) const { return compare(path(s)); }
+    int compare(const value_type* s) const  { return compare(path(s)); }
+
+    //  -----  decomposition  -----
+
+    path  root_path() const; 
+    path  root_name() const;         // returns 0 or 1 element path
+                                     // even on POSIX, root_name() is non-empty() for network paths
+    path  root_directory() const;    // returns 0 or 1 element path
+    path  relative_path() const;
+    path  parent_path() const;
+    path  filename() const;          // returns 0 or 1 element path
+    path  stem() const;              // returns 0 or 1 element path
+    path  extension() const;         // returns 0 or 1 element path
+
+    //  -----  query  -----
+
+    bool empty() const AUTOBOOST_NOEXCEPT{ return m_pathname.empty(); }
+    bool filename_is_dot() const;
+    bool filename_is_dot_dot() const;
+    bool has_root_path() const       { return has_root_directory() || has_root_name(); }
+    bool has_root_name() const       { return !root_name().empty(); }
+    bool has_root_directory() const  { return !root_directory().empty(); }
+    bool has_relative_path() const   { return !relative_path().empty(); }
+    bool has_parent_path() const     { return !parent_path().empty(); }
+    bool has_filename() const        { return !m_pathname.empty(); }
+    bool has_stem() const            { return !stem().empty(); }
+    bool has_extension() const       { return !extension().empty(); }
+    bool is_relative() const         { return !is_absolute(); } 
+    bool is_absolute() const
+    {
+#     ifdef AUTOBOOST_WINDOWS_API
+      return has_root_name() && has_root_directory();
+#     else
+      return has_root_directory();
+#     endif
+    }
+
+    //  -----  lexical operations  -----
+
+    path  lexically_normal() const;
+    path  lexically_relative(const path& base) const;
+    path  lexically_proximate(const path& base) const
+    {
+      path tmp(lexically_relative(base));
+      return tmp.empty() ? *this : tmp;
+    }
+
+    //  -----  iterators  -----
+
+    class iterator;
+    typedef iterator const_iterator;
+    class reverse_iterator;
+    typedef reverse_iterator const_reverse_iterator;
+
+    iterator begin() const;
+    iterator end() const;
+    reverse_iterator rbegin() const;
+    reverse_iterator rend() const;
+
+    //  -----  static member functions  -----
+
+    static std::locale          imbue(const std::locale& loc);
+    static const codecvt_type&  codecvt();
+
+    //  -----  deprecated functions  -----
+
+# if defined(AUTOBOOST_FILESYSTEM_DEPRECATED) && defined(AUTOBOOST_FILESYSTEM_NO_DEPRECATED)
+#   error both AUTOBOOST_FILESYSTEM_DEPRECATED and AUTOBOOST_FILESYSTEM_NO_DEPRECATED are defined
+# endif
+
+# if !defined(AUTOBOOST_FILESYSTEM_NO_DEPRECATED)
+    //  recently deprecated functions supplied by default
+    path&  normalize()              { 
+                                      path tmp(lexically_normal());
+                                      m_pathname.swap(tmp.m_pathname);
+                                      return *this;
+                                    }
+    path&  remove_leaf()            { return remove_filename(); }
+    path   leaf() const             { return filename(); }
+    path   branch_path() const      { return parent_path(); }
+    bool   has_leaf() const         { return !m_pathname.empty(); }
+    bool   has_branch_path() const  { return !parent_path().empty(); }
+    bool   is_complete() const      { return is_absolute(); }
+# endif
+
+# if defined(AUTOBOOST_FILESYSTEM_DEPRECATED)
+    //  deprecated functions with enough signature or semantic changes that they are
+    //  not supplied by default 
+    const std::string file_string() const               { return string(); }
+    const std::string directory_string() const          { return string(); }
+    const std::string native_file_string() const        { return string(); }
+    const std::string native_directory_string() const   { return string(); }
+    const string_type external_file_string() const      { return native(); }
+    const string_type external_directory_string() const { return native(); }
+
+    //  older functions no longer supported
+    //typedef bool (*name_check)(const std::string & name);
+    //basic_path(const string_type& str, name_check) { operator/=(str); }
+    //basic_path(const typename string_type::value_type* s, name_check)
+    //  { operator/=(s);}
+    //static bool default_name_check_writable() { return false; } 
+    //static void default_name_check(name_check) {}
+    //static name_check default_name_check() { return 0; }
+    //basic_path& canonize();
+# endif
+
+//--------------------------------------------------------------------------------------//
+//                            class path private members                                //
+//--------------------------------------------------------------------------------------//
+
+  private:
+
+#   if defined(_MSC_VER)
+#     pragma warning(push) // Save warning settings
+#     pragma warning(disable : 4251) // disable warning: class 'std::basic_string<_Elem,_Traits,_Ax>'
+#   endif                            // needs to have dll-interface...
+/*
+      m_pathname has the type, encoding, and format required by the native
+      operating system. Thus for POSIX and Windows there is no conversion for
+      passing m_pathname.c_str() to the O/S API or when obtaining a path from the
+      O/S API. POSIX encoding is unspecified other than for dot and slash
+      characters; POSIX just treats paths as a sequence of bytes. Windows
+      encoding is UCS-2 or UTF-16 depending on the version.
+*/
+    string_type  m_pathname;  // Windows: as input; backslashes NOT converted to slashes,
+                              // slashes NOT converted to backslashes
+#   if defined(_MSC_VER)
+#     pragma warning(pop) // restore warning settings.
+#   endif 
+
+    string_type::size_type m_append_separator_if_needed();
+    //  Returns: If separator is to be appended, m_pathname.size() before append. Otherwise 0.
+    //  Note: An append is never performed if size()==0, so a returned 0 is unambiguous.
+
+    void m_erase_redundant_separator(string_type::size_type sep_pos);
+    string_type::size_type m_parent_path_end() const;
+
+    path& m_normalize();
+
+    // Was qualified; como433beta8 reports:
+    //    warning #427-D: qualified name is not allowed in member declaration 
+    friend class iterator;
+    friend bool operator<(const path& lhs, const path& rhs);
+
+    // see path::iterator::increment/decrement comment below
+    static void m_path_iterator_increment(path::iterator & it);
+    static void m_path_iterator_decrement(path::iterator & it);
+
+  };  // class path
+
+  namespace detail
+  {
+    AUTOBOOST_FILESYSTEM_DECL
+      int lex_compare(path::iterator first1, path::iterator last1,
+        path::iterator first2, path::iterator last2);
+    AUTOBOOST_FILESYSTEM_DECL
+      const path&  dot_path();
+    AUTOBOOST_FILESYSTEM_DECL
+      const path&  dot_dot_path();
+  }
+
+# ifndef AUTOBOOST_FILESYSTEM_NO_DEPRECATED
+  typedef path wpath;
+# endif
+
+  //------------------------------------------------------------------------------------//
+  //                             class path::iterator                                   //
+  //------------------------------------------------------------------------------------//
+ 
+  class path::iterator
+    : public autoboost::iterator_facade<
+      path::iterator,
+      path const,
+      autoboost::bidirectional_traversal_tag >
+  {
+  private:
+    friend class autoboost::iterator_core_access;
+    friend class autoboost::filesystem::path;
+    friend class autoboost::filesystem::path::reverse_iterator;
+    friend void m_path_iterator_increment(path::iterator & it);
+    friend void m_path_iterator_decrement(path::iterator & it);
+
+    const path& dereference() const { return m_element; }
+
+    bool equal(const iterator & rhs) const
+    {
+      return m_path_ptr == rhs.m_path_ptr && m_pos == rhs.m_pos;
+    }
+
+    // iterator_facade derived classes don't seem to like implementations in
+    // separate translation unit dll's, so forward to class path static members
+    void increment() { m_path_iterator_increment(*this); }
+    void decrement() { m_path_iterator_decrement(*this); }
+
+    path                    m_element;   // current element
+    const path*             m_path_ptr;  // path being iterated over
+    string_type::size_type  m_pos;       // position of m_element in
+                                         // m_path_ptr->m_pathname.
+                                         // if m_element is implicit dot, m_pos is the
+                                         // position of the last separator in the path.
+                                         // end() iterator is indicated by 
+                                         // m_pos == m_path_ptr->m_pathname.size()
+  }; // path::iterator
+
+  //------------------------------------------------------------------------------------//
+  //                         class path::reverse_iterator                               //
+  //------------------------------------------------------------------------------------//
+ 
+  class path::reverse_iterator
+    : public autoboost::iterator_facade<
+      path::reverse_iterator,
+      path const,
+      autoboost::bidirectional_traversal_tag >
+  {
+  public:
+
+    explicit reverse_iterator(iterator itr) : m_itr(itr)
+    {
+      if (itr != itr.m_path_ptr->begin())
+        m_element = *--itr;
+    }
+  private:
+    friend class autoboost::iterator_core_access;
+    friend class autoboost::filesystem::path;
+
+    const path& dereference() const { return m_element; }
+    bool equal(const reverse_iterator& rhs) const { return m_itr == rhs.m_itr; }
+    void increment()
+    { 
+      --m_itr;
+      if (m_itr != m_itr.m_path_ptr->begin())
+      {
+        iterator tmp = m_itr;
+        m_element = *--tmp;
+      }
+    }
+    void decrement()
+    {
+      m_element = *m_itr;
+      ++m_itr;
+    }
+
+    iterator m_itr;
+    path     m_element;
+
+  }; // path::reverse_iterator
+
+  //------------------------------------------------------------------------------------//
+  //                                                                                    //
+  //                              non-member functions                                  //
+  //                                                                                    //
+  //------------------------------------------------------------------------------------//
+
+  //  std::lexicographical_compare would infinately recurse because path iterators
+  //  yield paths, so provide a path aware version
+  inline bool lexicographical_compare(path::iterator first1, path::iterator last1,
+    path::iterator first2, path::iterator last2)
+    { return detail::lex_compare(first1, last1, first2, last2) < 0; }
+  
+  inline bool operator==(const path& lhs, const path& rhs)              {return lhs.compare(rhs) == 0;}
+  inline bool operator==(const path& lhs, const path::string_type& rhs) {return lhs.compare(rhs) == 0;} 
+  inline bool operator==(const path::string_type& lhs, const path& rhs) {return rhs.compare(lhs) == 0;}
+  inline bool operator==(const path& lhs, const path::value_type* rhs)  {return lhs.compare(rhs) == 0;}
+  inline bool operator==(const path::value_type* lhs, const path& rhs)  {return rhs.compare(lhs) == 0;}
+  
+  inline bool operator!=(const path& lhs, const path& rhs)              {return lhs.compare(rhs) != 0;}
+  inline bool operator!=(const path& lhs, const path::string_type& rhs) {return lhs.compare(rhs) != 0;} 
+  inline bool operator!=(const path::string_type& lhs, const path& rhs) {return rhs.compare(lhs) != 0;}
+  inline bool operator!=(const path& lhs, const path::value_type* rhs)  {return lhs.compare(rhs) != 0;}
+  inline bool operator!=(const path::value_type* lhs, const path& rhs)  {return rhs.compare(lhs) != 0;}
+
+  // TODO: why do == and != have additional overloads, but the others don't?
+
+  inline bool operator<(const path& lhs, const path& rhs)  {return lhs.compare(rhs) < 0;}
+  inline bool operator<=(const path& lhs, const path& rhs) {return !(rhs < lhs);}
+  inline bool operator> (const path& lhs, const path& rhs) {return rhs < lhs;}
+  inline bool operator>=(const path& lhs, const path& rhs) {return !(lhs < rhs);}
+
+  inline std::size_t hash_value(const path& x)
+  {
+# ifdef AUTOBOOST_WINDOWS_API
+    std::size_t seed = 0;
+    for(const path::value_type* it = x.c_str(); *it; ++it)
+      hash_combine(seed, *it == '/' ? L'\\' : *it);
+    return seed;
+# else   // AUTOBOOST_POSIX_API
+    return hash_range(x.native().begin(), x.native().end());
+# endif
+  }
+
+  inline void swap(path& lhs, path& rhs)                   { lhs.swap(rhs); }
+
+  inline path operator/(const path& lhs, const path& rhs)  { return path(lhs) /= rhs; }
+
+  //  inserters and extractors
+  //    use autoboost::io::quoted() to handle spaces in paths
+  //    use '&' as escape character to ease use for Windows paths
+
+  template <class Char, class Traits>
+  inline std::basic_ostream<Char, Traits>&
+  operator<<(std::basic_ostream<Char, Traits>& os, const path& p)
+  {
+    return os
+      << autoboost::io::quoted(p.template string<std::basic_string<Char> >(), static_cast<Char>('&'));
+  }
+  
+  template <class Char, class Traits>
+  inline std::basic_istream<Char, Traits>&
+  operator>>(std::basic_istream<Char, Traits>& is, path& p)
+  {
+    std::basic_string<Char> str;
+    is >> autoboost::io::quoted(str, static_cast<Char>('&'));
+    p = str;
+    return is;
+  }
+ 
+  //  name_checks
+
+  //  These functions are holdovers from version 1. It isn't clear they have much
+  //  usefulness, or how to generalize them for later versions.
+
+  AUTOBOOST_FILESYSTEM_DECL bool portable_posix_name(const std::string & name);
+  AUTOBOOST_FILESYSTEM_DECL bool windows_name(const std::string & name);
+  AUTOBOOST_FILESYSTEM_DECL bool portable_name(const std::string & name);
+  AUTOBOOST_FILESYSTEM_DECL bool portable_directory_name(const std::string & name);
+  AUTOBOOST_FILESYSTEM_DECL bool portable_file_name(const std::string & name);
+  AUTOBOOST_FILESYSTEM_DECL bool native(const std::string & name);
+
+  namespace detail
+  {
+    //  For POSIX, is_directory_separator() and is_element_separator() are identical since
+    //  a forward slash is the only valid directory separator and also the only valid
+    //  element separator. For Windows, forward slash and back slash are the possible
+    //  directory separators, but colon (example: "c:foo") is also an element separator.
+
+    inline bool is_directory_separator(path::value_type c) AUTOBOOST_NOEXCEPT
+    {
+      return c == path::separator
+#     ifdef AUTOBOOST_WINDOWS_API
+        || c == path::preferred_separator
+#     endif
+      ;
+    }
+    inline bool is_element_separator(path::value_type c) AUTOBOOST_NOEXCEPT
+    {
+      return c == path::separator
+#     ifdef AUTOBOOST_WINDOWS_API
+        || c == path::preferred_separator || c == L':'
+#     endif
+      ;
+    }
+  }  // namespace detail
+
+  //------------------------------------------------------------------------------------//
+  //                  class path miscellaneous function implementations                 //
+  //------------------------------------------------------------------------------------//
+
+  inline path::reverse_iterator path::rbegin() const { return reverse_iterator(end()); }
+  inline path::reverse_iterator path::rend() const   { return reverse_iterator(begin()); }
+
+  inline bool path::filename_is_dot() const
+  {
+    // implicit dot is tricky, so actually call filename(); see path::filename() example
+    // in reference.html 
+    path p(filename());
+    return p.size() == 1 && *p.c_str() == dot;
+  }
+
+  inline bool path::filename_is_dot_dot() const
+  {
+    return size() >= 2 && m_pathname[size()-1] == dot && m_pathname[size()-2] == dot
+      && (m_pathname.size() == 2 || detail::is_element_separator(m_pathname[size()-3]));
+      // use detail::is_element_separator() rather than detail::is_directory_separator
+      // to deal with "c:.." edge case on Windows when ':' acts as a separator
+  }
+ 
+//--------------------------------------------------------------------------------------//
+//                     class path member template implementation                        //
+//--------------------------------------------------------------------------------------//
+
+  template <class InputIterator>
+  path& path::append(InputIterator begin, InputIterator end)
+  {
+    if (begin == end)
+      return *this;
+    string_type::size_type sep_pos(m_append_separator_if_needed());
+    std::basic_string<typename std::iterator_traits<InputIterator>::value_type>
+      seq(begin, end);
+    path_traits::convert(seq.c_str(), seq.c_str()+seq.size(), m_pathname);
+    if (sep_pos)
+      m_erase_redundant_separator(sep_pos);
+    return *this;
+  }
+
+  template <class InputIterator>
+  path& path::append(InputIterator begin, InputIterator end, const codecvt_type& cvt)
+  {
+    if (begin == end)
+      return *this;
+    string_type::size_type sep_pos(m_append_separator_if_needed());
+    std::basic_string<typename std::iterator_traits<InputIterator>::value_type>
+      seq(begin, end);
+    path_traits::convert(seq.c_str(), seq.c_str()+seq.size(), m_pathname, cvt);
+    if (sep_pos)
+      m_erase_redundant_separator(sep_pos);
+    return *this;
+  }
+
+  template <class Source>
+  path& path::append(Source const& source)
+  {
+    if (path_traits::empty(source))
+      return *this;
+    string_type::size_type sep_pos(m_append_separator_if_needed());
+    path_traits::dispatch(source, m_pathname);
+    if (sep_pos)
+      m_erase_redundant_separator(sep_pos);
+    return *this;
+  }
+
+  template <class Source>
+  path& path::append(Source const& source, const codecvt_type& cvt)
+  {
+    if (path_traits::empty(source))
+      return *this;
+    string_type::size_type sep_pos(m_append_separator_if_needed());
+    path_traits::dispatch(source, m_pathname, cvt);
+    if (sep_pos)
+      m_erase_redundant_separator(sep_pos);
+    return *this;
+  }
+
+//--------------------------------------------------------------------------------------//
+//                     class path member template specializations                       //
+//--------------------------------------------------------------------------------------//
+
+  template <> inline
+  std::string path::string<std::string>() const
+    { return string(); }
+
+  template <> inline
+  std::wstring path::string<std::wstring>() const
+    { return wstring(); }
+
+  template <> inline
+  std::string path::string<std::string>(const codecvt_type& cvt) const
+    { return string(cvt); }
+
+  template <> inline
+  std::wstring path::string<std::wstring>(const codecvt_type& cvt) const
+    { return wstring(cvt); }
+
+  template <> inline
+  std::string path::generic_string<std::string>() const
+    { return generic_string(); }
+
+  template <> inline
+  std::wstring path::generic_string<std::wstring>() const
+    { return generic_wstring(); }
+
+  template <> inline
+  std::string path::generic_string<std::string>(const codecvt_type& cvt) const
+    { return generic_string(cvt); }
+
+  template <> inline
+  std::wstring path::generic_string<std::wstring>(const codecvt_type& cvt) const
+    { return generic_wstring(cvt); }
+
+  //--------------------------------------------------------------------------------------//
+  //                     path_traits convert function implementations                     //
+  //                        requiring path::codecvt() be visable                          //
+  //--------------------------------------------------------------------------------------//
+
+namespace path_traits
+{  //  without codecvt
+
+  inline
+    void convert(const char* from,
+    const char* from_end,    // 0 for null terminated MBCS
+    std::wstring & to)
+  {
+    convert(from, from_end, to, path::codecvt());
+  }
+
+  inline
+    void convert(const wchar_t* from,
+    const wchar_t* from_end,  // 0 for null terminated MBCS
+    std::string & to)
+  {
+    convert(from, from_end, to, path::codecvt());
+  }
+
+  inline
+    void convert(const char* from,
+    std::wstring & to)
+  {
+    AUTOBOOST_ASSERT(from);
+    convert(from, 0, to, path::codecvt());
+  }
+
+  inline
+    void convert(const wchar_t* from,
+    std::string & to)
+  {
+    AUTOBOOST_ASSERT(from);
+    convert(from, 0, to, path::codecvt());
+  }
+}  // namespace path_traits
+}  // namespace filesystem
+}  // namespace autoboost
+
+//----------------------------------------------------------------------------//
+
+#include <autoboost/config/abi_suffix.hpp> // pops abi_prefix.hpp pragmas
+
+#endif  // AUTOBOOST_FILESYSTEM_PATH_HPP

--- a/contrib/autoboost/autoboost/filesystem/path_traits.hpp
+++ b/contrib/autoboost/autoboost/filesystem/path_traits.hpp
@@ -1,0 +1,352 @@
+//  filesystem path_traits.hpp  --------------------------------------------------------//
+
+//  Copyright Beman Dawes 2009
+
+//  Distributed under the Boost Software License, Version 1.0.
+//  See http://www.boost.org/LICENSE_1_0.txt
+
+//  Library home page: http://www.boost.org/libs/filesystem
+
+#ifndef AUTOBOOST_FILESYSTEM_PATH_TRAITS_HPP
+#define AUTOBOOST_FILESYSTEM_PATH_TRAITS_HPP
+
+#include <autoboost/config.hpp>
+
+# if defined( AUTOBOOST_NO_STD_WSTRING )
+#   error Configuration not supported: Boost.Filesystem V3 and later requires std::wstring support
+# endif
+
+#include <autoboost/filesystem/config.hpp>
+#include <autoboost/utility/enable_if.hpp>
+#include <autoboost/type_traits/is_array.hpp>
+#include <autoboost/type_traits/decay.hpp>
+#include <autoboost/system/error_code.hpp>
+#include <cwchar>  // for mbstate_t
+#include <string>
+#include <vector>
+#include <list>
+#include <iterator>
+#include <locale>
+#include <autoboost/assert.hpp>
+// #include <iostream>   //**** comment me out ****
+
+#include <autoboost/config/abi_prefix.hpp> // must be the last #include
+
+namespace autoboost { namespace filesystem {
+
+  AUTOBOOST_FILESYSTEM_DECL const system::error_category& codecvt_error_category();
+  //  uses std::codecvt_base::result used for error codes:
+  //
+  //    ok:       Conversion successful.
+  //    partial:  Not all source characters converted; one or more additional source
+  //              characters are needed to produce the final target character, or the
+  //              size of the target intermediate buffer was too small to hold the result.
+  //    error:    A character in the source could not be converted to the target encoding.
+  //    noconv:   The source and target characters have the same type and encoding, so no
+  //              conversion was necessary.
+
+  class directory_entry;
+  
+namespace path_traits {
+ 
+  typedef std::codecvt<wchar_t, char, std::mbstate_t> codecvt_type;
+
+  //  is_pathable type trait; allows disabling over-agressive class path member templates
+
+  template <class T>
+  struct is_pathable { static const bool value = false; };
+
+  template<> struct is_pathable<char*>                  { static const bool value = true; };
+  template<> struct is_pathable<const char*>            { static const bool value = true; };
+  template<> struct is_pathable<wchar_t*>               { static const bool value = true; };
+  template<> struct is_pathable<const wchar_t*>         { static const bool value = true; };
+  template<> struct is_pathable<std::string>            { static const bool value = true; };
+  template<> struct is_pathable<std::wstring>           { static const bool value = true; };
+  template<> struct is_pathable<std::vector<char> >     { static const bool value = true; };
+  template<> struct is_pathable<std::vector<wchar_t> >  { static const bool value = true; };
+  template<> struct is_pathable<std::list<char> >       { static const bool value = true; };
+  template<> struct is_pathable<std::list<wchar_t> >    { static const bool value = true; };
+  template<> struct is_pathable<directory_entry>        { static const bool value = true; };
+
+  //  Pathable empty
+
+  template <class Container> inline
+    // disable_if aids broken compilers (IBM, old GCC, etc.) and is harmless for
+    // conforming compilers. Replace by plain "bool" at some future date (2012?) 
+    typename autoboost::disable_if<autoboost::is_array<Container>, bool>::type
+      empty(const Container & c)
+        { return c.begin() == c.end(); }
+
+  template <class T> inline
+    bool empty(T * const & c_str)
+  {
+    AUTOBOOST_ASSERT(c_str);
+    return !*c_str;
+  }
+
+  template <typename T, size_t N> inline
+     bool empty(T (&x)[N])
+       { return !x[0]; }
+
+  // value types differ  ---------------------------------------------------------------//
+  //
+  //   A from_end argument of 0 is less efficient than a known end, so use only if needed
+
+  //  with codecvt
+
+  AUTOBOOST_FILESYSTEM_DECL
+    void convert(const char* from,
+    const char* from_end,    // 0 for null terminated MBCS
+    std::wstring & to,
+    const codecvt_type& cvt);
+
+  AUTOBOOST_FILESYSTEM_DECL
+    void convert(const wchar_t* from,
+    const wchar_t* from_end,  // 0 for null terminated MBCS
+    std::string & to,
+    const codecvt_type& cvt);
+
+  inline
+    void convert(const char* from,
+    std::wstring & to,
+    const codecvt_type& cvt)
+  {
+    AUTOBOOST_ASSERT(from);
+    convert(from, 0, to, cvt);
+  }
+
+  inline
+    void convert(const wchar_t* from,
+    std::string & to,
+    const codecvt_type& cvt)
+  {
+    AUTOBOOST_ASSERT(from);
+    convert(from, 0, to, cvt);
+  }
+
+  //  without codecvt
+
+  inline
+    void convert(const char* from,
+    const char* from_end,    // 0 for null terminated MBCS
+    std::wstring & to);
+
+  inline
+    void convert(const wchar_t* from,
+    const wchar_t* from_end,  // 0 for null terminated MBCS
+    std::string & to);
+
+  inline
+    void convert(const char* from,
+    std::wstring & to);
+
+  inline
+    void convert(const wchar_t* from,
+    std::string & to);
+
+  // value types same  -----------------------------------------------------------------//
+
+  // char with codecvt
+
+  inline
+    void convert(const char* from, const char* from_end, std::string & to,
+    const codecvt_type&)
+  {
+    AUTOBOOST_ASSERT(from);
+    AUTOBOOST_ASSERT(from_end);
+    to.append(from, from_end);
+  }
+
+  inline
+    void convert(const char* from,
+    std::string & to,
+    const codecvt_type&)
+  {
+    AUTOBOOST_ASSERT(from);
+    to += from;
+  }
+
+  // wchar_t with codecvt
+
+  inline
+    void convert(const wchar_t* from, const wchar_t* from_end, std::wstring & to,
+    const codecvt_type&)
+  {
+    AUTOBOOST_ASSERT(from);
+    AUTOBOOST_ASSERT(from_end);
+    to.append(from, from_end);
+  }
+
+  inline
+    void convert(const wchar_t* from,
+    std::wstring & to,
+    const codecvt_type&)
+  {
+    AUTOBOOST_ASSERT(from);
+    to += from;
+  }
+
+  // char without codecvt
+
+  inline
+    void convert(const char* from, const char* from_end, std::string & to)
+  {
+    AUTOBOOST_ASSERT(from);
+    AUTOBOOST_ASSERT(from_end);
+    to.append(from, from_end);
+  }
+
+  inline
+    void convert(const char* from, std::string & to)
+  {
+    AUTOBOOST_ASSERT(from);
+    to += from;
+  }
+
+  // wchar_t without codecvt
+
+  inline
+    void convert(const wchar_t* from, const wchar_t* from_end, std::wstring & to)
+  {
+    AUTOBOOST_ASSERT(from);
+    AUTOBOOST_ASSERT(from_end);
+    to.append(from, from_end);
+  }
+
+  inline
+    void convert(const wchar_t* from, std::wstring & to)
+  {
+    AUTOBOOST_ASSERT(from);
+    to += from;
+  }
+
+  //  Source dispatch  -----------------------------------------------------------------//
+
+  //  contiguous containers with codecvt
+  template <class U> inline
+    void dispatch(const std::string& c, U& to, const codecvt_type& cvt)
+  {
+    if (c.size())
+      convert(&*c.begin(), &*c.begin() + c.size(), to, cvt);
+  }
+  template <class U> inline
+    void dispatch(const std::wstring& c, U& to, const codecvt_type& cvt)
+  {
+    if (c.size())
+      convert(&*c.begin(), &*c.begin() + c.size(), to, cvt);
+  }
+  template <class U> inline
+    void dispatch(const std::vector<char>& c, U& to, const codecvt_type& cvt)
+  {
+    if (c.size())
+      convert(&*c.begin(), &*c.begin() + c.size(), to, cvt);
+  }
+  template <class U> inline
+    void dispatch(const std::vector<wchar_t>& c, U& to, const codecvt_type& cvt)
+  {
+    if (c.size())
+      convert(&*c.begin(), &*c.begin() + c.size(), to, cvt);
+  }
+
+  //  contiguous containers without codecvt
+  template <class U> inline
+    void dispatch(const std::string& c, U& to)
+  {
+    if (c.size())
+      convert(&*c.begin(), &*c.begin() + c.size(), to);
+  }
+  template <class U> inline
+    void dispatch(const std::wstring& c, U& to)
+  {
+    if (c.size())
+      convert(&*c.begin(), &*c.begin() + c.size(), to);
+  }
+  template <class U> inline
+    void dispatch(const std::vector<char>& c, U& to)
+  {
+    if (c.size())
+      convert(&*c.begin(), &*c.begin() + c.size(), to);
+  }
+  template <class U> inline
+    void dispatch(const std::vector<wchar_t>& c, U& to)
+  {
+    if (c.size())
+      convert(&*c.begin(), &*c.begin() + c.size(), to);
+  }
+
+  //  non-contiguous containers with codecvt
+  template <class Container, class U> inline
+    // disable_if aids broken compilers (IBM, old GCC, etc.) and is harmless for
+    // conforming compilers. Replace by plain "void" at some future date (2012?) 
+    typename autoboost::disable_if<autoboost::is_array<Container>, void>::type
+    dispatch(const Container & c, U& to, const codecvt_type& cvt)
+  {
+    if (c.size())
+    {
+      std::basic_string<typename Container::value_type> s(c.begin(), c.end());
+      convert(s.c_str(), s.c_str()+s.size(), to, cvt);
+    }
+  }
+
+  //  c_str
+  template <class T, class U> inline
+    void dispatch(T * const & c_str, U& to, const codecvt_type& cvt)
+  {
+    //    std::cout << "dispatch() const T *\n";
+    AUTOBOOST_ASSERT(c_str);
+    convert(c_str, to, cvt);
+  }
+
+  //  Note: there is no dispatch on C-style arrays because the array may
+  //  contain a string smaller than the array size. 
+
+  AUTOBOOST_FILESYSTEM_DECL
+    void dispatch(const directory_entry & de,
+#                ifdef AUTOBOOST_WINDOWS_API
+    std::wstring & to,
+#                else   
+    std::string & to,
+#                endif
+    const codecvt_type&);
+
+  //  non-contiguous containers without codecvt
+  template <class Container, class U> inline
+    // disable_if aids broken compilers (IBM, old GCC, etc.) and is harmless for
+    // conforming compilers. Replace by plain "void" at some future date (2012?) 
+    typename autoboost::disable_if<autoboost::is_array<Container>, void>::type
+    dispatch(const Container & c, U& to)
+  {
+    if (c.size())
+    {
+      std::basic_string<typename Container::value_type> seq(c.begin(), c.end());
+      convert(seq.c_str(), seq.c_str()+seq.size(), to);
+    }
+  }
+
+  //  c_str
+  template <class T, class U> inline
+    void dispatch(T * const & c_str, U& to)
+  {
+    //    std::cout << "dispatch() const T *\n";
+    AUTOBOOST_ASSERT(c_str);
+    convert(c_str, to);
+  }
+
+  //  Note: there is no dispatch on C-style arrays because the array may
+  //  contain a string smaller than the array size. 
+
+  AUTOBOOST_FILESYSTEM_DECL
+    void dispatch(const directory_entry & de,
+#                ifdef AUTOBOOST_WINDOWS_API
+    std::wstring & to
+#                else   
+    std::string & to
+#                endif
+    );
+
+
+}}} // namespace autoboost::filesystem::path_traits
+
+#include <autoboost/config/abi_suffix.hpp> // pops abi_prefix.hpp pragmas
+
+#endif  // AUTOBOOST_FILESYSTEM_PATH_TRAITS_HPP

--- a/contrib/autoboost/autoboost/filesystem/string_file.hpp
+++ b/contrib/autoboost/autoboost/filesystem/string_file.hpp
@@ -1,0 +1,43 @@
+//  filesystem/string_file.hpp  --------------------------------------------------------//
+
+//  Copyright Beman Dawes 2015
+
+//  Distributed under the Boost Software License, Version 1.0.
+//  See http://www.boost.org/LICENSE_1_0.txt
+
+//  Library home page: http://www.boost.org/libs/filesystem
+
+#ifndef AUTOBOOST_FILESYSTEM_STRING_FILE_HPP
+#define AUTOBOOST_FILESYSTEM_STRING_FILE_HPP
+
+#include <string>
+#include <autoboost/filesystem/fstream.hpp>
+#include <autoboost/filesystem/operations.hpp>
+
+namespace autoboost
+{
+namespace filesystem
+{
+inline
+void save_string_file(const path& p, const std::string& str)
+{
+  ofstream file;
+  file.exceptions(std::ofstream::failbit | std::ofstream::badbit);
+  file.open(p, std::ios_base::binary);
+  file.write(str.c_str(), str.size());
+}
+
+inline
+void load_string_file(const path& p, std::string& str)
+{
+  ifstream file;
+  file.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+  file.open(p, std::ios_base::binary);
+  std::size_t sz = static_cast<std::size_t>(file_size(p));
+  str.resize(sz, '\0');
+  file.read(&str[0], sz);
+}
+}  // namespace filesystem
+}  // namespace autoboost
+
+#endif  // include guard

--- a/contrib/autoboost/autoboost/io/detail/quoted_manip.hpp
+++ b/contrib/autoboost/autoboost/io/detail/quoted_manip.hpp
@@ -1,0 +1,190 @@
+//  boost/io/quoted_manip.hpp  ---------------------------------------------------------//
+
+//  Copyright Beman Dawes 2010
+
+//  Distributed under the Boost Software License, Version 1.0.
+//  See http://www.boost.org/LICENSE_1_0.txt
+
+//  Library home page http://www.boost.org/libs/io
+
+//--------------------------------------------------------------------------------------//
+
+#ifndef BOOST_IO_QUOTED_MANIP
+#define BOOST_IO_QUOTED_MANIP
+
+#include <iosfwd>
+#include <ios>
+#include <string>
+#include <iterator>
+#include <autoboost/io/ios_state.hpp>
+
+namespace autoboost
+{
+  namespace io
+  {
+    namespace detail { template <class String, class Char> struct quoted_proxy; }
+
+    //  ------------  public interface  ------------------------------------------------//
+
+    //  manipulator for const std::basic_string&
+    template <class Char, class Traits, class Alloc>
+      detail::quoted_proxy<std::basic_string<Char, Traits, Alloc> const &, Char>
+        quoted(const std::basic_string<Char, Traits, Alloc>& s,
+               Char escape='\\', Char delim='\"');
+
+    //  manipulator for non-const std::basic_string&
+    template <class Char, class Traits, class Alloc>
+      detail::quoted_proxy<std::basic_string<Char, Traits, Alloc> &, Char>
+        quoted(std::basic_string<Char, Traits, Alloc>& s,
+               Char escape='\\', Char delim='\"');
+
+    //  manipulator for const C-string*
+    template <class Char>
+      detail::quoted_proxy<const Char*, Char>
+        quoted(const Char* s, Char escape='\\', Char delim='\"');
+
+    //  -----------  implementation details  -------------------------------------------//
+
+    namespace detail
+    {
+      //  proxy used as an argument pack
+      template <class String, class Char>
+      struct quoted_proxy
+      {
+        String  string;
+        Char    escape;
+        Char    delim;
+
+        quoted_proxy(String s_, Char escape_, Char delim_)
+          : string(s_), escape(escape_), delim(delim_) {}
+      private:
+        // String may be a const type, so disable the assignment operator
+        quoted_proxy& operator=(const quoted_proxy&);  // = deleted
+      };
+
+      //  abstract away difference between proxies with const or non-const basic_strings
+      template <class Char, class Traits, class Alloc>
+      std::basic_ostream<Char, Traits>&
+      basic_string_inserter_imp(std::basic_ostream<Char, Traits>& os,
+        std::basic_string<Char, Traits, Alloc> const & string, Char escape, Char delim)
+      {
+        os << delim;
+        typename std::basic_string<Char, Traits, Alloc>::const_iterator
+          end_it = string.end();
+        for (typename std::basic_string<Char, Traits, Alloc>::const_iterator
+          it = string.begin();
+          it != end_it;
+          ++it )
+        {
+          if (*it == delim || *it == escape)
+            os << escape;
+          os << *it;
+        }
+        os << delim;
+        return os;
+      }
+
+      //  inserter for const std::basic_string& proxies
+      template <class Char, class Traits, class Alloc>
+      inline
+      std::basic_ostream<Char, Traits>& operator<<(std::basic_ostream<Char, Traits>& os,
+        const quoted_proxy<std::basic_string<Char, Traits, Alloc> const &, Char>& proxy)
+      {
+        return basic_string_inserter_imp(os, proxy.string, proxy.escape, proxy.delim);
+      }
+
+      //  inserter for non-const std::basic_string& proxies
+      template <class Char, class Traits, class Alloc>
+      inline
+      std::basic_ostream<Char, Traits>& operator<<(std::basic_ostream<Char, Traits>& os,
+        const quoted_proxy<std::basic_string<Char, Traits, Alloc>&, Char>& proxy)
+      {
+        return basic_string_inserter_imp(os, proxy.string, proxy.escape, proxy.delim);
+      }
+
+      //  inserter for const C-string* proxies
+      template <class Char, class Traits>
+      std::basic_ostream<Char, Traits>& operator<<(std::basic_ostream<Char, Traits>& os,
+        const quoted_proxy<const Char*, Char>& proxy)
+      {
+        os << proxy.delim;
+        for (const Char* it = proxy.string;
+          *it;
+          ++it )
+        {
+          if (*it == proxy.delim || *it == proxy.escape)
+            os << proxy.escape;
+          os << *it;
+        }
+        os << proxy.delim;
+        return os;
+      }
+
+      //  extractor for non-const std::basic_string& proxies
+      template <class Char, class Traits, class Alloc>
+      std::basic_istream<Char, Traits>& operator>>(std::basic_istream<Char, Traits>& is,
+        const quoted_proxy<std::basic_string<Char, Traits, Alloc>&, Char>& proxy)
+      {
+        proxy.string.clear();
+        Char c;
+        is >> c;
+        if (c != proxy.delim)
+        {
+          is.unget();
+          is >> proxy.string;
+          return is;
+        }
+        {
+          autoboost::io::ios_flags_saver ifs(is);
+          is >> std::noskipws;
+          for (;;)
+          {
+            is >> c;
+            if (!is.good())  // cope with I/O errors or end-of-file
+              break;
+            if (c == proxy.escape)
+            {
+              is >> c;
+              if (!is.good())  // cope with I/O errors or end-of-file
+                break;
+            }
+            else if (c == proxy.delim)
+              break;
+            proxy.string += c;
+          }
+        }
+        return is;
+      }
+
+    }  // namespace detail
+
+    //  manipulator implementation for const std::basic_string&
+    template <class Char, class Traits, class Alloc>
+    inline detail::quoted_proxy<std::basic_string<Char, Traits, Alloc> const &, Char>
+    quoted(const std::basic_string<Char, Traits, Alloc>& s, Char escape, Char delim)
+    {
+      return detail::quoted_proxy<std::basic_string<Char, Traits, Alloc> const &, Char>
+        (s, escape, delim);
+    }
+
+    //  manipulator implementation for non-const std::basic_string&
+    template <class Char, class Traits, class Alloc>
+    inline detail::quoted_proxy<std::basic_string<Char, Traits, Alloc> &, Char>
+    quoted(std::basic_string<Char, Traits, Alloc>& s, Char escape, Char delim)
+    {
+      return detail::quoted_proxy<std::basic_string<Char, Traits, Alloc>&, Char>
+        (s, escape, delim);
+    }
+
+    //  manipulator implementation for const C-string*
+    template <class Char>
+    inline detail::quoted_proxy<const Char*, Char>
+    quoted(const Char* s, Char escape, Char delim)
+    {
+      return detail::quoted_proxy<const Char*, Char> (s, escape, delim);
+    }
+
+  }  // namespace io
+}  // namespace boost
+
+#endif // BOOST_IO_QUOTED_MANIP

--- a/contrib/autoboost/libs/filesystem/codecvt_error_category.cpp
+++ b/contrib/autoboost/libs/filesystem/codecvt_error_category.cpp
@@ -1,0 +1,85 @@
+//  codecvt_error_category implementation file  ----------------------------------------//
+
+//  Copyright Beman Dawes 2009
+
+//  Distributed under the Boost Software License, Version 1.0.
+//  See http://www.boost.org/LICENSE_1_0.txt)
+
+//  Library home page at http://www.boost.org/libs/filesystem
+
+//--------------------------------------------------------------------------------------//
+
+#include "stdafx.h"
+#include <autoboost/config/warning_disable.hpp>
+
+// define AUTOBOOST_FILESYSTEM_SOURCE so that <autoboost/filesystem/config.hpp> knows
+// the library is being built (possibly exporting rather than importing code)
+#define AUTOBOOST_FILESYSTEM_SOURCE
+
+#ifndef AUTOBOOST_SYSTEM_NO_DEPRECATED
+#  define AUTOBOOST_SYSTEM_NO_DEPRECATED
+#endif
+
+#include <autoboost/filesystem/config.hpp>
+#include <autoboost/filesystem/path_traits.hpp>
+#include <autoboost/system/error_code.hpp>
+#include <locale>
+#include <vector>
+#include <cstdlib>
+#include <cassert>
+
+//--------------------------------------------------------------------------------------//
+
+namespace
+{
+  class codecvt_error_cat : public autoboost::system::error_category
+  {
+  public:
+    codecvt_error_cat(){}
+    const char*   name() const AUTOBOOST_SYSTEM_NOEXCEPT;
+    std::string    message(int ev) const;
+  };
+
+  const char* codecvt_error_cat::name() const AUTOBOOST_SYSTEM_NOEXCEPT
+  {
+    return "codecvt";
+  }
+
+  std::string codecvt_error_cat::message(int ev) const
+  {
+    std::string str;
+    switch (ev)
+    {
+    case std::codecvt_base::ok:
+      str = "ok";
+      break;
+    case std::codecvt_base::partial:
+      str = "partial";
+      break;
+    case std::codecvt_base::error:
+      str = "error";
+      break;
+    case std::codecvt_base::noconv:
+      str = "noconv";
+      break;
+    default:
+      str = "unknown error";
+    }
+    return str;
+  }
+
+} // unnamed namespace
+
+namespace autoboost
+{
+  namespace filesystem
+  {
+
+    AUTOBOOST_FILESYSTEM_DECL const autoboost::system::error_category& codecvt_error_category()
+    {
+      static const codecvt_error_cat  codecvt_error_cat_const;
+      return codecvt_error_cat_const;
+    }
+
+  } // namespace filesystem
+} // namespace autoboost

--- a/contrib/autoboost/libs/filesystem/operations.cpp
+++ b/contrib/autoboost/libs/filesystem/operations.cpp
@@ -1,0 +1,2339 @@
+//  operations.cpp  --------------------------------------------------------------------//
+
+//  Copyright 2002-2009, 2014 Beman Dawes
+//  Copyright 2001 Dietmar Kuehl
+
+//  Distributed under the Boost Software License, Version 1.0.
+//  See http://www.boost.org/LICENSE_1_0.txt
+
+//  See library home page at http://www.boost.org/libs/filesystem
+
+//--------------------------------------------------------------------------------------//
+
+//  define 64-bit offset macros BEFORE including boost/config.hpp (see ticket #5355)
+#include "stdafx.h"
+#if !(defined(__HP_aCC) && defined(_ILP32) && !defined(_STATVFS_ACPP_PROBLEMS_FIXED))
+#define _FILE_OFFSET_BITS 64 // at worst, these defines may have no effect,
+#endif
+#if !defined(__PGI)
+#define __USE_FILE_OFFSET64 // but that is harmless on Windows and on POSIX
+      // 64-bit systems or on 32-bit systems which don't have files larger
+      // than can be represented by a traditional POSIX/UNIX off_t type.
+      // OTOH, defining them should kick in 64-bit off_t's (and thus
+      // st_size)on 32-bit systems that provide the Large File
+      // Support (LFS)interface, such as Linux, Solaris, and IRIX.
+      // The defines are given before any headers are included to
+      // ensure that they are available to all included headers.
+      // That is required at least on Solaris, and possibly on other
+      // systems as well.
+#else
+#define _FILE_OFFSET_BITS 64
+#endif
+
+// define AUTOBOOST_FILESYSTEM_SOURCE so that <autoboost/filesystem/config.hpp> knows
+// the library is being built (possibly exporting rather than importing code)
+#define AUTOBOOST_FILESYSTEM_SOURCE
+
+#ifndef AUTOBOOST_SYSTEM_NO_DEPRECATED
+# define AUTOBOOST_SYSTEM_NO_DEPRECATED
+#endif
+
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# define _POSIX_PTHREAD_SEMANTICS  // Sun readdir_r()needs this
+#endif
+
+#include <autoboost/filesystem/operations.hpp>
+#include <autoboost/scoped_array.hpp>
+#include <autoboost/detail/workaround.hpp>
+#include <vector>
+#include <cstdlib>     // for malloc, free
+#include <cstring>
+#include <cstdio>      // for remove, rename
+#if defined(__QNXNTO__)  // see ticket #5355
+# include <stdio.h>
+#endif
+#include <cerrno>
+
+#ifdef AUTOBOOST_FILEYSTEM_INCLUDE_IOSTREAM
+# include <iostream>
+#endif
+
+namespace fs = autoboost::filesystem;
+using autoboost::filesystem::path;
+using autoboost::filesystem::filesystem_error;
+using autoboost::filesystem::perms;
+using autoboost::system::error_code;
+using autoboost::system::error_category;
+using autoboost::system::system_category;
+using std::string;
+using std::wstring;
+
+# ifdef AUTOBOOST_POSIX_API
+
+#   include <sys/types.h>
+#   include <sys/stat.h>
+#   if !defined(__APPLE__) && !defined(__OpenBSD__) && !defined(__ANDROID__) \
+ && !defined(__VXWORKS__)
+#     include <sys/statvfs.h>
+#     define AUTOBOOST_STATVFS statvfs
+#     define AUTOBOOST_STATVFS_F_FRSIZE vfs.f_frsize
+#   else
+#     ifdef __OpenBSD__
+#       include <sys/param.h>
+#     elif defined(__ANDROID__)
+#       include <sys/vfs.h>
+#     endif
+#     if !defined(__VXWORKS__)
+#       include <sys/mount.h>
+#     endif
+#     define AUTOBOOST_STATVFS statfs
+#     define AUTOBOOST_STATVFS_F_FRSIZE static_cast<autoboost::uintmax_t>(vfs.f_bsize)
+#   endif
+#   include <dirent.h>
+#   include <unistd.h>
+#   include <fcntl.h>
+#   include <utime.h>
+#   include "limits.h"
+
+# else // AUTOBOOST_WINDOW_API
+
+#   if (defined(__MINGW32__) || defined(__CYGWIN__)) && !defined(WINVER)
+      // Versions of MinGW or Cygwin that support Filesystem V3 support at least WINVER 0x501.
+      // See MinGW's windef.h
+#     define WINVER 0x501
+#   endif
+#   include <io.h>
+#   include <windows.h>
+#   include <winnt.h>
+#   if !defined(_WIN32_WINNT)
+#     define  _WIN32_WINNT   0x0500
+#   endif
+#   if defined(__BORLANDC__) || defined(__MWERKS__)
+#     if defined(__BORLANDC__)
+        using std::time_t;
+#     endif
+#     include <utime.h>
+#   else
+#     include <sys/utime.h>
+#   endif
+
+//  REPARSE_DATA_BUFFER related definitions are found in ntifs.h, which is part of the
+//  Windows Device Driver Kit. Since that's inconvenient, the definitions are provided
+//  here. See http://msdn.microsoft.com/en-us/library/ms791514.aspx
+
+#if !defined(REPARSE_DATA_BUFFER_HEADER_SIZE)  // mingw winnt.h does provide the defs
+
+#define SYMLINK_FLAG_RELATIVE 1
+
+typedef struct _REPARSE_DATA_BUFFER {
+  ULONG  ReparseTag;
+  USHORT  ReparseDataLength;
+  USHORT  Reserved;
+  union {
+    struct {
+      USHORT  SubstituteNameOffset;
+      USHORT  SubstituteNameLength;
+      USHORT  PrintNameOffset;
+      USHORT  PrintNameLength;
+      ULONG  Flags;
+      WCHAR  PathBuffer[1];
+  /*  Example of distinction between substitute and print names:
+        mklink /d ldrive c:\
+        SubstituteName: c:\\??\
+        PrintName: c:\
+  */
+     } SymbolicLinkReparseBuffer;
+    struct {
+      USHORT  SubstituteNameOffset;
+      USHORT  SubstituteNameLength;
+      USHORT  PrintNameOffset;
+      USHORT  PrintNameLength;
+      WCHAR  PathBuffer[1];
+      } MountPointReparseBuffer;
+    struct {
+      UCHAR  DataBuffer[1];
+    } GenericReparseBuffer;
+  };
+} REPARSE_DATA_BUFFER, *PREPARSE_DATA_BUFFER;
+
+#define REPARSE_DATA_BUFFER_HEADER_SIZE \
+  FIELD_OFFSET(REPARSE_DATA_BUFFER, GenericReparseBuffer)
+
+#endif
+
+#ifndef MAXIMUM_REPARSE_DATA_BUFFER_SIZE
+#define MAXIMUM_REPARSE_DATA_BUFFER_SIZE  ( 16 * 1024 )
+#endif
+
+# ifndef FSCTL_GET_REPARSE_POINT
+#   define FSCTL_GET_REPARSE_POINT 0x900a8
+# endif
+
+# ifndef IO_REPARSE_TAG_SYMLINK
+#   define IO_REPARSE_TAG_SYMLINK (0xA000000CL)
+# endif
+
+inline std::wstring wgetenv(const wchar_t* name)
+{
+  // use vector since for C++03 basic_string is not required to be contiguous
+  std::vector<wchar_t> buf(::GetEnvironmentVariableW(name, NULL, 0));
+
+  // C++03 vector does not have data() so use &buf[0]
+  return (buf.empty()
+    || ::GetEnvironmentVariableW(name, &buf[0], static_cast<DWORD>(buf.size())) == 0)
+    ? std::wstring() : std::wstring(&buf[0]);
+}
+
+# endif  // AUTOBOOST_WINDOWS_API
+
+//  AUTOBOOST_FILESYSTEM_STATUS_CACHE enables file_status cache in
+//  dir_itr_increment. The config tests are placed here because some of the
+//  macros being tested come from dirent.h.
+//
+// TODO: find out what macros indicate dirent::d_type present in more libraries
+# if defined(AUTOBOOST_WINDOWS_API)\
+  || defined(_DIRENT_HAVE_D_TYPE)// defined by GNU C library if d_type present
+#   define AUTOBOOST_FILESYSTEM_STATUS_CACHE
+# endif
+
+//  POSIX/Windows macros  ----------------------------------------------------//
+
+//  Portions of the POSIX and Windows API's are very similar, except for name,
+//  order of arguments, and meaning of zero/non-zero returns. The macros below
+//  abstract away those differences. They follow Windows naming and order of
+//  arguments, and return true to indicate no error occurred. [POSIX naming,
+//  order of arguments, and meaning of return were followed initially, but
+//  found to be less clear and cause more coding errors.]
+
+# if defined(AUTOBOOST_POSIX_API)
+
+typedef int err_t;
+
+//  POSIX uses a 0 return to indicate success
+#   define AUTOBOOST_ERRNO    errno
+#   define AUTOBOOST_SET_CURRENT_DIRECTORY(P)(::chdir(P)== 0)
+#   define AUTOBOOST_CREATE_DIRECTORY(P)(::mkdir(P, S_IRWXU|S_IRWXG|S_IRWXO)== 0)
+#   define AUTOBOOST_CREATE_HARD_LINK(F,T)(::link(T, F)== 0)
+#   define AUTOBOOST_CREATE_SYMBOLIC_LINK(F,T,Flag)(::symlink(T, F)== 0)
+#   define AUTOBOOST_REMOVE_DIRECTORY(P)(::rmdir(P)== 0)
+#   define AUTOBOOST_DELETE_FILE(P)(::unlink(P)== 0)
+#   define AUTOBOOST_COPY_DIRECTORY(F,T)(!(::stat(from.c_str(), &from_stat)!= 0\
+         || ::mkdir(to.c_str(),from_stat.st_mode)!= 0))
+#   define AUTOBOOST_COPY_FILE(F,T,FailIfExistsBool)copy_file_api(F, T, FailIfExistsBool)
+#   define AUTOBOOST_MOVE_FILE(OLD,NEW)(::rename(OLD, NEW)== 0)
+#   define AUTOBOOST_RESIZE_FILE(P,SZ)(::truncate(P, SZ)== 0)
+
+#   define AUTOBOOST_ERROR_NOT_SUPPORTED ENOSYS
+#   define AUTOBOOST_ERROR_ALREADY_EXISTS EEXIST
+
+# else  // AUTOBOOST_WINDOWS_API
+
+typedef DWORD err_t;
+
+//  Windows uses a non-0 return to indicate success
+#   define AUTOBOOST_ERRNO    ::GetLastError()
+#   define AUTOBOOST_SET_CURRENT_DIRECTORY(P)(::SetCurrentDirectoryW(P)!= 0)
+#   define AUTOBOOST_CREATE_DIRECTORY(P)(::CreateDirectoryW(P, 0)!= 0)
+#   define AUTOBOOST_CREATE_HARD_LINK(F,T)(create_hard_link_api(F, T, 0)!= 0)
+#   define AUTOBOOST_CREATE_SYMBOLIC_LINK(F,T,Flag)(create_symbolic_link_api(F, T, Flag)!= 0)
+#   define AUTOBOOST_REMOVE_DIRECTORY(P)(::RemoveDirectoryW(P)!= 0)
+#   define AUTOBOOST_DELETE_FILE(P)(::DeleteFileW(P)!= 0)
+#   define AUTOBOOST_COPY_DIRECTORY(F,T)(::CreateDirectoryExW(F, T, 0)!= 0)
+#   define AUTOBOOST_COPY_FILE(F,T,FailIfExistsBool)(::CopyFileW(F, T, FailIfExistsBool)!= 0)
+#   define AUTOBOOST_MOVE_FILE(OLD,NEW)(::MoveFileExW(OLD, NEW, MOVEFILE_REPLACE_EXISTING|MOVEFILE_COPY_ALLOWED)!= 0)
+#   define AUTOBOOST_RESIZE_FILE(P,SZ)(resize_file_api(P, SZ)!= 0)
+#   define AUTOBOOST_READ_SYMLINK(P,T)
+
+#   define AUTOBOOST_ERROR_ALREADY_EXISTS ERROR_ALREADY_EXISTS
+#   define AUTOBOOST_ERROR_NOT_SUPPORTED ERROR_NOT_SUPPORTED
+
+# endif
+
+//--------------------------------------------------------------------------------------//
+//                                                                                      //
+//                        helpers (all operating systems)                               //
+//                                                                                      //
+//--------------------------------------------------------------------------------------//
+
+namespace
+{
+
+  fs::file_type query_file_type(const path& p, error_code* ec);
+
+  autoboost::filesystem::directory_iterator end_dir_itr;
+
+  //  error handling helpers  ----------------------------------------------------------//
+
+  bool error(err_t error_num, error_code* ec, const char* message);
+  bool error(err_t error_num, const path& p, error_code* ec, const char* message);
+  bool error(err_t error_num, const path& p1, const path& p2, error_code* ec,
+    const char* message);
+
+  const error_code ok;
+
+  //  error_num is value of errno on POSIX, error code (from ::GetLastError()) on Windows.
+  //  Interface changed 30 Jan 15 to have caller supply error_num as ::SetLastError()
+  //  values were apparently getting cleared before they could be retrieved by error().
+
+  bool error(err_t error_num, error_code* ec, const char* message)
+  {
+    if (!error_num)
+    {
+      if (ec != 0) ec->clear();
+    }
+    else
+    { //  error
+      if (ec == 0)
+        AUTOBOOST_FILESYSTEM_THROW(filesystem_error(message,
+          error_code(error_num, system_category())));
+      else
+        ec->assign(error_num, system_category());
+    }
+    return error_num != 0;
+  }
+
+  bool error(err_t error_num, const path& p, error_code* ec, const char* message)
+  {
+    if (!error_num)
+    {
+      if (ec != 0) ec->clear();
+    }
+    else
+    { //  error
+      if (ec == 0)
+        AUTOBOOST_FILESYSTEM_THROW(filesystem_error(message,
+          p, error_code(error_num, system_category())));
+      else
+        ec->assign(error_num, system_category());
+    }
+    return error_num != 0;
+  }
+
+  bool error(err_t error_num, const path& p1, const path& p2, error_code* ec,
+    const char* message)
+  {
+    if (!error_num)
+    {
+      if (ec != 0) ec->clear();
+    }
+    else
+    { //  error
+      if (ec == 0)
+        AUTOBOOST_FILESYSTEM_THROW(filesystem_error(message,
+          p1, p2, error_code(error_num, system_category())));
+      else
+        ec->assign(error_num, system_category());
+    }
+    return error_num != 0;
+  }
+
+  //  general helpers  -----------------------------------------------------------------//
+
+  bool is_empty_directory(const path& p)
+  {
+    return fs::directory_iterator(p)== end_dir_itr;
+  }
+
+  bool not_found_error(int errval); // forward declaration
+
+  // only called if directory exists
+  bool remove_directory(const path& p) // true if succeeds or not found
+  {
+    return AUTOBOOST_REMOVE_DIRECTORY(p.c_str())
+      || not_found_error(AUTOBOOST_ERRNO);  // mitigate possible file system race. See #11166
+  }
+
+  // only called if file exists
+  bool remove_file(const path& p) // true if succeeds or not found
+  {
+    return AUTOBOOST_DELETE_FILE(p.c_str())
+      || not_found_error(AUTOBOOST_ERRNO);  // mitigate possible file system race. See #11166
+  }
+
+  // called by remove and remove_all_aux
+  bool remove_file_or_directory(const path& p, fs::file_type type, error_code* ec)
+    // return true if file removed, false if not removed
+  {
+    if (type == fs::file_not_found)
+    {
+      if (ec != 0) ec->clear();
+      return false;
+    }
+
+    if (type == fs::directory_file
+#     ifdef AUTOBOOST_WINDOWS_API
+        || type == fs::_detail_directory_symlink
+#     endif
+      )
+    {
+      if (error(!remove_directory(p) ? AUTOBOOST_ERRNO : 0, p, ec,
+        "boost::filesystem::remove"))
+          return false;
+    }
+    else
+    {
+      if (error(!remove_file(p) ? AUTOBOOST_ERRNO : 0, p, ec,
+        "boost::filesystem::remove"))
+          return false;
+    }
+    return true;
+  }
+
+  autoboost::uintmax_t remove_all_aux(const path& p, fs::file_type type,
+    error_code* ec)
+  {
+    autoboost::uintmax_t count = 1;
+
+    if (type == fs::directory_file)  // but not a directory symlink
+    {
+      for (fs::directory_iterator itr(p);
+            itr != end_dir_itr; ++itr)
+      {
+        fs::file_type tmp_type = query_file_type(itr->path(), ec);
+        if (ec != 0 && *ec)
+          return count;
+        count += remove_all_aux(itr->path(), tmp_type, ec);
+      }
+    }
+    remove_file_or_directory(p, type, ec);
+    return count;
+  }
+
+#ifdef AUTOBOOST_POSIX_API
+
+//--------------------------------------------------------------------------------------//
+//                                                                                      //
+//                            POSIX-specific helpers                                    //
+//                                                                                      //
+//--------------------------------------------------------------------------------------//
+
+  const char dot = '.';
+
+  bool not_found_error(int errval)
+  {
+    return errno == ENOENT || errno == ENOTDIR;
+  }
+
+  bool // true if ok
+  copy_file_api(const std::string& from_p,
+    const std::string& to_p, bool fail_if_exists)
+  {
+    const std::size_t buf_sz = 32768;
+    autoboost::scoped_array<char> buf(new char [buf_sz]);
+    int infile=-1, outfile=-1;  // -1 means not open
+
+    // bug fixed: code previously did a stat()on the from_file first, but that
+    // introduced a gratuitous race condition; the stat()is now done after the open()
+
+    if ((infile = ::open(from_p.c_str(), O_RDONLY))< 0)
+      { return false; }
+
+    struct stat from_stat;
+    if (::stat(from_p.c_str(), &from_stat)!= 0)
+    {
+      ::close(infile);
+      return false;
+    }
+
+    int oflag = O_CREAT | O_WRONLY | O_TRUNC;
+    if (fail_if_exists)
+      oflag |= O_EXCL;
+    if ((outfile = ::open(to_p.c_str(), oflag, from_stat.st_mode))< 0)
+    {
+      int open_errno = errno;
+      AUTOBOOST_ASSERT(infile >= 0);
+      ::close(infile);
+      errno = open_errno;
+      return false;
+    }
+
+    ssize_t sz, sz_read=1, sz_write;
+    while (sz_read > 0
+      && (sz_read = ::read(infile, buf.get(), buf_sz)) > 0)
+    {
+      // Allow for partial writes - see Advanced Unix Programming (2nd Ed.),
+      // Marc Rochkind, Addison-Wesley, 2004, page 94
+      sz_write = 0;
+      do
+      {
+        AUTOBOOST_ASSERT(sz_read - sz_write > 0);  // #1
+          // ticket 4438 claimed possible infinite loop if write returns 0. My analysis
+          // is that POSIX specifies 0 return only if 3rd arg is 0, and that will never
+          // happen due to loop entry and coninuation conditions. AUTOBOOST_ASSERT #1 above
+          // and #2 below added to verify that analysis.
+        if ((sz = ::write(outfile, buf.get() + sz_write,
+          sz_read - sz_write)) < 0)
+        {
+          sz_read = sz; // cause read loop termination
+          break;        //  and error reported after closes
+        }
+        AUTOBOOST_ASSERT(sz > 0);                  // #2
+        sz_write += sz;
+      } while (sz_write < sz_read);
+    }
+
+    if (::close(infile)< 0)
+      sz_read = -1;
+    if (::close(outfile)< 0)
+      sz_read = -1;
+
+    return sz_read >= 0;
+  }
+
+  inline fs::file_type query_file_type(const path& p, error_code* ec)
+  {
+    return fs::detail::symlink_status(p, ec).type();
+  }
+
+# else
+
+//--------------------------------------------------------------------------------------//
+//                                                                                      //
+//                            Windows-specific helpers                                  //
+//                                                                                      //
+//--------------------------------------------------------------------------------------//
+
+  const std::size_t buf_size=128;
+
+  const wchar_t dot = L'.';
+
+  bool not_found_error(int errval)
+  {
+    return errval == ERROR_FILE_NOT_FOUND
+      || errval == ERROR_PATH_NOT_FOUND
+      || errval == ERROR_INVALID_NAME  // "tools/jam/src/:sys:stat.h", "//foo"
+      || errval == ERROR_INVALID_DRIVE  // USB card reader with no card inserted
+      || errval == ERROR_NOT_READY  // CD/DVD drive with no disc inserted
+      || errval == ERROR_INVALID_PARAMETER  // ":sys:stat.h"
+      || errval == ERROR_BAD_PATHNAME  // "//nosuch" on Win64
+      || errval == ERROR_BAD_NETPATH;  // "//nosuch" on Win32
+  }
+
+// some distributions of mingw as early as GLIBCXX__ 20110325 have _stricmp, but the
+// offical 4.6.2 release with __GLIBCXX__ 20111026  doesn't. Play it safe for now, and
+// only use _stricmp if _MSC_VER is defined
+#if defined(_MSC_VER) // || (defined(__GLIBCXX__) && __GLIBCXX__ >= 20110325)
+#  define AUTOBOOST_FILESYSTEM_STRICMP _stricmp
+#else
+#  define AUTOBOOST_FILESYSTEM_STRICMP strcmp
+#endif
+
+  perms make_permissions(const path& p, DWORD attr)
+  {
+    perms prms = fs::owner_read | fs::group_read | fs::others_read;
+    if  ((attr & FILE_ATTRIBUTE_READONLY) == 0)
+      prms |= fs::owner_write | fs::group_write | fs::others_write;
+    if (AUTOBOOST_FILESYSTEM_STRICMP(p.extension().string().c_str(), ".exe") == 0
+      || AUTOBOOST_FILESYSTEM_STRICMP(p.extension().string().c_str(), ".com") == 0
+      || AUTOBOOST_FILESYSTEM_STRICMP(p.extension().string().c_str(), ".bat") == 0
+      || AUTOBOOST_FILESYSTEM_STRICMP(p.extension().string().c_str(), ".cmd") == 0)
+      prms |= fs::owner_exe | fs::group_exe | fs::others_exe;
+    return prms;
+  }
+
+  // these constants come from inspecting some Microsoft sample code
+  std::time_t to_time_t(const FILETIME & ft)
+  {
+    __int64 t = (static_cast<__int64>(ft.dwHighDateTime)<< 32)
+      + ft.dwLowDateTime;
+#   if !defined(AUTOBOOST_MSVC) || AUTOBOOST_MSVC > 1300 // > VC++ 7.0
+    t -= 116444736000000000LL;
+#   else
+    t -= 116444736000000000;
+#   endif
+    t /= 10000000;
+    return static_cast<std::time_t>(t);
+  }
+
+  void to_FILETIME(std::time_t t, FILETIME & ft)
+  {
+    __int64 temp = t;
+    temp *= 10000000;
+#   if !defined(AUTOBOOST_MSVC) || AUTOBOOST_MSVC > 1300 // > VC++ 7.0
+    temp += 116444736000000000LL;
+#   else
+    temp += 116444736000000000;
+#   endif
+    ft.dwLowDateTime = static_cast<DWORD>(temp);
+    ft.dwHighDateTime = static_cast<DWORD>(temp >> 32);
+  }
+
+  // Thanks to Jeremy Maitin-Shepard for much help and for permission to
+  // base the equivalent()implementation on portions of his
+  // file-equivalence-win32.cpp experimental code.
+
+  struct handle_wrapper
+  {
+    HANDLE handle;
+    handle_wrapper(HANDLE h)
+      : handle(h){}
+    ~handle_wrapper()
+    {
+      if (handle != INVALID_HANDLE_VALUE)
+        ::CloseHandle(handle);
+    }
+  };
+
+  HANDLE create_file_handle(const path& p, DWORD dwDesiredAccess,
+    DWORD dwShareMode, LPSECURITY_ATTRIBUTES lpSecurityAttributes,
+    DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes,
+    HANDLE hTemplateFile)
+  {
+    return ::CreateFileW(p.c_str(), dwDesiredAccess, dwShareMode,
+      lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes,
+      hTemplateFile);
+  }
+
+  bool is_reparse_point_a_symlink(const path& p)
+  {
+    handle_wrapper h(create_file_handle(p, FILE_READ_EA,
+      FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING,
+      FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, NULL));
+    if (h.handle == INVALID_HANDLE_VALUE)
+      return false;
+
+    autoboost::scoped_array<char> buf(new char [MAXIMUM_REPARSE_DATA_BUFFER_SIZE]);
+
+    // Query the reparse data
+    DWORD dwRetLen;
+    BOOL result = ::DeviceIoControl(h.handle, FSCTL_GET_REPARSE_POINT, NULL, 0, buf.get(),
+      MAXIMUM_REPARSE_DATA_BUFFER_SIZE, &dwRetLen, NULL);
+    if (!result) return false;
+
+    return reinterpret_cast<const REPARSE_DATA_BUFFER*>(buf.get())->ReparseTag
+        == IO_REPARSE_TAG_SYMLINK
+        // Issue 9016 asked that NTFS directory junctions be recognized as directories.
+        // That is equivalent to recognizing them as symlinks, and then the normal symlink
+        // mechanism will take care of recognizing them as directories.
+        //
+        // Directory junctions are very similar to symlinks, but have some performance
+        // and other advantages over symlinks. They can be created from the command line
+        // with "mklink /j junction-name target-path".
+      || reinterpret_cast<const REPARSE_DATA_BUFFER*>(buf.get())->ReparseTag
+        == IO_REPARSE_TAG_MOUNT_POINT;  // aka "directory junction" or "junction"
+  }
+
+  inline std::size_t get_full_path_name(
+    const path& src, std::size_t len, wchar_t* buf, wchar_t** p)
+  {
+    return static_cast<std::size_t>(
+      ::GetFullPathNameW(src.c_str(), static_cast<DWORD>(len), buf, p));
+  }
+
+  fs::file_status process_status_failure(const path& p, error_code* ec)
+  {
+    int errval(::GetLastError());
+    if (ec != 0)                             // always report errval, even though some
+      ec->assign(errval, system_category());   // errval values are not status_errors
+
+    if (not_found_error(errval))
+    {
+      return fs::file_status(fs::file_not_found, fs::no_perms);
+    }
+    else if ((errval == ERROR_SHARING_VIOLATION))
+    {
+      return fs::file_status(fs::type_unknown);
+    }
+    if (ec == 0)
+      AUTOBOOST_FILESYSTEM_THROW(filesystem_error("boost::filesystem::status",
+        p, error_code(errval, system_category())));
+    return fs::file_status(fs::status_error);
+  }
+
+  //  differs from symlink_status() in that directory symlinks are reported as
+  //  _detail_directory_symlink, as required on Windows by remove() and its helpers.
+  fs::file_type query_file_type(const path& p, error_code* ec)
+  {
+    DWORD attr(::GetFileAttributesW(p.c_str()));
+    if (attr == 0xFFFFFFFF)
+    {
+      return process_status_failure(p, ec).type();
+    }
+
+    if (ec != 0) ec->clear();
+
+    if (attr & FILE_ATTRIBUTE_REPARSE_POINT)
+    {
+      if (is_reparse_point_a_symlink(p))
+        return (attr & FILE_ATTRIBUTE_DIRECTORY)
+          ? fs::_detail_directory_symlink
+          : fs::symlink_file;
+      return fs::reparse_file;
+    }
+
+    return (attr & FILE_ATTRIBUTE_DIRECTORY)
+      ? fs::directory_file
+      : fs::regular_file;
+  }
+
+  BOOL resize_file_api(const wchar_t* p, autoboost::uintmax_t size)
+  {
+    handle_wrapper h(CreateFileW(p, GENERIC_WRITE, 0, 0, OPEN_EXISTING,
+                                FILE_ATTRIBUTE_NORMAL, 0));
+    LARGE_INTEGER sz;
+    sz.QuadPart = size;
+    return h.handle != INVALID_HANDLE_VALUE
+      && ::SetFilePointerEx(h.handle, sz, 0, FILE_BEGIN)
+      && ::SetEndOfFile(h.handle);
+  }
+
+  //  Windows kernel32.dll functions that may or may not be present
+  //  must be accessed through pointers
+
+  typedef BOOL (WINAPI *PtrCreateHardLinkW)(
+    /*__in*/       LPCWSTR lpFileName,
+    /*__in*/       LPCWSTR lpExistingFileName,
+    /*__reserved*/ LPSECURITY_ATTRIBUTES lpSecurityAttributes
+   );
+
+  PtrCreateHardLinkW create_hard_link_api = PtrCreateHardLinkW(
+    ::GetProcAddress(
+      ::GetModuleHandle(TEXT("kernel32.dll")), "CreateHardLinkW"));
+
+  typedef BOOLEAN (WINAPI *PtrCreateSymbolicLinkW)(
+    /*__in*/ LPCWSTR lpSymlinkFileName,
+    /*__in*/ LPCWSTR lpTargetFileName,
+    /*__in*/ DWORD dwFlags
+   );
+
+  PtrCreateSymbolicLinkW create_symbolic_link_api = PtrCreateSymbolicLinkW(
+    ::GetProcAddress(
+      ::GetModuleHandle(TEXT("kernel32.dll")), "CreateSymbolicLinkW"));
+
+#endif
+
+//#ifdef AUTOBOOST_WINDOWS_API
+//
+//
+//  inline bool get_free_disk_space(const std::wstring& ph,
+//    PULARGE_INTEGER avail, PULARGE_INTEGER total, PULARGE_INTEGER free)
+//    { return ::GetDiskFreeSpaceExW(ph.c_str(), avail, total, free)!= 0; }
+//
+//#endif
+
+} // unnamed namespace
+
+//--------------------------------------------------------------------------------------//
+//                                                                                      //
+//                operations functions declared in operations.hpp                       //
+//                            in alphabetic order                                       //
+//                                                                                      //
+//--------------------------------------------------------------------------------------//
+
+namespace autoboost
+{
+namespace filesystem
+{
+
+  AUTOBOOST_FILESYSTEM_DECL
+  path absolute(const path& p, const path& base)
+  {
+//    if ( p.empty() || p.is_absolute() )
+//      return p;
+//    //  recursively calling absolute is sub-optimal, but is simple
+//    path abs_base(base.is_absolute() ? base : absolute(base));
+//# ifdef AUTOBOOST_WINDOWS_API
+//    if (p.has_root_directory())
+//      return abs_base.root_name() / p;
+//    //  !p.has_root_directory
+//    if (p.has_root_name())
+//      return p.root_name()
+//        / abs_base.root_directory() / abs_base.relative_path() / p.relative_path();
+//    //  !p.has_root_name()
+//# endif
+//    return abs_base / p;
+
+    //  recursively calling absolute is sub-optimal, but is sure and simple
+    path abs_base(base.is_absolute() ? base : absolute(base));
+
+    //  store expensive to compute values that are needed multiple times
+    path p_root_name (p.root_name());
+    path base_root_name (abs_base.root_name());
+    path p_root_directory (p.root_directory());
+
+    if (p.empty())
+      return abs_base;
+
+    if (!p_root_name.empty())  // p.has_root_name()
+    {
+      if (p_root_directory.empty())  // !p.has_root_directory()
+        return p_root_name / abs_base.root_directory()
+        / abs_base.relative_path() / p.relative_path();
+      // p is absolute, so fall through to return p at end of block
+    }
+
+    else if (!p_root_directory.empty())  // p.has_root_directory()
+    {
+#     ifdef AUTOBOOST_POSIX_API
+      // POSIX can have root name it it is a network path
+      if (base_root_name.empty())   // !abs_base.has_root_name()
+        return p;
+#     endif
+      return base_root_name / p;
+    }
+
+    else
+    {
+      return abs_base / p;
+    }
+
+    return p;  // p.is_absolute() is true
+  }
+
+namespace detail
+{
+  AUTOBOOST_FILESYSTEM_DECL bool possible_large_file_size_support()
+  {
+#   ifdef AUTOBOOST_POSIX_API
+    struct stat lcl_stat;
+    return sizeof(lcl_stat.st_size)> 4;
+#   else
+    return true;
+#   endif
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  path canonical(const path& p, const path& base, system::error_code* ec)
+  {
+    path source (p.is_absolute() ? p : absolute(p, base));
+    path root(source.root_path());
+    path result;
+
+    system::error_code local_ec;
+    file_status stat (status(source, local_ec));
+
+    if (stat.type() == fs::file_not_found)
+    {
+      if (ec == 0)
+        AUTOBOOST_FILESYSTEM_THROW(filesystem_error(
+          "boost::filesystem::canonical", source,
+          error_code(system::errc::no_such_file_or_directory, system::generic_category())));
+      ec->assign(system::errc::no_such_file_or_directory, system::generic_category());
+      return result;
+    }
+    else if (local_ec)
+    {
+      if (ec == 0)
+        AUTOBOOST_FILESYSTEM_THROW(filesystem_error(
+          "boost::filesystem::canonical", source, local_ec));
+      *ec = local_ec;
+      return result;
+    }
+
+    bool scan (true);
+    while (scan)
+    {
+      scan = false;
+      result.clear();
+      for (path::iterator itr = source.begin(); itr != source.end(); ++itr)
+      {
+        if (*itr == dot_path())
+          continue;
+        if (*itr == dot_dot_path())
+        {
+          if (result != root)
+            result.remove_filename();
+          continue;
+        }
+
+        result /= *itr;
+
+        bool is_sym (is_symlink(detail::symlink_status(result, ec)));
+        if (ec && *ec)
+          return path();
+
+        if (is_sym)
+        {
+          path link(detail::read_symlink(result, ec));
+          if (ec && *ec)
+            return path();
+          result.remove_filename();
+
+          if (link.is_absolute())
+          {
+            for (++itr; itr != source.end(); ++itr)
+              link /= *itr;
+            source = link;
+          }
+          else // link is relative
+          {
+            path new_source(result);
+            new_source /= link;
+            for (++itr; itr != source.end(); ++itr)
+              new_source /= *itr;
+            source = new_source;
+          }
+          scan = true;  // symlink causes scan to be restarted
+          break;
+        }
+      }
+    }
+    if (ec != 0)
+      ec->clear();
+    AUTOBOOST_ASSERT_MSG(result.is_absolute(), "canonical() implementation error; please report");
+    return result;
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  void copy(const path& from, const path& to, system::error_code* ec)
+  {
+    file_status s(symlink_status(from, *ec));
+    if (ec != 0 && *ec) return;
+
+    if(is_symlink(s))
+    {
+      copy_symlink(from, to, *ec);
+    }
+    else if(is_directory(s))
+    {
+      copy_directory(from, to, *ec);
+    }
+    else if(is_regular_file(s))
+    {
+      copy_file(from, to, fs::copy_option::fail_if_exists, *ec);
+    }
+    else
+    {
+      if (ec == 0)
+        AUTOBOOST_FILESYSTEM_THROW(filesystem_error("boost::filesystem::copy",
+          from, to, error_code(AUTOBOOST_ERROR_NOT_SUPPORTED, system_category())));
+      ec->assign(AUTOBOOST_ERROR_NOT_SUPPORTED, system_category());
+    }
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  void copy_directory(const path& from, const path& to, system::error_code* ec)
+  {
+#   ifdef AUTOBOOST_POSIX_API
+    struct stat from_stat;
+#   endif
+    error(!AUTOBOOST_COPY_DIRECTORY(from.c_str(), to.c_str()) ? AUTOBOOST_ERRNO : 0,
+      from, to, ec, "boost::filesystem::copy_directory");
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  void copy_file(const path& from, const path& to, copy_option option, error_code* ec)
+  {
+    error(!AUTOBOOST_COPY_FILE(from.c_str(), to.c_str(),
+      option == fail_if_exists) ? AUTOBOOST_ERRNO : 0,
+        from, to, ec, "boost::filesystem::copy_file");
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  void copy_symlink(const path& existing_symlink, const path& new_symlink,
+    system::error_code* ec)
+  {
+# if defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0600
+    error(AUTOBOOST_ERROR_NOT_SUPPORTED, new_symlink, existing_symlink, ec,
+      "boost::filesystem::copy_symlink");
+
+# else  // modern Windows or AUTOBOOST_POSIX_API
+    path p(read_symlink(existing_symlink, ec));
+    if (ec != 0 && *ec) return;
+    create_symlink(p, new_symlink, ec);
+
+# endif
+  }
+
+ AUTOBOOST_FILESYSTEM_DECL
+  bool create_directories(const path& p, system::error_code* ec)
+  {
+    if (p.filename_is_dot() || p.filename_is_dot_dot())
+      return create_directories(p.parent_path(), ec);
+
+    error_code local_ec;
+    file_status p_status = status(p, local_ec);
+
+    if (p_status.type() == directory_file)
+    {
+      if (ec != 0)
+        ec->clear();
+      return false;
+    }
+
+    path parent = p.parent_path();
+    AUTOBOOST_ASSERT_MSG(parent != p, "internal error: p == p.parent_path()");
+    if (!parent.empty())
+    {
+      // determine if the parent exists
+      file_status parent_status = status(parent, local_ec);
+
+      // if the parent does not exist, create the parent
+      if (parent_status.type() == file_not_found)
+      {
+        create_directories(parent, local_ec);
+        if (local_ec)
+        {
+          if (ec == 0)
+            AUTOBOOST_FILESYSTEM_THROW(filesystem_error(
+              "boost::filesystem::create_directories", parent, local_ec));
+          else
+            *ec = local_ec;
+          return false;
+        }
+      }
+    }
+
+    // create the directory
+    return create_directory(p, ec);
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  bool create_directory(const path& p, error_code* ec)
+  {
+    if (AUTOBOOST_CREATE_DIRECTORY(p.c_str()))
+    {
+      if (ec != 0)
+        ec->clear();
+      return true;
+    }
+
+    //  attempt to create directory failed
+    int errval(AUTOBOOST_ERRNO);  // save reason for failure
+    error_code dummy;
+    if (errval == AUTOBOOST_ERROR_ALREADY_EXISTS && is_directory(p, dummy))
+    {
+      if (ec != 0)
+        ec->clear();
+      return false;
+    }
+
+    //  attempt to create directory failed && it doesn't already exist
+    if (ec == 0)
+      AUTOBOOST_FILESYSTEM_THROW(filesystem_error("boost::filesystem::create_directory",
+        p, error_code(errval, system_category())));
+    else
+      ec->assign(errval, system_category());
+    return false;
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  void create_directory_symlink(const path& to, const path& from,
+                                 system::error_code* ec)
+  {
+#   if defined(AUTOBOOST_WINDOWS_API) && _WIN32_WINNT < 0x0600  // SDK earlier than Vista and Server 2008
+
+    error(AUTOBOOST_ERROR_NOT_SUPPORTED, to, from, ec,
+      "boost::filesystem::create_directory_symlink");
+#   else
+
+#     if defined(AUTOBOOST_WINDOWS_API) && _WIN32_WINNT >= 0x0600
+        // see if actually supported by Windows runtime dll
+        if (error(!create_symbolic_link_api ? AUTOBOOST_ERROR_NOT_SUPPORTED : 0, to, from, ec,
+            "boost::filesystem::create_directory_symlink"))
+          return;
+#     endif
+
+    error(!AUTOBOOST_CREATE_SYMBOLIC_LINK(from.c_str(), to.c_str(),
+      SYMBOLIC_LINK_FLAG_DIRECTORY) ? AUTOBOOST_ERRNO : 0,
+      to, from, ec, "boost::filesystem::create_directory_symlink");
+#   endif
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  void create_hard_link(const path& to, const path& from, error_code* ec)
+  {
+
+#   if defined(AUTOBOOST_WINDOWS_API) && _WIN32_WINNT < 0x0500  // SDK earlier than Win 2K
+
+    error(AUTOBOOST_ERROR_NOT_SUPPORTED, to, from, ec,
+      "boost::filesystem::create_hard_link");
+#   else
+
+#     if defined(AUTOBOOST_WINDOWS_API) && _WIN32_WINNT >= 0x0500
+        // see if actually supported by Windows runtime dll
+        if (error(!create_hard_link_api ? AUTOBOOST_ERROR_NOT_SUPPORTED : 0, to, from, ec,
+            "boost::filesystem::create_hard_link"))
+          return;
+#     endif
+
+    error(!AUTOBOOST_CREATE_HARD_LINK(from.c_str(), to.c_str()) ? AUTOBOOST_ERRNO : 0, to, from, ec,
+      "boost::filesystem::create_hard_link");
+#   endif
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  void create_symlink(const path& to, const path& from, error_code* ec)
+  {
+#   if defined(AUTOBOOST_WINDOWS_API) && _WIN32_WINNT < 0x0600  // SDK earlier than Vista and Server 2008
+    error(AUTOBOOST_ERROR_NOT_SUPPORTED, to, from, ec,
+      "boost::filesystem::create_directory_symlink");
+#   else
+
+#     if defined(AUTOBOOST_WINDOWS_API) && _WIN32_WINNT >= 0x0600
+        // see if actually supported by Windows runtime dll
+        if (error(!create_symbolic_link_api ? AUTOBOOST_ERROR_NOT_SUPPORTED : 0, to, from, ec,
+            "boost::filesystem::create_symlink"))
+          return;
+#     endif
+
+    error(!AUTOBOOST_CREATE_SYMBOLIC_LINK(from.c_str(), to.c_str(), 0) ? AUTOBOOST_ERRNO : 0,
+      to, from, ec, "boost::filesystem::create_symlink");
+#   endif
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  path current_path(error_code* ec)
+  {
+#   ifdef AUTOBOOST_POSIX_API
+    path cur;
+    for (long path_max = 128;; path_max *=2)// loop 'til buffer large enough
+    {
+      autoboost::scoped_array<char>
+        buf(new char[static_cast<std::size_t>(path_max)]);
+      if (::getcwd(buf.get(), static_cast<std::size_t>(path_max))== 0)
+      {
+        if (error(errno != ERANGE ? errno : 0
+      // bug in some versions of the Metrowerks C lib on the Mac: wrong errno set
+#         if defined(__MSL__) && (defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__))
+          && errno != 0
+#         endif
+          , ec, "boost::filesystem::current_path"))
+        {
+          break;
+        }
+      }
+      else
+      {
+        cur = buf.get();
+        if (ec != 0) ec->clear();
+        break;
+      }
+    }
+    return cur;
+
+#   else
+    DWORD sz;
+    if ((sz = ::GetCurrentDirectoryW(0, NULL)) == 0)sz = 1;
+    autoboost::scoped_array<path::value_type> buf(new path::value_type[sz]);
+    error(::GetCurrentDirectoryW(sz, buf.get()) == 0 ? AUTOBOOST_ERRNO : 0, ec,
+      "boost::filesystem::current_path");
+    return path(buf.get());
+#   endif
+  }
+
+
+  AUTOBOOST_FILESYSTEM_DECL
+  void current_path(const path& p, system::error_code* ec)
+  {
+    error(!AUTOBOOST_SET_CURRENT_DIRECTORY(p.c_str()) ? AUTOBOOST_ERRNO : 0,
+      p, ec, "boost::filesystem::current_path");
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  bool equivalent(const path& p1, const path& p2, system::error_code* ec)
+  {
+#   ifdef AUTOBOOST_POSIX_API
+    struct stat s2;
+    int e2(::stat(p2.c_str(), &s2));
+    struct stat s1;
+    int e1(::stat(p1.c_str(), &s1));
+
+    if (e1 != 0 || e2 != 0)
+    {
+      // if one is invalid and the other isn't then they aren't equivalent,
+      // but if both are invalid then it is an error
+      error (e1 != 0 && e2 != 0, p1, p2, ec, "boost::filesystem::equivalent");
+      return false;
+    }
+
+    // both stats now known to be valid
+    return  s1.st_dev == s2.st_dev && s1.st_ino == s2.st_ino
+        // According to the POSIX stat specs, "The st_ino and st_dev fields
+        // taken together uniquely identify the file within the system."
+        // Just to be sure, size and mod time are also checked.
+        && s1.st_size == s2.st_size && s1.st_mtime == s2.st_mtime;
+
+#   else  // Windows
+
+    // Note well: Physical location on external media is part of the
+    // equivalence criteria. If there are no open handles, physical location
+    // can change due to defragmentation or other relocations. Thus handles
+    // must be held open until location information for both paths has
+    // been retrieved.
+
+    // p2 is done first, so any error reported is for p1
+    handle_wrapper h2(
+      create_file_handle(
+          p2.c_str(),
+          0,
+          FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+          0,
+          OPEN_EXISTING,
+          FILE_FLAG_BACKUP_SEMANTICS,
+          0));
+
+    handle_wrapper h1(
+      create_file_handle(
+          p1.c_str(),
+          0,
+          FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+          0,
+          OPEN_EXISTING,
+          FILE_FLAG_BACKUP_SEMANTICS,
+          0));
+
+    if (h1.handle == INVALID_HANDLE_VALUE
+      || h2.handle == INVALID_HANDLE_VALUE)
+    {
+      // if one is invalid and the other isn't, then they aren't equivalent,
+      // but if both are invalid then it is an error
+      error((h1.handle == INVALID_HANDLE_VALUE
+        && h2.handle == INVALID_HANDLE_VALUE) ? AUTOBOOST_ERROR_NOT_SUPPORTED : 0, p1, p2, ec,
+          "boost::filesystem::equivalent");
+      return false;
+    }
+
+    // at this point, both handles are known to be valid
+
+    BY_HANDLE_FILE_INFORMATION info1, info2;
+
+    if (error(!::GetFileInformationByHandle(h1.handle, &info1) ? AUTOBOOST_ERRNO : 0,
+      p1, p2, ec, "boost::filesystem::equivalent"))
+        return  false;
+
+    if (error(!::GetFileInformationByHandle(h2.handle, &info2) ? AUTOBOOST_ERRNO : 0,
+      p1, p2, ec, "boost::filesystem::equivalent"))
+        return  false;
+
+    // In theory, volume serial numbers are sufficient to distinguish between
+    // devices, but in practice VSN's are sometimes duplicated, so last write
+    // time and file size are also checked.
+      return
+        info1.dwVolumeSerialNumber == info2.dwVolumeSerialNumber
+        && info1.nFileIndexHigh == info2.nFileIndexHigh
+        && info1.nFileIndexLow == info2.nFileIndexLow
+        && info1.nFileSizeHigh == info2.nFileSizeHigh
+        && info1.nFileSizeLow == info2.nFileSizeLow
+        && info1.ftLastWriteTime.dwLowDateTime
+          == info2.ftLastWriteTime.dwLowDateTime
+        && info1.ftLastWriteTime.dwHighDateTime
+          == info2.ftLastWriteTime.dwHighDateTime;
+
+#   endif
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  autoboost::uintmax_t file_size(const path& p, error_code* ec)
+  {
+#   ifdef AUTOBOOST_POSIX_API
+
+    struct stat path_stat;
+    if (error(::stat(p.c_str(), &path_stat)!= 0 ? AUTOBOOST_ERRNO : 0,
+        p, ec, "boost::filesystem::file_size"))
+      return static_cast<autoboost::uintmax_t>(-1);
+   if (error(!S_ISREG(path_stat.st_mode) ? EPERM : 0,
+        p, ec, "boost::filesystem::file_size"))
+      return static_cast<autoboost::uintmax_t>(-1);
+
+    return static_cast<autoboost::uintmax_t>(path_stat.st_size);
+
+#   else  // Windows
+
+    // assume uintmax_t is 64-bits on all Windows compilers
+
+    WIN32_FILE_ATTRIBUTE_DATA fad;
+
+    if (error(::GetFileAttributesExW(p.c_str(), ::GetFileExInfoStandard, &fad)== 0
+      ? AUTOBOOST_ERRNO : 0, p, ec, "boost::filesystem::file_size"))
+          return static_cast<autoboost::uintmax_t>(-1);
+
+    if (error((fad.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)!= 0
+      ? ERROR_NOT_SUPPORTED : 0, p, ec, "boost::filesystem::file_size"))
+      return static_cast<autoboost::uintmax_t>(-1);
+
+    return (static_cast<autoboost::uintmax_t>(fad.nFileSizeHigh)
+              << (sizeof(fad.nFileSizeLow)*8)) + fad.nFileSizeLow;
+#   endif
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  autoboost::uintmax_t hard_link_count(const path& p, system::error_code* ec)
+  {
+#   ifdef AUTOBOOST_POSIX_API
+
+    struct stat path_stat;
+    return error(::stat(p.c_str(), &path_stat)!= 0 ? AUTOBOOST_ERRNO : 0,
+                  p, ec, "boost::filesystem::hard_link_count")
+           ? 0
+           : static_cast<autoboost::uintmax_t>(path_stat.st_nlink);
+
+#   else // Windows
+
+    // Link count info is only available through GetFileInformationByHandle
+    BY_HANDLE_FILE_INFORMATION info;
+    handle_wrapper h(
+      create_file_handle(p.c_str(), 0,
+          FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE, 0,
+          OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, 0));
+    return
+      !error(h.handle == INVALID_HANDLE_VALUE ? AUTOBOOST_ERRNO : 0,
+              p, ec, "boost::filesystem::hard_link_count")
+      && !error(::GetFileInformationByHandle(h.handle, &info)== 0 ? AUTOBOOST_ERRNO : 0,
+                 p, ec, "boost::filesystem::hard_link_count")
+           ? info.nNumberOfLinks
+           : 0;
+#   endif
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  path initial_path(error_code* ec)
+  {
+      static path init_path;
+      if (init_path.empty())
+        init_path = current_path(ec);
+      else if (ec != 0) ec->clear();
+      return init_path;
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  bool is_empty(const path& p, system::error_code* ec)
+  {
+#   ifdef AUTOBOOST_POSIX_API
+
+    struct stat path_stat;
+    if (error(::stat(p.c_str(), &path_stat)!= 0,
+        p, ec, "boost::filesystem::is_empty"))
+      return false;
+    return S_ISDIR(path_stat.st_mode)
+      ? is_empty_directory(p)
+      : path_stat.st_size == 0;
+#   else
+
+    WIN32_FILE_ATTRIBUTE_DATA fad;
+    if (error(::GetFileAttributesExW(p.c_str(), ::GetFileExInfoStandard, &fad)== 0
+      ? AUTOBOOST_ERRNO : 0, p, ec, "boost::filesystem::is_empty"))
+        return false;
+
+    if (ec != 0) ec->clear();
+    return
+      (fad.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+        ? is_empty_directory(p)
+        : (!fad.nFileSizeHigh && !fad.nFileSizeLow);
+#   endif
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  std::time_t last_write_time(const path& p, system::error_code* ec)
+  {
+#   ifdef AUTOBOOST_POSIX_API
+
+    struct stat path_stat;
+    if (error(::stat(p.c_str(), &path_stat)!= 0 ? AUTOBOOST_ERRNO : 0,
+      p, ec, "boost::filesystem::last_write_time"))
+        return std::time_t(-1);
+    return path_stat.st_mtime;
+
+#   else
+
+    handle_wrapper hw(
+      create_file_handle(p.c_str(), 0,
+        FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE, 0,
+        OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, 0));
+
+    if (error(hw.handle == INVALID_HANDLE_VALUE ? AUTOBOOST_ERRNO : 0,
+      p, ec, "boost::filesystem::last_write_time"))
+        return std::time_t(-1);
+
+    FILETIME lwt;
+
+    if (error(::GetFileTime(hw.handle, 0, 0, &lwt)== 0 ? AUTOBOOST_ERRNO : 0,
+      p, ec, "boost::filesystem::last_write_time"))
+        return std::time_t(-1);
+
+    return to_time_t(lwt);
+#   endif
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  void last_write_time(const path& p, const std::time_t new_time,
+                        system::error_code* ec)
+  {
+#   ifdef AUTOBOOST_POSIX_API
+
+    struct stat path_stat;
+    if (error(::stat(p.c_str(), &path_stat)!= 0,
+      p, ec, "boost::filesystem::last_write_time"))
+        return;
+    ::utimbuf buf;
+    buf.actime = path_stat.st_atime; // utime()updates access time too:-(
+    buf.modtime = new_time;
+    error(::utime(p.c_str(), &buf)!= 0 ? AUTOBOOST_ERRNO : 0,
+      p, ec, "boost::filesystem::last_write_time");
+
+#   else
+
+    handle_wrapper hw(
+      create_file_handle(p.c_str(), FILE_WRITE_ATTRIBUTES,
+        FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE, 0,
+        OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, 0));
+
+    if (error(hw.handle == INVALID_HANDLE_VALUE ? AUTOBOOST_ERRNO : 0,
+      p, ec, "boost::filesystem::last_write_time"))
+        return;
+
+    FILETIME lwt;
+    to_FILETIME(new_time, lwt);
+
+    error(::SetFileTime(hw.handle, 0, 0, &lwt)== 0 ? AUTOBOOST_ERRNO : 0,
+      p, ec, "boost::filesystem::last_write_time");
+#   endif
+  }
+
+# ifdef AUTOBOOST_POSIX_API
+    const perms active_bits(all_all | set_uid_on_exe | set_gid_on_exe | sticky_bit);
+    inline mode_t mode_cast(perms prms) { return prms & active_bits; }
+# endif
+
+  AUTOBOOST_FILESYSTEM_DECL
+  void permissions(const path& p, perms prms, system::error_code* ec)
+  {
+    AUTOBOOST_ASSERT_MSG(!((prms & add_perms) && (prms & remove_perms)),
+      "add_perms and remove_perms are mutually exclusive");
+
+    if ((prms & add_perms) && (prms & remove_perms))  // precondition failed
+      return;
+
+# ifdef AUTOBOOST_POSIX_API
+    error_code local_ec;
+    file_status current_status((prms & symlink_perms)
+                               ? fs::symlink_status(p, local_ec)
+                               : fs::status(p, local_ec));
+    if (local_ec)
+    {
+      if (ec == 0)
+      AUTOBOOST_FILESYSTEM_THROW(filesystem_error(
+          "boost::filesystem::permissions", p, local_ec));
+      else
+        *ec = local_ec;
+      return;
+    }
+
+    if (prms & add_perms)
+      prms |= current_status.permissions();
+    else if (prms & remove_perms)
+      prms = current_status.permissions() & ~prms;
+
+    // OS X <10.10, iOS <8.0 and some other platforms don't support fchmodat().
+    // Solaris (SunPro and gcc) only support fchmodat() on Solaris 11 and higher,
+    // and a runtime check is too much trouble.
+    // Linux does not support permissions on symbolic links and has no plans to
+    // support them in the future.  The chmod() code is thus more practical,
+    // rather than always hitting ENOTSUP when sending in AT_SYMLINK_NO_FOLLOW.
+    //  - See the 3rd paragraph of
+    // "Symbolic link ownership, permissions, and timestamps" at:
+    //   "http://man7.org/linux/man-pages/man7/symlink.7.html"
+    //  - See the fchmodat() Linux man page:
+    //   "http://man7.org/linux/man-pages/man2/fchmodat.2.html"
+#   if defined(AT_FDCWD) && defined(AT_SYMLINK_NOFOLLOW) \
+      && !(defined(__SUNPRO_CC) || defined(__sun) || defined(sun)) \
+      && !(defined(linux) || defined(__linux) || defined(__linux__)) \
+      && !(defined(__MAC_OS_X_VERSION_MIN_REQUIRED) \
+           && __MAC_OS_X_VERSION_MIN_REQUIRED < 101000) \
+      && !(defined(__IPHONE_OS_VERSION_MIN_REQUIRED) \
+           && __IPHONE_OS_VERSION_MIN_REQUIRED < 80000)
+      if (::fchmodat(AT_FDCWD, p.c_str(), mode_cast(prms),
+           !(prms & symlink_perms) ? 0 : AT_SYMLINK_NOFOLLOW))
+#   else  // fallback if fchmodat() not supported
+      if (::chmod(p.c_str(), mode_cast(prms)))
+#   endif
+    {
+      if (ec == 0)
+      AUTOBOOST_FILESYSTEM_THROW(filesystem_error(
+          "boost::filesystem::permissions", p,
+          error_code(errno, system::generic_category())));
+      else
+        ec->assign(errno, system::generic_category());
+    }
+
+# else  // Windows
+
+    // if not going to alter FILE_ATTRIBUTE_READONLY, just return
+    if (!(!((prms & (add_perms | remove_perms)))
+      || (prms & (owner_write|group_write|others_write))))
+      return;
+
+    DWORD attr = ::GetFileAttributesW(p.c_str());
+
+    if (error(attr == 0 ? AUTOBOOST_ERRNO : 0, p, ec, "boost::filesystem::permissions"))
+      return;
+
+    if (prms & add_perms)
+      attr &= ~FILE_ATTRIBUTE_READONLY;
+    else if (prms & remove_perms)
+      attr |= FILE_ATTRIBUTE_READONLY;
+    else if (prms & (owner_write|group_write|others_write))
+      attr &= ~FILE_ATTRIBUTE_READONLY;
+    else
+      attr |= FILE_ATTRIBUTE_READONLY;
+
+    error(::SetFileAttributesW(p.c_str(), attr) == 0 ? AUTOBOOST_ERRNO : 0,
+      p, ec, "boost::filesystem::permissions");
+# endif
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  path read_symlink(const path& p, system::error_code* ec)
+  {
+    path symlink_path;
+
+#   ifdef AUTOBOOST_POSIX_API
+
+    for (std::size_t path_max = 64;; path_max *= 2)// loop 'til buffer large enough
+    {
+      autoboost::scoped_array<char> buf(new char[path_max]);
+      ssize_t result;
+      if ((result=::readlink(p.c_str(), buf.get(), path_max))== -1)
+      {
+        if (ec == 0)
+          AUTOBOOST_FILESYSTEM_THROW(filesystem_error("boost::filesystem::read_symlink",
+            p, error_code(errno, system_category())));
+        else ec->assign(errno, system_category());
+        break;
+      }
+      else
+      {
+        if(result != static_cast<ssize_t>(path_max))
+        {
+          symlink_path.assign(buf.get(), buf.get() + result);
+          if (ec != 0) ec->clear();
+          break;
+        }
+      }
+    }
+
+#   elif _WIN32_WINNT < 0x0600  // SDK earlier than Vista and Server 2008
+    error(AUTOBOOST_ERROR_NOT_SUPPORTED, p, ec,
+          "boost::filesystem::read_symlink");
+#   else  // Vista and Server 2008 SDK, or later
+
+    union info_t
+    {
+      char buf[REPARSE_DATA_BUFFER_HEADER_SIZE+MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
+      REPARSE_DATA_BUFFER rdb;
+    } info;
+
+    handle_wrapper h(
+      create_file_handle(p.c_str(), GENERIC_READ, 0, 0, OPEN_EXISTING,
+        FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, 0));
+
+    if (error(h.handle == INVALID_HANDLE_VALUE ? AUTOBOOST_ERRNO : 0,
+      p, ec, "boost::filesystem::read_symlink"))
+        return symlink_path;
+
+    DWORD sz;
+
+    if (!error(::DeviceIoControl(h.handle, FSCTL_GET_REPARSE_POINT,
+          0, 0, info.buf, sizeof(info), &sz, 0) == 0 ? AUTOBOOST_ERRNO : 0, p, ec,
+          "boost::filesystem::read_symlink" ))
+      symlink_path.assign(
+        static_cast<wchar_t*>(info.rdb.SymbolicLinkReparseBuffer.PathBuffer)
+        + info.rdb.SymbolicLinkReparseBuffer.PrintNameOffset/sizeof(wchar_t),
+        static_cast<wchar_t*>(info.rdb.SymbolicLinkReparseBuffer.PathBuffer)
+        + info.rdb.SymbolicLinkReparseBuffer.PrintNameOffset/sizeof(wchar_t)
+        + info.rdb.SymbolicLinkReparseBuffer.PrintNameLength/sizeof(wchar_t));
+#     endif
+    return symlink_path;
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  path relative(const path& p, const path& base, error_code* ec)
+  {
+    error_code tmp_ec;
+    path wc_base(weakly_canonical(base, &tmp_ec));
+    if (error(tmp_ec.value(), base, ec, "boost::filesystem::relative"))
+      return path();
+    path wc_p(weakly_canonical(p, &tmp_ec));
+    if (error(tmp_ec.value(), base, ec, "boost::filesystem::relative"))
+      return path();
+    return wc_p.lexically_relative(wc_base);
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  bool remove(const path& p, error_code* ec)
+  {
+    error_code tmp_ec;
+    file_type type = query_file_type(p, &tmp_ec);
+    if (error(type == status_error ? tmp_ec.value() : 0, p, ec,
+        "boost::filesystem::remove"))
+      return false;
+
+    // Since POSIX remove() is specified to work with either files or directories, in a
+    // perfect world it could just be called. But some important real-world operating
+    // systems (Windows, Mac OS X, for example) don't implement the POSIX spec. So
+    // remove_file_or_directory() is always called to keep it simple.
+    return remove_file_or_directory(p, type, ec);
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  autoboost::uintmax_t remove_all(const path& p, error_code* ec)
+  {
+    error_code tmp_ec;
+    file_type type = query_file_type(p, &tmp_ec);
+    if (error(type == status_error ? tmp_ec.value() : 0, p, ec,
+      "boost::filesystem::remove_all"))
+      return 0;
+
+    return (type != status_error && type != file_not_found) // exists
+      ? remove_all_aux(p, type, ec)
+      : 0;
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  void rename(const path& old_p, const path& new_p, error_code* ec)
+  {
+    error(!AUTOBOOST_MOVE_FILE(old_p.c_str(), new_p.c_str()) ? AUTOBOOST_ERRNO : 0, old_p, new_p,
+      ec, "boost::filesystem::rename");
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  void resize_file(const path& p, uintmax_t size, system::error_code* ec)
+  {
+    error(!AUTOBOOST_RESIZE_FILE(p.c_str(), size) ? AUTOBOOST_ERRNO : 0, p, ec,
+      "boost::filesystem::resize_file");
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  space_info space(const path& p, error_code* ec)
+  {
+#   ifdef AUTOBOOST_POSIX_API
+    struct AUTOBOOST_STATVFS vfs;
+    space_info info;
+    if (!error(::AUTOBOOST_STATVFS(p.c_str(), &vfs)!= 0,
+      p, ec, "boost::filesystem::space"))
+    {
+      info.capacity
+        = static_cast<autoboost::uintmax_t>(vfs.f_blocks)* AUTOBOOST_STATVFS_F_FRSIZE;
+      info.free
+        = static_cast<autoboost::uintmax_t>(vfs.f_bfree)* AUTOBOOST_STATVFS_F_FRSIZE;
+      info.available
+        = static_cast<autoboost::uintmax_t>(vfs.f_bavail)* AUTOBOOST_STATVFS_F_FRSIZE;
+    }
+
+#   else
+    ULARGE_INTEGER avail, total, free;
+    space_info info;
+
+    if (!error(::GetDiskFreeSpaceExW(p.c_str(), &avail, &total, &free)== 0,
+       p, ec, "boost::filesystem::space"))
+    {
+      info.capacity
+        = (static_cast<autoboost::uintmax_t>(total.HighPart)<< 32)
+          + total.LowPart;
+      info.free
+        = (static_cast<autoboost::uintmax_t>(free.HighPart)<< 32)
+          + free.LowPart;
+      info.available
+        = (static_cast<autoboost::uintmax_t>(avail.HighPart)<< 32)
+          + avail.LowPart;
+    }
+
+#   endif
+
+    else
+    {
+      info.capacity = info.free = info.available = 0;
+    }
+    return info;
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  file_status status(const path& p, error_code* ec)
+  {
+#   ifdef AUTOBOOST_POSIX_API
+
+    struct stat path_stat;
+    if (::stat(p.c_str(), &path_stat)!= 0)
+    {
+      if (ec != 0)                            // always report errno, even though some
+        ec->assign(errno, system_category());   // errno values are not status_errors
+
+      if (not_found_error(errno))
+      {
+        return fs::file_status(fs::file_not_found, fs::no_perms);
+      }
+      if (ec == 0)
+        AUTOBOOST_FILESYSTEM_THROW(filesystem_error("boost::filesystem::status",
+          p, error_code(errno, system_category())));
+      return fs::file_status(fs::status_error);
+    }
+    if (ec != 0) ec->clear();;
+    if (S_ISDIR(path_stat.st_mode))
+      return fs::file_status(fs::directory_file,
+        static_cast<perms>(path_stat.st_mode) & fs::perms_mask);
+    if (S_ISREG(path_stat.st_mode))
+      return fs::file_status(fs::regular_file,
+        static_cast<perms>(path_stat.st_mode) & fs::perms_mask);
+    if (S_ISBLK(path_stat.st_mode))
+      return fs::file_status(fs::block_file,
+        static_cast<perms>(path_stat.st_mode) & fs::perms_mask);
+    if (S_ISCHR(path_stat.st_mode))
+      return fs::file_status(fs::character_file,
+        static_cast<perms>(path_stat.st_mode) & fs::perms_mask);
+    if (S_ISFIFO(path_stat.st_mode))
+      return fs::file_status(fs::fifo_file,
+        static_cast<perms>(path_stat.st_mode) & fs::perms_mask);
+    if (S_ISSOCK(path_stat.st_mode))
+      return fs::file_status(fs::socket_file,
+        static_cast<perms>(path_stat.st_mode) & fs::perms_mask);
+    return fs::file_status(fs::type_unknown);
+
+#   else  // Windows
+
+    DWORD attr(::GetFileAttributesW(p.c_str()));
+    if (attr == 0xFFFFFFFF)
+    {
+      return process_status_failure(p, ec);
+    }
+
+    //  reparse point handling;
+    //    since GetFileAttributesW does not resolve symlinks, try to open a file
+    //    handle to discover if the file exists
+    if (attr & FILE_ATTRIBUTE_REPARSE_POINT)
+    {
+      handle_wrapper h(
+        create_file_handle(
+            p.c_str(),
+            0,  // dwDesiredAccess; attributes only
+            FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+            0,  // lpSecurityAttributes
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS,
+            0)); // hTemplateFile
+      if (h.handle == INVALID_HANDLE_VALUE)
+      {
+        return process_status_failure(p, ec);
+      }
+
+      if (!is_reparse_point_a_symlink(p))
+        return file_status(reparse_file, make_permissions(p, attr));
+    }
+
+    if (ec != 0) ec->clear();
+    return (attr & FILE_ATTRIBUTE_DIRECTORY)
+      ? file_status(directory_file, make_permissions(p, attr))
+      : file_status(regular_file, make_permissions(p, attr));
+
+#   endif
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  file_status symlink_status(const path& p, error_code* ec)
+  {
+#   ifdef AUTOBOOST_POSIX_API
+
+    struct stat path_stat;
+    if (::lstat(p.c_str(), &path_stat)!= 0)
+    {
+      if (ec != 0)                            // always report errno, even though some
+        ec->assign(errno, system_category());   // errno values are not status_errors
+
+      if (errno == ENOENT || errno == ENOTDIR) // these are not errors
+      {
+        return fs::file_status(fs::file_not_found, fs::no_perms);
+      }
+      if (ec == 0)
+        AUTOBOOST_FILESYSTEM_THROW(filesystem_error("boost::filesystem::status",
+          p, error_code(errno, system_category())));
+      return fs::file_status(fs::status_error);
+    }
+    if (ec != 0) ec->clear();
+    if (S_ISREG(path_stat.st_mode))
+      return fs::file_status(fs::regular_file,
+        static_cast<perms>(path_stat.st_mode) & fs::perms_mask);
+    if (S_ISDIR(path_stat.st_mode))
+      return fs::file_status(fs::directory_file,
+        static_cast<perms>(path_stat.st_mode) & fs::perms_mask);
+    if (S_ISLNK(path_stat.st_mode))
+      return fs::file_status(fs::symlink_file,
+        static_cast<perms>(path_stat.st_mode) & fs::perms_mask);
+    if (S_ISBLK(path_stat.st_mode))
+      return fs::file_status(fs::block_file,
+        static_cast<perms>(path_stat.st_mode) & fs::perms_mask);
+    if (S_ISCHR(path_stat.st_mode))
+      return fs::file_status(fs::character_file,
+        static_cast<perms>(path_stat.st_mode) & fs::perms_mask);
+    if (S_ISFIFO(path_stat.st_mode))
+      return fs::file_status(fs::fifo_file,
+        static_cast<perms>(path_stat.st_mode) & fs::perms_mask);
+    if (S_ISSOCK(path_stat.st_mode))
+      return fs::file_status(fs::socket_file,
+        static_cast<perms>(path_stat.st_mode) & fs::perms_mask);
+    return fs::file_status(fs::type_unknown);
+
+#   else  // Windows
+
+    DWORD attr(::GetFileAttributesW(p.c_str()));
+    if (attr == 0xFFFFFFFF)
+    {
+      return process_status_failure(p, ec);
+    }
+
+    if (ec != 0) ec->clear();
+
+    if (attr & FILE_ATTRIBUTE_REPARSE_POINT)
+      return is_reparse_point_a_symlink(p)
+             ? file_status(symlink_file, make_permissions(p, attr))
+             : file_status(reparse_file, make_permissions(p, attr));
+
+    return (attr & FILE_ATTRIBUTE_DIRECTORY)
+      ? file_status(directory_file, make_permissions(p, attr))
+      : file_status(regular_file, make_permissions(p, attr));
+
+#   endif
+  }
+
+   // contributed by Jeff Flinn
+  AUTOBOOST_FILESYSTEM_DECL
+  path temp_directory_path(system::error_code* ec)
+  {
+#   ifdef AUTOBOOST_POSIX_API
+      const char* val = 0;
+
+      (val = std::getenv("TMPDIR" )) ||
+      (val = std::getenv("TMP"    )) ||
+      (val = std::getenv("TEMP"   )) ||
+      (val = std::getenv("TEMPDIR"));
+
+#     ifdef __ANDROID__
+        const char* default_tmp = "/data/local/tmp";
+#     else
+        const char* default_tmp = "/tmp";
+#     endif
+      path p((val!=0) ? val : default_tmp);
+
+      if (p.empty() || (ec&&!is_directory(p, *ec))||(!ec&&!is_directory(p)))
+      {
+        error(ENOTDIR, p, ec, "boost::filesystem::temp_directory_path");
+        return p;
+      }
+
+      return p;
+
+#   else  // Windows
+
+      const wchar_t* tmp_env = L"TMP";
+      const wchar_t* temp_env = L"TEMP";
+      const wchar_t* localappdata_env = L"LOCALAPPDATA";
+      const wchar_t* userprofile_env = L"USERPROFILE";
+      const wchar_t* env_list[]
+        = {tmp_env, temp_env, localappdata_env, userprofile_env, 0};
+
+      path p;
+      for (int i = 0; env_list[i]; ++i)
+      {
+        std::wstring env = wgetenv(env_list[i]);
+        if (!env.empty())
+        {
+          p = env;
+          if (i >= 2)
+            p /= L"Temp";
+          error_code lcl_ec;
+          if (exists(p, lcl_ec) && !lcl_ec && is_directory(p, lcl_ec) && !lcl_ec)
+            break;
+          p.clear();
+        }
+      }
+
+      if (p.empty())
+      {
+        // use vector since in C++03 a string is not required to be contiguous
+        std::vector<wchar_t> buf(::GetWindowsDirectoryW(NULL, 0));
+
+        if (buf.empty()
+          || ::GetWindowsDirectoryW(&buf[0], static_cast<UINT>(buf.size())) == 0)
+        {
+          error(::GetLastError(), ec, "boost::filesystem::temp_directory_path");
+          return path();
+        }
+        p = &*buf.begin();  // do not depend on buf.size(); see ticket #10388
+        p /= L"Temp";
+      }
+      return p;
+
+#   endif
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  path system_complete(const path& p, system::error_code* ec)
+  {
+#   ifdef AUTOBOOST_POSIX_API
+    return (p.empty() || p.is_absolute())
+      ? p : current_path()/ p;
+
+#   else
+    if (p.empty())
+    {
+      if (ec != 0) ec->clear();
+      return p;
+    }
+    wchar_t buf[buf_size];
+    wchar_t* pfn;
+    std::size_t len = get_full_path_name(p, buf_size, buf, &pfn);
+
+    if (error(len == 0 ? AUTOBOOST_ERRNO : 0, p, ec, "boost::filesystem::system_complete"))
+      return path();
+
+    if (len < buf_size)// len does not include null termination character
+      return path(&buf[0]);
+
+    autoboost::scoped_array<wchar_t> big_buf(new wchar_t[len]);
+
+    return error(get_full_path_name(p, len , big_buf.get(), &pfn)== 0 ? AUTOBOOST_ERRNO : 0,
+      p, ec, "boost::filesystem::system_complete")
+      ? path()
+      : path(big_buf.get());
+#   endif
+  }
+
+  AUTOBOOST_FILESYSTEM_DECL
+  path weakly_canonical(const path& p, system::error_code* ec)
+  {
+    path head(p);
+    path tail;
+    system::error_code tmp_ec;
+    path::iterator itr = p.end();
+
+    for (; !head.empty(); --itr)
+    {
+      file_status head_status = status(head, tmp_ec);
+      if (error(head_status.type() == fs::status_error,
+        head, ec, "boost::filesystem::weakly_canonical"))
+        return path();
+      if (head_status.type() != fs::file_not_found)
+        break;
+      head.remove_filename();
+    }
+
+    bool tail_has_dots = false;
+    for (; itr != p.end(); ++itr)
+    {
+      tail /= *itr;
+      // for a later optimization, track if any dot or dot-dot elements are present
+      if (itr->native().size() <= 2
+        && itr->native()[0] == dot
+        && (itr->native().size() == 1 || itr->native()[1] == dot))
+        tail_has_dots = true;
+    }
+
+    if (head.empty())
+      return p.lexically_normal();
+    head = canonical(head, tmp_ec);
+    if (error(tmp_ec.value(), head, ec, "boost::filesystem::weakly_canonical"))
+      return path();
+    return tail.empty()
+      ? head
+      : (tail_has_dots  // optimization: only normalize if tail had dot or dot-dot element
+          ? (head/tail).lexically_normal()
+          : head/tail);
+  }
+}  // namespace detail
+
+//--------------------------------------------------------------------------------------//
+//                                                                                      //
+//                                 directory_entry                                      //
+//                                                                                      //
+//--------------------------------------------------------------------------------------//
+
+  file_status
+  directory_entry::m_get_status(system::error_code* ec) const
+  {
+    if (!status_known(m_status))
+    {
+      // optimization: if the symlink status is known, and it isn't a symlink,
+      // then status and symlink_status are identical so just copy the
+      // symlink status to the regular status.
+      if (status_known(m_symlink_status)
+        && !is_symlink(m_symlink_status))
+      {
+        m_status = m_symlink_status;
+        if (ec != 0) ec->clear();
+      }
+      else m_status = detail::status(m_path, ec);
+    }
+    else if (ec != 0) ec->clear();
+    return m_status;
+  }
+
+  file_status
+  directory_entry::m_get_symlink_status(system::error_code* ec) const
+  {
+    if (!status_known(m_symlink_status))
+      m_symlink_status = detail::symlink_status(m_path, ec);
+    else if (ec != 0) ec->clear();
+    return m_symlink_status;
+  }
+
+//  dispatch directory_entry supplied here rather than in
+//  <autoboost/filesystem/path_traits.hpp>, thus avoiding header circularity.
+//  test cases are in operations_unit_test.cpp
+
+namespace path_traits
+{
+  void dispatch(const directory_entry & de,
+#                ifdef AUTOBOOST_WINDOWS_API
+    std::wstring& to,
+#                else
+    std::string& to,
+#                endif
+    const codecvt_type &)
+  {
+    to = de.path().native();
+  }
+
+  void dispatch(const directory_entry & de,
+#                ifdef AUTOBOOST_WINDOWS_API
+    std::wstring& to
+#                else
+    std::string& to
+#                endif
+    )
+  {
+    to = de.path().native();
+  }
+}  // namespace path_traits
+} // namespace filesystem
+} // namespace autoboost
+
+//--------------------------------------------------------------------------------------//
+//                                                                                      //
+//                               directory_iterator                                     //
+//                                                                                      //
+//--------------------------------------------------------------------------------------//
+
+namespace
+{
+# ifdef AUTOBOOST_POSIX_API
+
+  error_code path_max(std::size_t & result)
+  // this code is based on Stevens and Rago, Advanced Programming in the
+  // UNIX envirnment, 2nd Ed., ISBN 0-201-43307-9, page 49
+  {
+#   ifdef PATH_MAX
+    static std::size_t max = PATH_MAX;
+#   else
+    static std::size_t max = 0;
+#   endif
+    if (max == 0)
+    {
+      errno = 0;
+      long tmp = ::pathconf("/", _PC_NAME_MAX);
+      if (tmp < 0)
+      {
+        if (errno == 0)// indeterminate
+          max = 4096; // guess
+        else return error_code(errno, system_category());
+      }
+      else max = static_cast<std::size_t>(tmp + 1); // relative root
+    }
+    result = max;
+    return ok;
+  }
+
+#if defined(__PGI) && defined(__USE_FILE_OFFSET64)
+#define dirent dirent64
+#endif
+
+  error_code dir_itr_first(void *& handle, void *& buffer,
+    const char* dir, string& target,
+    fs::file_status &, fs::file_status &)
+  {
+    if ((handle = ::opendir(dir))== 0)
+      return error_code(errno, system_category());
+    target = string(".");  // string was static but caused trouble
+                             // when iteration called from dtor, after
+                             // static had already been destroyed
+    std::size_t path_size (0);  // initialization quiets gcc warning (ticket #3509)
+    error_code ec = path_max(path_size);
+    if (ec)return ec;
+    dirent de;
+    buffer = std::malloc((sizeof(dirent) - sizeof(de.d_name))
+      +  path_size + 1); // + 1 for "/0"
+    return ok;
+  }
+
+  // warning: the only dirent member updated is d_name
+  inline int readdir_r_simulator(DIR * dirp, struct dirent * entry,
+    struct dirent ** result)// *result set to 0 on end of directory
+  {
+    errno = 0;
+
+#   if !defined(__CYGWIN__)\
+    && defined(_POSIX_THREAD_SAFE_FUNCTIONS)\
+    && defined(_SC_THREAD_SAFE_FUNCTIONS)\
+    && (_POSIX_THREAD_SAFE_FUNCTIONS+0 >= 0)\
+    && (!defined(__hpux) || defined(_REENTRANT)) \
+    && (!defined(_AIX) || defined(__THREAD_SAFE))
+    if (::sysconf(_SC_THREAD_SAFE_FUNCTIONS)>= 0)
+      { return ::readdir_r(dirp, entry, result); }
+#   endif
+
+    struct dirent * p;
+    *result = 0;
+    if ((p = ::readdir(dirp))== 0)
+      return errno;
+    std::strcpy(entry->d_name, p->d_name);
+    *result = entry;
+    return 0;
+  }
+
+  error_code dir_itr_increment(void *& handle, void *& buffer,
+    string& target, fs::file_status & sf, fs::file_status & symlink_sf)
+  {
+    AUTOBOOST_ASSERT(buffer != 0);
+    dirent * entry(static_cast<dirent *>(buffer));
+    dirent * result;
+    int return_code;
+    if ((return_code = readdir_r_simulator(static_cast<DIR*>(handle), entry, &result))!= 0)
+      return error_code(errno, system_category());
+    if (result == 0)
+      return fs::detail::dir_itr_close(handle, buffer);
+    target = entry->d_name;
+#   ifdef AUTOBOOST_FILESYSTEM_STATUS_CACHE
+    if (entry->d_type == DT_UNKNOWN) // filesystem does not supply d_type value
+    {
+      sf = symlink_sf = fs::file_status(fs::status_error);
+    }
+    else  // filesystem supplies d_type value
+    {
+      if (entry->d_type == DT_DIR)
+        sf = symlink_sf = fs::file_status(fs::directory_file);
+      else if (entry->d_type == DT_REG)
+        sf = symlink_sf = fs::file_status(fs::regular_file);
+      else if (entry->d_type == DT_LNK)
+      {
+        sf = fs::file_status(fs::status_error);
+        symlink_sf = fs::file_status(fs::symlink_file);
+      }
+      else sf = symlink_sf = fs::file_status(fs::status_error);
+    }
+#   else
+    sf = symlink_sf = fs::file_status(fs::status_error);
+#    endif
+    return ok;
+  }
+
+# else // AUTOBOOST_WINDOWS_API
+
+  error_code dir_itr_first(void *& handle, const fs::path& dir,
+    wstring& target, fs::file_status & sf, fs::file_status & symlink_sf)
+  // Note: an empty root directory has no "." or ".." entries, so this
+  // causes a ERROR_FILE_NOT_FOUND error which we do not considered an
+  // error. It is treated as eof instead.
+  {
+    // use a form of search Sebastian Martel reports will work with Win98
+    wstring dirpath(dir.wstring());
+    dirpath += (dirpath.empty()
+      || (dirpath[dirpath.size()-1] != L'\\'
+        && dirpath[dirpath.size()-1] != L'/'
+        && dirpath[dirpath.size()-1] != L':'))? L"\\*" : L"*";
+
+    WIN32_FIND_DATAW data;
+    if ((handle = ::FindFirstFileW(dirpath.c_str(), &data))
+      == INVALID_HANDLE_VALUE)
+    {
+      handle = 0;  // signal eof
+      return error_code( (::GetLastError() == ERROR_FILE_NOT_FOUND
+                       // Windows Mobile returns ERROR_NO_MORE_FILES; see ticket #3551
+                       || ::GetLastError() == ERROR_NO_MORE_FILES)
+        ? 0 : ::GetLastError(), system_category() );
+    }
+    target = data.cFileName;
+    if (data.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)
+    // reparse points are complex, so don't try to handle them here; instead just mark
+    // them as status_error which causes directory_entry caching to call status()
+    // and symlink_status() which do handle reparse points fully
+    {
+      sf.type(fs::status_error);
+      symlink_sf.type(fs::status_error);
+    }
+    else
+    {
+      if (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+      {
+        sf.type(fs::directory_file);
+        symlink_sf.type(fs::directory_file);
+      }
+      else
+      {
+        sf.type(fs::regular_file);
+        symlink_sf.type(fs::regular_file);
+      }
+      sf.permissions(make_permissions(data.cFileName, data.dwFileAttributes));
+      symlink_sf.permissions(sf.permissions());
+    }
+    return error_code();
+  }
+
+  error_code  dir_itr_increment(void *& handle, wstring& target,
+    fs::file_status & sf, fs::file_status & symlink_sf)
+  {
+    WIN32_FIND_DATAW data;
+    if (::FindNextFileW(handle, &data)== 0)// fails
+    {
+      int error = ::GetLastError();
+      fs::detail::dir_itr_close(handle);
+      return error_code(error == ERROR_NO_MORE_FILES ? 0 : error, system_category());
+    }
+    target = data.cFileName;
+    if (data.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)
+    // reparse points are complex, so don't try to handle them here; instead just mark
+    // them as status_error which causes directory_entry caching to call status()
+    // and symlink_status() which do handle reparse points fully
+    {
+      sf.type(fs::status_error);
+      symlink_sf.type(fs::status_error);
+    }
+    else
+    {
+      if (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+      {
+        sf.type(fs::directory_file);
+        symlink_sf.type(fs::directory_file);
+      }
+      else
+      {
+        sf.type(fs::regular_file);
+        symlink_sf.type(fs::regular_file);
+      }
+      sf.permissions(make_permissions(data.cFileName, data.dwFileAttributes));
+      symlink_sf.permissions(sf.permissions());
+    }
+    return error_code();
+  }
+#endif
+
+  const error_code not_found_error_code (
+#     ifdef AUTOBOOST_WINDOWS_API
+        ERROR_PATH_NOT_FOUND
+#     else
+        ENOENT
+#     endif
+        , system_category());
+
+}  // unnamed namespace
+
+namespace autoboost
+{
+namespace filesystem
+{
+
+namespace detail
+{
+  //  dir_itr_close is called both from the ~dir_itr_imp()destructor
+  //  and dir_itr_increment()
+  AUTOBOOST_FILESYSTEM_DECL
+  system::error_code dir_itr_close( // never throws
+    void *& handle
+#   if defined(AUTOBOOST_POSIX_API)
+    , void *& buffer
+#   endif
+   )
+  {
+#   ifdef AUTOBOOST_POSIX_API
+    std::free(buffer);
+    buffer = 0;
+    if (handle == 0)return ok;
+    DIR * h(static_cast<DIR*>(handle));
+    handle = 0;
+    return error_code(::closedir(h)== 0 ? 0 : errno, system_category());
+
+#   else
+    if (handle != 0)
+    {
+      ::FindClose(handle);
+      handle = 0;
+    }
+    return ok;
+
+#   endif
+  }
+
+  void directory_iterator_construct(directory_iterator& it,
+    const path& p, system::error_code* ec)
+  {
+    if (error(p.empty() ? not_found_error_code.value() : 0, p, ec,
+              "boost::filesystem::directory_iterator::construct"))
+      return;
+
+    path::string_type filename;
+    file_status file_stat, symlink_file_stat;
+    error_code result = dir_itr_first(it.m_imp->handle,
+#     if defined(AUTOBOOST_POSIX_API)
+      it.m_imp->buffer,
+#     endif
+      p.c_str(), filename, file_stat, symlink_file_stat);
+
+    if (result)
+    {
+      it.m_imp.reset();
+      error(result.value(), p,
+        ec, "boost::filesystem::directory_iterator::construct");
+      return;
+    }
+
+    if (it.m_imp->handle == 0)
+      it.m_imp.reset(); // eof, so make end iterator
+    else // not eof
+    {
+      it.m_imp->dir_entry.assign(p / filename, file_stat, symlink_file_stat);
+      if (filename[0] == dot // dot or dot-dot
+        && (filename.size()== 1
+          || (filename[1] == dot
+            && filename.size()== 2)))
+        {  it.increment(*ec); }
+    }
+  }
+
+  void directory_iterator_increment(directory_iterator& it,
+    system::error_code* ec)
+  {
+    AUTOBOOST_ASSERT_MSG(it.m_imp.get(), "attempt to increment end iterator");
+    AUTOBOOST_ASSERT_MSG(it.m_imp->handle != 0, "internal program error");
+
+    path::string_type filename;
+    file_status file_stat, symlink_file_stat;
+    system::error_code temp_ec;
+
+    for (;;)
+    {
+      temp_ec = dir_itr_increment(it.m_imp->handle,
+#       if defined(AUTOBOOST_POSIX_API)
+        it.m_imp->buffer,
+#       endif
+        filename, file_stat, symlink_file_stat);
+
+      if (temp_ec)  // happens if filesystem is corrupt, such as on a damaged optical disc
+      {
+        path error_path(it.m_imp->dir_entry.path().parent_path());  // fix ticket #5900
+        it.m_imp.reset();
+        if (ec == 0)
+          AUTOBOOST_FILESYSTEM_THROW(
+            filesystem_error("boost::filesystem::directory_iterator::operator++",
+              error_path,
+              error_code(AUTOBOOST_ERRNO, system_category())));
+        ec->assign(AUTOBOOST_ERRNO, system_category());
+        return;
+      }
+      else if (ec != 0) ec->clear();
+
+      if (it.m_imp->handle == 0)  // eof, make end
+      {
+        it.m_imp.reset();
+        return;
+      }
+
+      if (!(filename[0] == dot // !(dot or dot-dot)
+        && (filename.size()== 1
+          || (filename[1] == dot
+            && filename.size()== 2))))
+      {
+        it.m_imp->dir_entry.replace_filename(
+          filename, file_stat, symlink_file_stat);
+        return;
+      }
+    }
+  }
+}  // namespace detail
+} // namespace filesystem
+} // namespace autoboost

--- a/contrib/autoboost/libs/filesystem/path.cpp
+++ b/contrib/autoboost/libs/filesystem/path.cpp
@@ -1,0 +1,954 @@
+//  filesystem path.cpp  -------------------------------------------------------------  //
+
+//  Copyright Beman Dawes 2008
+
+//  Distributed under the Boost Software License, Version 1.0.
+//  See http://www.boost.org/LICENSE_1_0.txt
+
+//  Library home page: http://www.boost.org/libs/filesystem
+
+//  Old standard library configurations, particularly MingGW, don't support wide strings.
+//  Report this with an explicit error message.
+#include "stdafx.h"
+#include <autoboost/config.hpp>
+# if defined( AUTOBOOST_NO_STD_WSTRING )
+#   error Configuration not supported: Boost.Filesystem V3 and later requires std::wstring support
+# endif
+
+// define AUTOBOOST_FILESYSTEM_SOURCE so that <autoboost/system/config.hpp> knows
+// the library is being built (possibly exporting rather than importing code)
+#define AUTOBOOST_FILESYSTEM_SOURCE
+
+#ifndef AUTOBOOST_SYSTEM_NO_DEPRECATED
+# define AUTOBOOST_SYSTEM_NO_DEPRECATED
+#endif
+
+#include <autoboost/filesystem/config.hpp>
+#include <autoboost/filesystem/path.hpp>
+#include <autoboost/filesystem/operations.hpp>  // for filesystem_error
+#include <autoboost/scoped_array.hpp>
+#include <autoboost/system/error_code.hpp>
+#include <autoboost/assert.hpp>
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+#include <cassert>
+
+#ifdef AUTOBOOST_WINDOWS_API
+# include "windows_file_codecvt.hpp"
+# include <windows.h>
+#elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__) \
+ || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__HAIKU__)
+# include <autoboost/filesystem/detail/utf8_codecvt_facet.hpp>
+#endif
+
+#ifdef AUTOBOOST_FILESYSTEM_DEBUG
+# include <iostream>
+# include <iomanip>
+#endif
+
+namespace fs = autoboost::filesystem;
+
+using autoboost::filesystem::path;
+
+using std::string;
+using std::wstring;
+
+using autoboost::system::error_code;
+
+//--------------------------------------------------------------------------------------//
+//                                                                                      //
+//                                class path helpers                                    //
+//                                                                                      //
+//--------------------------------------------------------------------------------------//
+
+namespace
+{
+  //------------------------------------------------------------------------------------//
+  //                        miscellaneous class path helpers                            //
+  //------------------------------------------------------------------------------------//
+
+  typedef path::value_type        value_type;
+  typedef path::string_type       string_type;
+  typedef string_type::size_type  size_type;
+
+# ifdef AUTOBOOST_WINDOWS_API
+
+  const wchar_t* const separators = L"/\\";
+  const wchar_t* separator_string = L"/";
+  const wchar_t* preferred_separator_string = L"\\";
+  const wchar_t colon = L':';
+  const wchar_t questionmark = L'?';
+
+  inline bool is_letter(wchar_t c)
+  {
+    return (c >= L'a' && c <=L'z') || (c >= L'A' && c <=L'Z');
+  }
+
+# else
+
+  const char* const separators = "/";
+  const char* separator_string = "/";
+  const char* preferred_separator_string = "/";
+
+# endif
+
+  bool is_root_separator(const string_type& str, size_type pos);
+    // pos is position of the separator
+
+  size_type filename_pos(const string_type& str,
+                          size_type end_pos); // end_pos is past-the-end position
+  //  Returns: 0 if str itself is filename (or empty)
+
+  size_type root_directory_start(const string_type& path, size_type size);
+  //  Returns:  npos if no root_directory found
+
+  void first_element(
+      const string_type& src,
+      size_type& element_pos,
+      size_type& element_size,
+#     if !AUTOBOOST_WORKAROUND(AUTOBOOST_MSVC, <= 1310) // VC++ 7.1
+      size_type size = string_type::npos
+#     else
+      size_type size = -1
+#     endif
+    );
+
+}  // unnamed namespace
+
+//--------------------------------------------------------------------------------------//
+//                                                                                      //
+//                            class path implementation                                 //
+//                                                                                      //
+//--------------------------------------------------------------------------------------//
+
+namespace autoboost
+{
+namespace filesystem
+{
+  path& path::operator/=(const path& p)
+  {
+    if (p.empty())
+      return *this;
+    if (this == &p)  // self-append
+    {
+      path rhs(p);
+      if (!detail::is_directory_separator(rhs.m_pathname[0]))
+        m_append_separator_if_needed();
+      m_pathname += rhs.m_pathname;
+    }
+    else
+    {
+      if (!detail::is_directory_separator(*p.m_pathname.begin()))
+        m_append_separator_if_needed();
+      m_pathname += p.m_pathname;
+    }
+    return *this;
+  }
+
+  path& path::operator/=(const value_type* ptr)
+  {
+    if (!*ptr)
+      return *this;
+    if (ptr >= m_pathname.data()
+      && ptr < m_pathname.data() + m_pathname.size())  // overlapping source
+    {
+      path rhs(ptr);
+      if (!detail::is_directory_separator(rhs.m_pathname[0]))
+        m_append_separator_if_needed();
+      m_pathname += rhs.m_pathname;
+    }
+    else
+    {
+      if (!detail::is_directory_separator(*ptr))
+        m_append_separator_if_needed();
+      m_pathname += ptr;
+    }
+    return *this;
+  }
+
+  int path::compare(const path& p) const AUTOBOOST_NOEXCEPT
+  {
+    return detail::lex_compare(begin(), end(), p.begin(), p.end());
+  }
+
+# ifdef AUTOBOOST_WINDOWS_API
+
+  const std::string path::generic_string() const
+  {
+    path tmp(*this);
+    std::replace(tmp.m_pathname.begin(), tmp.m_pathname.end(), L'\\', L'/');
+    return tmp.string();
+  }
+
+  const std::string path::generic_string(const codecvt_type& cvt) const
+  {
+    path tmp(*this);
+    std::replace(tmp.m_pathname.begin(), tmp.m_pathname.end(), L'\\', L'/');
+    return tmp.string(cvt);
+  }
+
+  const std::wstring path::generic_wstring() const
+  {
+    path tmp(*this);
+    std::replace(tmp.m_pathname.begin(), tmp.m_pathname.end(), L'\\', L'/');
+    return tmp.wstring();
+  }
+
+# endif  // AUTOBOOST_WINDOWS_API
+
+  //  m_append_separator_if_needed  ----------------------------------------------------//
+
+  path::string_type::size_type path::m_append_separator_if_needed()
+  {
+    if (!m_pathname.empty() &&
+#     ifdef AUTOBOOST_WINDOWS_API
+      *(m_pathname.end()-1) != colon &&
+#     endif
+      !detail::is_directory_separator(*(m_pathname.end()-1)))
+    {
+      string_type::size_type tmp(m_pathname.size());
+      m_pathname += preferred_separator;
+      return tmp;
+    }
+    return 0;
+  }
+
+  //  m_erase_redundant_separator  -----------------------------------------------------//
+
+  void path::m_erase_redundant_separator(string_type::size_type sep_pos)
+  {
+    if (sep_pos                         // a separator was added
+      && sep_pos < m_pathname.size()         // and something was appended
+      && (m_pathname[sep_pos+1] == separator // and it was also separator
+#      ifdef AUTOBOOST_WINDOWS_API
+       || m_pathname[sep_pos+1] == preferred_separator  // or preferred_separator
+#      endif
+)) { m_pathname.erase(sep_pos, 1); } // erase the added separator
+  }
+
+  //  modifiers  -----------------------------------------------------------------------//
+
+# ifdef AUTOBOOST_WINDOWS_API
+  path & path::make_preferred()
+  {
+    std::replace(m_pathname.begin(), m_pathname.end(), L'/', L'\\');
+    return *this;
+  }
+# endif
+
+  path& path::remove_filename()
+  {
+    m_pathname.erase(m_parent_path_end());
+    return *this;
+  }
+
+  path&  path::remove_trailing_separator()
+  {
+    if (!m_pathname.empty()
+      && detail::is_directory_separator(m_pathname[m_pathname.size() - 1]))
+      m_pathname.erase(m_pathname.size() - 1);
+    return *this;
+  }
+
+  path& path::replace_extension(const path& new_extension)
+  {
+    // erase existing extension, including the dot, if any
+    m_pathname.erase(m_pathname.size()-extension().m_pathname.size());
+
+    if (!new_extension.empty())
+    {
+      // append new_extension, adding the dot if necessary
+      if (new_extension.m_pathname[0] != dot)
+        m_pathname.push_back(dot);
+      m_pathname.append(new_extension.m_pathname);
+    }
+
+    return *this;
+  }
+
+  //  decomposition  -------------------------------------------------------------------//
+
+  path  path::root_path() const
+  {
+    path temp(root_name());
+    if (!root_directory().empty()) temp.m_pathname += root_directory().c_str();
+    return temp;
+  }
+
+  path path::root_name() const
+  {
+    iterator itr(begin());
+
+    return (itr.m_pos != m_pathname.size()
+      && (
+          (itr.m_element.m_pathname.size() > 1
+            && detail::is_directory_separator(itr.m_element.m_pathname[0])
+            && detail::is_directory_separator(itr.m_element.m_pathname[1])
+   )
+#       ifdef AUTOBOOST_WINDOWS_API
+        || itr.m_element.m_pathname[itr.m_element.m_pathname.size()-1] == colon
+#       endif
+  ))
+      ? itr.m_element
+      : path();
+  }
+
+  path path::root_directory() const
+  {
+    size_type pos(root_directory_start(m_pathname, m_pathname.size()));
+
+    return pos == string_type::npos
+      ? path()
+      : path(m_pathname.c_str() + pos, m_pathname.c_str() + pos + 1);
+  }
+
+  path path::relative_path() const
+  {
+    iterator itr(begin());
+
+    for (; itr.m_pos != m_pathname.size()
+      && (detail::is_directory_separator(itr.m_element.m_pathname[0])
+#     ifdef AUTOBOOST_WINDOWS_API
+      || itr.m_element.m_pathname[itr.m_element.m_pathname.size()-1] == colon
+#     endif
+    ); ++itr) {}
+
+    return path(m_pathname.c_str() + itr.m_pos);
+  }
+
+  string_type::size_type path::m_parent_path_end() const
+  {
+    size_type end_pos(filename_pos(m_pathname, m_pathname.size()));
+
+    bool filename_was_separator(m_pathname.size()
+      && detail::is_directory_separator(m_pathname[end_pos]));
+
+    // skip separators unless root directory
+    size_type root_dir_pos(root_directory_start(m_pathname, end_pos));
+    for (;
+      end_pos > 0
+      && (end_pos-1) != root_dir_pos
+      && detail::is_directory_separator(m_pathname[end_pos-1])
+      ;
+      --end_pos) {}
+
+   return (end_pos == 1 && root_dir_pos == 0 && filename_was_separator)
+     ? string_type::npos
+     : end_pos;
+  }
+
+  path path::parent_path() const
+  {
+   size_type end_pos(m_parent_path_end());
+   return end_pos == string_type::npos
+     ? path()
+     : path(m_pathname.c_str(), m_pathname.c_str() + end_pos);
+  }
+
+  path path::filename() const
+  {
+    size_type pos(filename_pos(m_pathname, m_pathname.size()));
+    return (m_pathname.size()
+              && pos
+              && detail::is_directory_separator(m_pathname[pos])
+              && !is_root_separator(m_pathname, pos))
+      ? detail::dot_path()
+      : path(m_pathname.c_str() + pos);
+  }
+
+  path path::stem() const
+  {
+    path name(filename());
+    if (name == detail::dot_path() || name == detail::dot_dot_path()) return name;
+    size_type pos(name.m_pathname.rfind(dot));
+    return pos == string_type::npos
+      ? name
+      : path(name.m_pathname.c_str(), name.m_pathname.c_str() + pos);
+  }
+
+  path path::extension() const
+  {
+    path name(filename());
+    if (name == detail::dot_path() || name == detail::dot_dot_path()) return path();
+    size_type pos(name.m_pathname.rfind(dot));
+    return pos == string_type::npos
+      ? path()
+      : path(name.m_pathname.c_str() + pos);
+  }
+
+  //  lexical operations  --------------------------------------------------------------//
+
+  namespace detail
+  {
+    // C++14 provide a mismatch algorithm with four iterator arguments(), but earlier
+    // standard libraries didn't, so provide this needed functionality.
+    inline
+    std::pair<path::iterator, path::iterator> mismatch(path::iterator it1,
+      path::iterator it1end, path::iterator it2, path::iterator it2end)
+    {
+      for (; it1 != it1end && it2 != it2end && *it1 == *it2;)
+      {
+        ++it1;
+        ++it2;
+      }
+      return std::make_pair(it1, it2);
+    }
+  }
+
+  path path::lexically_relative(const path& base) const
+  {
+    std::pair<path::iterator, path::iterator> mm
+      = detail::mismatch(begin(), end(), base.begin(), base.end());
+    if (mm.first == begin() && mm.second == base.begin())
+      return path();
+    if (mm.first == end() && mm.second == base.end())
+      return detail::dot_path();
+    path tmp;
+    for (; mm.second != base.end(); ++mm.second)
+      tmp /= detail::dot_dot_path();
+    for (; mm.first != end(); ++mm.first)
+      tmp /= *mm.first;
+    return tmp;
+  }
+
+  //  normal  --------------------------------------------------------------------------//
+
+  path path::lexically_normal() const
+  {
+    if (m_pathname.empty())
+      return *this;
+
+    path temp;
+    iterator start(begin());
+    iterator last(end());
+    iterator stop(last--);
+    for (iterator itr(start); itr != stop; ++itr)
+    {
+      // ignore "." except at start and last
+      if (itr->native().size() == 1
+        && (itr->native())[0] == dot
+        && itr != start
+        && itr != last) continue;
+
+      // ignore a name and following ".."
+      if (!temp.empty()
+        && itr->native().size() == 2
+        && (itr->native())[0] == dot
+        && (itr->native())[1] == dot) // dot dot
+      {
+        string_type lf(temp.filename().native());
+        if (lf.size() > 0
+          && (lf.size() != 1
+            || (lf[0] != dot
+              && lf[0] != separator))
+          && (lf.size() != 2
+            || (lf[0] != dot
+              && lf[1] != dot
+#             ifdef AUTOBOOST_WINDOWS_API
+              && lf[1] != colon
+#             endif
+               )
+             )
+          )
+        {
+          temp.remove_filename();
+          //// if not root directory, must also remove "/" if any
+          //if (temp.native().size() > 0
+          //  && temp.native()[temp.native().size()-1]
+          //    == separator)
+          //{
+          //  string_type::size_type rds(
+          //    root_directory_start(temp.native(), temp.native().size()));
+          //  if (rds == string_type::npos
+          //    || rds != temp.native().size()-1)
+          //  {
+          //    temp.m_pathname.erase(temp.native().size()-1);
+          //  }
+          //}
+
+          iterator next(itr);
+          if (temp.empty() && ++next != stop
+            && next == last && *last == detail::dot_path())
+          {
+            temp /= detail::dot_path();
+          }
+          continue;
+        }
+      }
+
+      temp /= *itr;
+    };
+
+    if (temp.empty())
+      temp /= detail::dot_path();
+    return temp;
+  }
+
+}  // namespace filesystem
+}  // namespace autoboost
+
+//--------------------------------------------------------------------------------------//
+//                                                                                      //
+//                         class path helpers implementation                            //
+//                                                                                      //
+//--------------------------------------------------------------------------------------//
+
+namespace
+{
+
+  //  is_root_separator  ---------------------------------------------------------------//
+
+  bool is_root_separator(const string_type & str, size_type pos)
+    // pos is position of the separator
+  {
+    AUTOBOOST_ASSERT_MSG(!str.empty() && fs::detail::is_directory_separator(str[pos]),
+      "precondition violation");
+
+    // subsequent logic expects pos to be for leftmost slash of a set
+    while (pos > 0 && fs::detail::is_directory_separator(str[pos-1]))
+      --pos;
+
+    //  "/" [...]
+    if (pos == 0)
+      return true;
+
+# ifdef AUTOBOOST_WINDOWS_API
+    //  "c:/" [...]
+    if (pos == 2 && is_letter(str[0]) && str[1] == colon)
+      return true;
+# endif
+
+    //  "//" name "/"
+    if (pos < 3 || !fs::detail::is_directory_separator(str[0])
+      || !fs::detail::is_directory_separator(str[1]))
+      return false;
+
+    return str.find_first_of(separators, 2) == pos;
+  }
+
+  //  filename_pos  --------------------------------------------------------------------//
+
+  size_type filename_pos(const string_type & str,
+                          size_type end_pos) // end_pos is past-the-end position
+    // return 0 if str itself is filename (or empty)
+  {
+    // case: "//"
+    if (end_pos == 2
+      && fs::detail::is_directory_separator(str[0])
+      && fs::detail::is_directory_separator(str[1])) return 0;
+
+    // case: ends in "/"
+    if (end_pos && fs::detail::is_directory_separator(str[end_pos-1]))
+      return end_pos-1;
+
+    // set pos to start of last element
+    size_type pos(str.find_last_of(separators, end_pos-1));
+
+#   ifdef AUTOBOOST_WINDOWS_API
+    if (pos == string_type::npos && end_pos > 1)
+      pos = str.find_last_of(colon, end_pos-2);
+#   endif
+
+    return (pos == string_type::npos // path itself must be a filename (or empty)
+      || (pos == 1 && fs::detail::is_directory_separator(str[0]))) // or net
+        ? 0 // so filename is entire string
+        : pos + 1; // or starts after delimiter
+  }
+
+  //  root_directory_start  ------------------------------------------------------------//
+
+  size_type root_directory_start(const string_type & path, size_type size)
+  // return npos if no root_directory found
+  {
+
+#   ifdef AUTOBOOST_WINDOWS_API
+    // case "c:/"
+    if (size > 2
+      && path[1] == colon
+      && fs::detail::is_directory_separator(path[2])) return 2;
+#   endif
+
+    // case "//"
+    if (size == 2
+      && fs::detail::is_directory_separator(path[0])
+      && fs::detail::is_directory_separator(path[1])) return string_type::npos;
+
+#   ifdef AUTOBOOST_WINDOWS_API
+    // case "\\?\"
+    if (size > 4
+      && fs::detail::is_directory_separator(path[0])
+      && fs::detail::is_directory_separator(path[1])
+      && path[2] == questionmark
+      && fs::detail::is_directory_separator(path[3]))
+    {
+      string_type::size_type pos(path.find_first_of(separators, 4));
+        return pos < size ? pos : string_type::npos;
+    }
+#   endif
+
+    // case "//net {/}"
+    if (size > 3
+      && fs::detail::is_directory_separator(path[0])
+      && fs::detail::is_directory_separator(path[1])
+      && !fs::detail::is_directory_separator(path[2]))
+    {
+      string_type::size_type pos(path.find_first_of(separators, 2));
+      return pos < size ? pos : string_type::npos;
+    }
+
+    // case "/"
+    if (size > 0 && fs::detail::is_directory_separator(path[0])) return 0;
+
+    return string_type::npos;
+  }
+
+  //  first_element --------------------------------------------------------------------//
+  //   sets pos and len of first element, excluding extra separators
+  //   if src.empty(), sets pos,len, to 0,0.
+
+  void first_element(
+      const string_type & src,
+      size_type & element_pos,
+      size_type & element_size,
+      size_type size
+)
+  {
+    if (size == string_type::npos) size = src.size();
+    element_pos = 0;
+    element_size = 0;
+    if (src.empty()) return;
+
+    string_type::size_type cur(0);
+
+    // deal with // [network]
+    if (size >= 2 && fs::detail::is_directory_separator(src[0])
+      && fs::detail::is_directory_separator(src[1])
+      && (size == 2
+        || !fs::detail::is_directory_separator(src[2])))
+    {
+      cur += 2;
+      element_size += 2;
+    }
+
+    // leading (not non-network) separator
+    else if (fs::detail::is_directory_separator(src[0]))
+    {
+      ++element_size;
+      // bypass extra leading separators
+      while (cur+1 < size
+        && fs::detail::is_directory_separator(src[cur+1]))
+      {
+        ++cur;
+        ++element_pos;
+      }
+      return;
+    }
+
+    // at this point, we have either a plain name, a network name,
+    // or (on Windows only) a device name
+
+    // find the end
+    while (cur < size
+#     ifdef AUTOBOOST_WINDOWS_API
+      && src[cur] != colon
+#     endif
+      && !fs::detail::is_directory_separator(src[cur]))
+    {
+      ++cur;
+      ++element_size;
+    }
+
+#   ifdef AUTOBOOST_WINDOWS_API
+    if (cur == size) return;
+    // include device delimiter
+    if (src[cur] == colon)
+      { ++element_size; }
+#   endif
+
+    return;
+  }
+
+}  // unnamed namespace
+
+
+namespace autoboost
+{
+namespace filesystem
+{
+  namespace detail
+  {
+    AUTOBOOST_FILESYSTEM_DECL
+      int lex_compare(path::iterator first1, path::iterator last1,
+        path::iterator first2, path::iterator last2)
+    {
+      for (; first1 != last1 && first2 != last2;)
+      {
+        if (first1->native() < first2->native()) return -1;
+        if (first2->native() < first1->native()) return 1;
+        AUTOBOOST_ASSERT(first2->native() == first1->native());
+        ++first1;
+        ++first2;
+      }
+      if (first1 == last1 && first2 == last2)
+        return 0;
+      return first1 == last1 ? -1 : 1;
+    }
+
+    AUTOBOOST_FILESYSTEM_DECL
+    const path&  dot_path()
+    {
+#   ifdef AUTOBOOST_WINDOWS_API
+      static const fs::path dot_pth(L".");
+#   else
+      static const fs::path dot_pth(".");
+#   endif
+      return dot_pth;
+    }
+
+    AUTOBOOST_FILESYSTEM_DECL
+    const path&  dot_dot_path()
+    {
+#   ifdef AUTOBOOST_WINDOWS_API
+      static const fs::path dot_dot(L"..");
+#   else
+      static const fs::path dot_dot("..");
+#   endif
+      return dot_dot;
+    }
+  }
+
+//--------------------------------------------------------------------------------------//
+//                                                                                      //
+//                        class path::iterator implementation                           //
+//                                                                                      //
+//--------------------------------------------------------------------------------------//
+
+  path::iterator path::begin() const
+  {
+    iterator itr;
+    itr.m_path_ptr = this;
+    size_type element_size;
+    first_element(m_pathname, itr.m_pos, element_size);
+    itr.m_element = m_pathname.substr(itr.m_pos, element_size);
+    if (itr.m_element.m_pathname == preferred_separator_string)
+      itr.m_element.m_pathname = separator_string;  // needed for Windows, harmless on POSIX
+    return itr;
+  }
+
+  path::iterator path::end() const
+  {
+    iterator itr;
+    itr.m_path_ptr = this;
+    itr.m_pos = m_pathname.size();
+    return itr;
+  }
+
+  void path::m_path_iterator_increment(path::iterator & it)
+  {
+    AUTOBOOST_ASSERT_MSG(it.m_pos < it.m_path_ptr->m_pathname.size(),
+      "path::basic_iterator increment past end()");
+
+    // increment to position past current element; if current element is implicit dot,
+    // this will cause it.m_pos to represent the end iterator
+    it.m_pos += it.m_element.m_pathname.size();
+
+    // if the end is reached, we are done
+    if (it.m_pos == it.m_path_ptr->m_pathname.size())
+    {
+      it.m_element.clear();  // aids debugging, may release unneeded memory
+      return;
+    }
+
+    // both POSIX and Windows treat paths that begin with exactly two separators specially
+    bool was_net(it.m_element.m_pathname.size() > 2
+      && detail::is_directory_separator(it.m_element.m_pathname[0])
+      && detail::is_directory_separator(it.m_element.m_pathname[1])
+      && !detail::is_directory_separator(it.m_element.m_pathname[2]));
+
+    // process separator (Windows drive spec is only case not a separator)
+    if (detail::is_directory_separator(it.m_path_ptr->m_pathname[it.m_pos]))
+    {
+      // detect root directory
+      if (was_net
+#       ifdef AUTOBOOST_WINDOWS_API
+        // case "c:/"
+        || it.m_element.m_pathname[it.m_element.m_pathname.size()-1] == colon
+#       endif
+         )
+      {
+        it.m_element.m_pathname = separator;  // generic format; see docs
+        return;
+      }
+
+      // skip separators until it.m_pos points to the start of the next element
+      while (it.m_pos != it.m_path_ptr->m_pathname.size()
+        && detail::is_directory_separator(it.m_path_ptr->m_pathname[it.m_pos]))
+        { ++it.m_pos; }
+
+      // detect trailing separator, and treat it as ".", per POSIX spec
+      if (it.m_pos == it.m_path_ptr->m_pathname.size()
+        && !is_root_separator(it.m_path_ptr->m_pathname, it.m_pos-1))
+      {
+        --it.m_pos;
+        it.m_element = detail::dot_path();
+        return;
+      }
+    }
+
+    // get m_element
+    size_type end_pos(it.m_path_ptr->m_pathname.find_first_of(separators, it.m_pos));
+    if (end_pos == string_type::npos)
+      end_pos = it.m_path_ptr->m_pathname.size();
+    it.m_element = it.m_path_ptr->m_pathname.substr(it.m_pos, end_pos - it.m_pos);
+  }
+
+  void path::m_path_iterator_decrement(path::iterator & it)
+  {
+    AUTOBOOST_ASSERT_MSG(it.m_pos, "path::iterator decrement past begin()");
+
+    size_type end_pos(it.m_pos);
+
+    // if at end and there was a trailing non-root '/', return "."
+    if (it.m_pos == it.m_path_ptr->m_pathname.size()
+      && it.m_path_ptr->m_pathname.size() > 1
+      && detail::is_directory_separator(it.m_path_ptr->m_pathname[it.m_pos-1])
+      && !is_root_separator(it.m_path_ptr->m_pathname, it.m_pos-1)
+       )
+    {
+      --it.m_pos;
+      it.m_element = detail::dot_path();
+      return;
+    }
+
+    size_type root_dir_pos(root_directory_start(it.m_path_ptr->m_pathname, end_pos));
+
+    // skip separators unless root directory
+    for (
+      ;
+      end_pos > 0
+      && (end_pos-1) != root_dir_pos
+      && detail::is_directory_separator(it.m_path_ptr->m_pathname[end_pos-1])
+      ;
+      --end_pos) {}
+
+    it.m_pos = filename_pos(it.m_path_ptr->m_pathname, end_pos);
+    it.m_element = it.m_path_ptr->m_pathname.substr(it.m_pos, end_pos - it.m_pos);
+    if (it.m_element.m_pathname == preferred_separator_string) // needed for Windows, harmless on POSIX
+      it.m_element.m_pathname = separator_string;    // generic format; see docs
+  }
+
+}  // namespace filesystem
+}  // namespace autoboost
+
+namespace
+{
+
+  //------------------------------------------------------------------------------------//
+  //                                locale helpers                                      //
+  //------------------------------------------------------------------------------------//
+
+  //  Prior versions of these locale and codecvt implementations tried to take advantage
+  //  of static initialization where possible, kept a local copy of the current codecvt
+  //  facet (to avoid codecvt() having to call use_facet()), and was not multi-threading
+  //  safe (again for efficiency).
+  //
+  //  This was error prone, and required different implementation techniques depending
+  //  on the compiler and also whether static or dynamic linking was used. Furthermore,
+  //  users could not easily provide their multi-threading safe wrappers because the
+  //  path interface requires the implementation itself to call codecvt() to obtain the
+  //  default facet, and the initialization of the static within path_locale() could race.
+  //
+  //  The code below is portable to all platforms, is much simpler, and hopefully will be
+  //  much more robust. Timing tests (on Windows, using a Visual C++ release build)
+  //  indicated the current code is roughly 9% slower than the previous code, and that
+  //  seems a small price to pay for better code that is easier to use.
+
+  std::locale default_locale()
+  {
+# if defined(AUTOBOOST_WINDOWS_API)
+    std::locale global_loc = std::locale();
+    return std::locale(global_loc, new windows_file_codecvt);
+# elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__) \
+  || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__HAIKU__)
+    // "All BSD system functions expect their string parameters to be in UTF-8 encoding
+    // and nothing else." See
+    // http://developer.apple.com/mac/library/documentation/MacOSX/Conceptual/BPInternational/Articles/FileEncodings.html
+    //
+    // "The kernel will reject any filename that is not a valid UTF-8 string, and it will
+    // even be normalized (to Unicode NFD) before stored on disk, at least when using HFS.
+    // The right way to deal with it would be to always convert the filename to UTF-8
+    // before trying to open/create a file." See
+    // http://lists.apple.com/archives/unix-porting/2007/Sep/msg00023.html
+    //
+    // "How a file name looks at the API level depends on the API. Current Carbon APIs
+    // handle file names as an array of UTF-16 characters; POSIX ones handle them as an
+    // array of UTF-8, which is why UTF-8 works well in Terminal. How it's stored on disk
+    // depends on the disk format; HFS+ uses UTF-16, but that's not important in most
+    // cases." See
+    // http://lists.apple.com/archives/applescript-users/2002/Sep/msg00319.html
+    //
+    // Many thanks to Peter Dimov for digging out the above references!
+
+    std::locale global_loc = std::locale();
+    return std::locale(global_loc, new autoboost::filesystem::detail::utf8_codecvt_facet);
+# else  // Other POSIX
+    // ISO C calls std::locale("") "the locale-specific native environment", and this
+    // locale is the default for many POSIX-based operating systems such as Linux.
+    return std::locale("");
+# endif
+  }
+
+  std::locale& path_locale()
+  // std::locale("") construction, needed on non-Apple POSIX systems, can throw
+  // (if environmental variables LC_MESSAGES or LANG are wrong, for example), so
+  // path_locale() provides lazy initialization via a local static to ensure that any
+  // exceptions occur after main() starts and so can be caught. Furthermore,
+  // path_locale() is only called if path::codecvt() or path::imbue() are themselves
+  // actually called, ensuring that an exception will only be thrown if std::locale("")
+  // is really needed.
+  {
+    // [locale] paragraph 6: Once a facet reference is obtained from a locale object by
+    // calling use_facet<>, that reference remains usable, and the results from member
+    // functions of it may be cached and re-used, as long as some locale object refers
+    // to that facet.
+    static std::locale loc(default_locale());
+#ifdef AUTOBOOST_FILESYSTEM_DEBUG
+    std::cout << "***** path_locale() called" << std::endl;
+#endif
+    return loc;
+  }
+}  // unnamed namespace
+
+//--------------------------------------------------------------------------------------//
+//              path::codecvt() and path::imbue() implementation                        //
+//--------------------------------------------------------------------------------------//
+
+namespace autoboost
+{
+namespace filesystem
+{
+  // See comments above
+
+  const path::codecvt_type& path::codecvt()
+  {
+#ifdef AUTOBOOST_FILESYSTEM_DEBUG
+    std::cout << "***** path::codecvt() called" << std::endl;
+#endif
+    AUTOBOOST_ASSERT_MSG(&path_locale(), "boost::filesystem::path locale initialization error");
+
+    return std::use_facet<std::codecvt<wchar_t, char, std::mbstate_t> >(path_locale());
+  }
+
+  std::locale path::imbue(const std::locale& loc)
+  {
+#ifdef AUTOBOOST_FILESYSTEM_DEBUG
+    std::cout << "***** path::imbue() called" << std::endl;
+#endif
+    std::locale temp(path_locale());
+    path_locale() = loc;
+    return temp;
+  }
+
+}  // namespace filesystem
+}  // namespace autoboost

--- a/contrib/autoboost/libs/filesystem/path_traits.cpp
+++ b/contrib/autoboost/libs/filesystem/path_traits.cpp
@@ -1,0 +1,201 @@
+//  filesystem path_traits.cpp  --------------------------------------------------------//
+
+//  Copyright Beman Dawes 2008, 2009
+
+//  Distributed under the Boost Software License, Version 1.0.
+//  See http://www.boost.org/LICENSE_1_0.txt
+
+//  Library home page: http://www.boost.org/libs/filesystem
+
+//--------------------------------------------------------------------------------------//
+
+// define AUTOBOOST_FILESYSTEM_SOURCE so that <autoboost/system/config.hpp> knows
+// the library is being built (possibly exporting rather than importing code)
+#include "stdafx.h"
+#define AUTOBOOST_FILESYSTEM_SOURCE
+
+#ifndef AUTOBOOST_SYSTEM_NO_DEPRECATED
+# define AUTOBOOST_SYSTEM_NO_DEPRECATED
+#endif
+
+#include <autoboost/filesystem/config.hpp>
+#include <autoboost/filesystem/path_traits.hpp>
+#include <autoboost/system/system_error.hpp>
+#include <autoboost/scoped_array.hpp>
+#include <locale>   // for codecvt_base::result
+#include <cstring>  // for strlen
+#include <cwchar>   // for wcslen
+
+namespace pt = autoboost::filesystem::path_traits;
+namespace fs = autoboost::filesystem;
+namespace bs = autoboost::system;
+
+//--------------------------------------------------------------------------------------//
+//                                  configuration                                       //
+//--------------------------------------------------------------------------------------//
+
+#ifndef AUTOBOOST_FILESYSTEM_CODECVT_BUF_SIZE
+# define AUTOBOOST_FILESYSTEM_CODECVT_BUF_SIZE 256
+#endif
+
+namespace {
+
+  const std::size_t default_codecvt_buf_size = AUTOBOOST_FILESYSTEM_CODECVT_BUF_SIZE;
+
+
+//--------------------------------------------------------------------------------------//
+//                                                                                      //
+//  The public convert() functions do buffer management, and then forward to the        //
+//  convert_aux() functions for the actual call to the codecvt facet.                   //
+//                                                                                      //
+//--------------------------------------------------------------------------------------//
+
+//--------------------------------------------------------------------------------------//
+//                      convert_aux const char* to wstring                             //
+//--------------------------------------------------------------------------------------//
+
+  void convert_aux(
+                   const char* from,
+                   const char* from_end,
+                   wchar_t* to, wchar_t* to_end,
+                   std::wstring & target,
+                   const pt::codecvt_type & cvt)
+  {
+    //std::cout << std::hex
+    //          << " from=" << std::size_t(from)
+    //          << " from_end=" << std::size_t(from_end)
+    //          << " to=" << std::size_t(to)
+    //          << " to_end=" << std::size_t(to_end)
+    //          << std::endl;
+
+    std::mbstate_t state  = std::mbstate_t();  // perhaps unneeded, but cuts bug reports
+    const char* from_next;
+    wchar_t* to_next;
+
+    std::codecvt_base::result res;
+
+    if ((res=cvt.in(state, from, from_end, from_next,
+           to, to_end, to_next)) != std::codecvt_base::ok)
+    {
+      //std::cout << " result is " << static_cast<int>(res) << std::endl;
+      AUTOBOOST_FILESYSTEM_THROW(bs::system_error(res, fs::codecvt_error_category(),
+        "boost::filesystem::path codecvt to wstring"));
+    }
+    target.append(to, to_next);
+  }
+
+//--------------------------------------------------------------------------------------//
+//                      convert_aux const wchar_t* to string                           //
+//--------------------------------------------------------------------------------------//
+
+  void convert_aux(
+                   const wchar_t* from,
+                   const wchar_t* from_end,
+                   char* to, char* to_end,
+                   std::string & target,
+                   const pt::codecvt_type & cvt)
+  {
+    //std::cout << std::hex
+    //          << " from=" << std::size_t(from)
+    //          << " from_end=" << std::size_t(from_end)
+    //          << " to=" << std::size_t(to)
+    //          << " to_end=" << std::size_t(to_end)
+    //          << std::endl;
+
+    std::mbstate_t state  = std::mbstate_t();  // perhaps unneeded, but cuts bug reports
+    const wchar_t* from_next;
+    char* to_next;
+
+    std::codecvt_base::result res;
+
+    if ((res=cvt.out(state, from, from_end, from_next,
+           to, to_end, to_next)) != std::codecvt_base::ok)
+    {
+      //std::cout << " result is " << static_cast<int>(res) << std::endl;
+      AUTOBOOST_FILESYSTEM_THROW(bs::system_error(res, fs::codecvt_error_category(),
+        "boost::filesystem::path codecvt to string"));
+    }
+    target.append(to, to_next);
+  }
+
+}  // unnamed namespace
+
+//--------------------------------------------------------------------------------------//
+//                                   path_traits                                        //
+//--------------------------------------------------------------------------------------//
+
+namespace autoboost { namespace filesystem { namespace path_traits {
+
+//--------------------------------------------------------------------------------------//
+//                          convert const char* to wstring                              //
+//--------------------------------------------------------------------------------------//
+
+  AUTOBOOST_FILESYSTEM_DECL
+  void convert(const char* from,
+                const char* from_end,    // 0 for null terminated MBCS
+                std::wstring & to,
+                const codecvt_type & cvt)
+  {
+    AUTOBOOST_ASSERT(from);
+
+    if (!from_end)  // null terminated
+    {
+      from_end = from + std::strlen(from);
+    }
+
+    if (from == from_end) return;
+
+    std::size_t buf_size = (from_end - from) * 3;  // perhaps too large, but that's OK
+
+    //  dynamically allocate a buffer only if source is unusually large
+    if (buf_size > default_codecvt_buf_size)
+    {
+      autoboost::scoped_array< wchar_t > buf(new wchar_t [buf_size]);
+      convert_aux(from, from_end, buf.get(), buf.get()+buf_size, to, cvt);
+    }
+    else
+    {
+      wchar_t buf[default_codecvt_buf_size];
+      convert_aux(from, from_end, buf, buf+default_codecvt_buf_size, to, cvt);
+    }
+  }
+
+//--------------------------------------------------------------------------------------//
+//                         convert const wchar_t* to string                            //
+//--------------------------------------------------------------------------------------//
+
+  AUTOBOOST_FILESYSTEM_DECL
+  void convert(const wchar_t* from,
+                const wchar_t* from_end,  // 0 for null terminated MBCS
+                std::string & to,
+                const codecvt_type & cvt)
+  {
+    AUTOBOOST_ASSERT(from);
+
+    if (!from_end)  // null terminated
+    {
+      from_end = from + std::wcslen(from);
+    }
+
+    if (from == from_end) return;
+
+    //  The codecvt length functions may not be implemented, and I don't really
+    //  understand them either. Thus this code is just a guess; if it turns
+    //  out the buffer is too small then an error will be reported and the code
+    //  will have to be fixed.
+    std::size_t buf_size = (from_end - from) * 4;  // perhaps too large, but that's OK
+    buf_size += 4;  // encodings like shift-JIS need some prefix space
+
+    //  dynamically allocate a buffer only if source is unusually large
+    if (buf_size > default_codecvt_buf_size)
+    {
+      autoboost::scoped_array< char > buf(new char [buf_size]);
+      convert_aux(from, from_end, buf.get(), buf.get()+buf_size, to, cvt);
+    }
+    else
+    {
+      char buf[default_codecvt_buf_size];
+      convert_aux(from, from_end, buf, buf+default_codecvt_buf_size, to, cvt);
+    }
+  }
+}}} // namespace autoboost::filesystem::path_traits

--- a/contrib/autoboost/libs/filesystem/portability.cpp
+++ b/contrib/autoboost/libs/filesystem/portability.cpp
@@ -1,0 +1,120 @@
+//  portability.cpp  -------------------------------------------------------------------//
+
+//  Copyright 2002-2005 Beman Dawes
+//  Use, modification, and distribution is subject to the Boost Software
+//  License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy
+//  at http://www.boost.org/LICENSE_1_0.txt)
+
+//  See library home page at http://www.boost.org/libs/filesystem
+
+//--------------------------------------------------------------------------------------//
+
+// define AUTOBOOST_FILESYSTEM_SOURCE so that <autoboost/filesystem/config.hpp> knows
+// the library is being built (possibly exporting rather than importing code)
+#include "stdafx.h"
+#define AUTOBOOST_FILESYSTEM_SOURCE
+
+#ifndef AUTOBOOST_SYSTEM_NO_DEPRECATED
+# define AUTOBOOST_SYSTEM_NO_DEPRECATED
+#endif
+
+#include <autoboost/filesystem/config.hpp>
+#include <autoboost/filesystem/path.hpp>
+
+namespace fs = autoboost::filesystem;
+
+#include <cstring> // SGI MIPSpro compilers need this
+
+# ifdef AUTOBOOST_NO_STDC_NAMESPACE
+    namespace std { using ::strerror; }
+# endif
+
+//--------------------------------------------------------------------------------------//
+
+namespace
+{
+  const char invalid_chars[] =
+    "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F"
+    "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F"
+    "<>:\"/\\|";
+  // note that the terminating '\0' is part of the string - thus the size below
+  // is sizeof(invalid_chars) rather than sizeof(invalid_chars)-1.  I
+  const std::string windows_invalid_chars(invalid_chars, sizeof(invalid_chars));
+
+  const std::string valid_posix(
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-");
+
+} // unnamed namespace
+
+namespace autoboost
+{
+  namespace filesystem
+  {
+
+    //  name_check functions  ----------------------------------------------//
+
+#   ifdef AUTOBOOST_WINDOWS
+    AUTOBOOST_FILESYSTEM_DECL bool native(const std::string & name)
+    {
+      return windows_name(name);
+    }
+#   else
+    AUTOBOOST_FILESYSTEM_DECL bool native(const std::string & name)
+    {
+      return  name.size() != 0
+        && name[0] != ' '
+        && name.find('/') == std::string::npos;
+    }
+#   endif
+
+    AUTOBOOST_FILESYSTEM_DECL bool portable_posix_name(const std::string & name)
+    {
+      return name.size() != 0
+        && name.find_first_not_of(valid_posix) == std::string::npos;
+    }
+
+    AUTOBOOST_FILESYSTEM_DECL bool windows_name(const std::string & name)
+    {
+      return name.size() != 0
+        && name[0] != ' '
+        && name.find_first_of(windows_invalid_chars) == std::string::npos
+        && *(name.end()-1) != ' '
+        && (*(name.end()-1) != '.'
+          || name.length() == 1 || name == "..");
+    }
+
+    AUTOBOOST_FILESYSTEM_DECL bool portable_name(const std::string & name)
+    {
+      return
+        name.size() != 0
+        && (name == "."
+          || name == ".."
+          || (windows_name(name)
+            && portable_posix_name(name)
+            && name[0] != '.' && name[0] != '-'));
+    }
+
+    AUTOBOOST_FILESYSTEM_DECL bool portable_directory_name(const std::string & name)
+    {
+      return
+        name == "."
+        || name == ".."
+        || (portable_name(name)
+          && name.find('.') == std::string::npos);
+    }
+
+    AUTOBOOST_FILESYSTEM_DECL bool portable_file_name(const std::string & name)
+    {
+      std::string::size_type pos;
+      return
+         portable_name(name)
+         && name != "."
+         && name != ".."
+         && ((pos = name.find('.')) == std::string::npos
+             || (name.find('.', pos+1) == std::string::npos
+               && (pos + 5) > name.length()))
+        ;
+    }
+
+  } // namespace filesystem
+} // namespace autoboost

--- a/contrib/autoboost/libs/filesystem/unique_path.cpp
+++ b/contrib/autoboost/libs/filesystem/unique_path.cpp
@@ -1,0 +1,162 @@
+//  filesystem unique_path.cpp  --------------------------------------------------------//
+
+//  Copyright Beman Dawes 2010
+
+//  Distributed under the Boost Software License, Version 1.0.
+//  See http://www.boost.org/LICENSE_1_0.txt
+
+//  Library home page: http://www.boost.org/libs/filesystem
+
+//--------------------------------------------------------------------------------------//
+
+// define AUTOBOOST_FILESYSTEM_SOURCE so that <autoboost/filesystem/config.hpp> knows
+// the library is being built (possibly exporting rather than importing code)
+#include "stdafx.h"
+#define AUTOBOOST_FILESYSTEM_SOURCE
+
+#ifndef AUTOBOOST_SYSTEM_NO_DEPRECATED
+# define AUTOBOOST_SYSTEM_NO_DEPRECATED
+#endif
+
+#include <autoboost/filesystem/operations.hpp>
+#include <cassert>
+
+# ifdef AUTOBOOST_POSIX_API
+#   include <fcntl.h>
+#   ifdef AUTOBOOST_HAS_UNISTD_H
+#      include <unistd.h>
+#   endif
+# else // AUTOBOOST_WINDOWS_API
+#   include <windows.h>
+#   include <wincrypt.h>
+#   pragma comment(lib, "Advapi32.lib")
+# endif
+
+namespace {
+
+void fail(int err, autoboost::system::error_code* ec)
+{
+  if (ec == 0)
+    AUTOBOOST_FILESYSTEM_THROW( autoboost::system::system_error(err,
+      autoboost::system::system_category(),
+      "boost::filesystem::unique_path"));
+
+  ec->assign(err, autoboost::system::system_category());
+  return;
+}
+
+#ifdef AUTOBOOST_WINDOWS_API
+
+int acquire_crypt_handle(HCRYPTPROV& handle)
+{
+  if (::CryptAcquireContextW(&handle, 0, 0, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT | CRYPT_SILENT))
+    return 0;
+
+  int errval = ::GetLastError();
+  if (errval != NTE_BAD_KEYSET)
+    return errval;
+
+  if (::CryptAcquireContextW(&handle, 0, 0, PROV_RSA_FULL, CRYPT_NEWKEYSET | CRYPT_VERIFYCONTEXT | CRYPT_SILENT))
+    return 0;
+
+  errval = ::GetLastError();
+  // Another thread could have attempted to create the keyset at the same time.
+  if (errval != NTE_EXISTS)
+    return errval;
+
+  if (::CryptAcquireContextW(&handle, 0, 0, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT | CRYPT_SILENT))
+    return 0;
+
+  return ::GetLastError();
+}
+
+#endif
+
+void system_crypt_random(void* buf, std::size_t len, autoboost::system::error_code* ec)
+{
+# ifdef AUTOBOOST_POSIX_API
+
+  int file = open("/dev/urandom", O_RDONLY);
+  if (file == -1)
+  {
+    file = open("/dev/random", O_RDONLY);
+    if (file == -1)
+    {
+      fail(errno, ec);
+      return;
+    }
+  }
+
+  size_t bytes_read = 0;
+  while (bytes_read < len)
+  {
+    ssize_t n = read(file, buf, len - bytes_read);
+    if (n == -1)
+    {
+      close(file);
+      fail(errno, ec);
+      return;
+    }
+    bytes_read += n;
+    buf = static_cast<char*>(buf) + n;
+  }
+
+  close(file);
+
+# else // AUTOBOOST_WINDOWS_API
+
+  HCRYPTPROV handle;
+  int errval = acquire_crypt_handle(handle);
+
+  if (!errval)
+  {
+    BOOL gen_ok = ::CryptGenRandom(handle, len, static_cast<unsigned char*>(buf));
+    if (!gen_ok)
+      errval = ::GetLastError();
+    ::CryptReleaseContext(handle, 0);
+  }
+
+  if (!errval) return;
+
+  fail(errval, ec);
+# endif
+}
+
+}  // unnamed namespace
+
+namespace autoboost { namespace filesystem { namespace detail {
+
+AUTOBOOST_FILESYSTEM_DECL
+path unique_path(const path& model, system::error_code* ec)
+{
+  std::wstring s (model.wstring());  // std::string ng for MBCS encoded POSIX
+  const wchar_t hex[] = L"0123456789abcdef";
+  char ran[] = "123456789abcdef";  // init to avoid clang static analyzer message
+                                   // see ticket #8954
+  assert(sizeof(ran) == 16);
+  const int max_nibbles = 2 * sizeof(ran);   // 4-bits per nibble
+
+  int nibbles_used = max_nibbles;
+  for(std::wstring::size_type i=0; i < s.size(); ++i)
+  {
+    if (s[i] == L'%')                        // digit request
+    {
+      if (nibbles_used == max_nibbles)
+      {
+        system_crypt_random(ran, sizeof(ran), ec);
+        if (ec != 0 && *ec)
+          return "";
+        nibbles_used = 0;
+      }
+      int c = ran[nibbles_used/2];
+      c >>= 4 * (nibbles_used++ & 1);  // if odd, shift right 1 nibble
+      s[i] = hex[c & 0xf];             // convert to hex digit and replace
+    }
+  }
+
+  if (ec != 0) ec->clear();
+
+  return s;
+}
+
+}}}

--- a/contrib/autoboost/libs/filesystem/utf8_codecvt_facet.cpp
+++ b/contrib/autoboost/libs/filesystem/utf8_codecvt_facet.cpp
@@ -1,0 +1,28 @@
+// Copyright Vladimir Prus 2004.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// For HP-UX, request that WCHAR_MAX and WCHAR_MIN be defined as macros,
+// not casts. See ticket 5048
+#include "stdafx.h"
+#define _INCLUDE_STDCSOURCE_199901
+
+#ifndef AUTOBOOST_SYSTEM_NO_DEPRECATED
+# define AUTOBOOST_SYSTEM_NO_DEPRECATED
+#endif
+
+#define AUTOBOOST_FILESYSTEM_SOURCE
+#include <autoboost/filesystem/config.hpp>
+
+#define AUTOBOOST_UTF8_BEGIN_NAMESPACE \
+     namespace autoboost { namespace filesystem { namespace detail {
+
+#define AUTOBOOST_UTF8_END_NAMESPACE }}}
+#define AUTOBOOST_UTF8_DECL AUTOBOOST_FILESYSTEM_DECL
+
+#include <autoboost/detail/utf8_codecvt_facet.ipp>
+
+#undef AUTOBOOST_UTF8_BEGIN_NAMESPACE
+#undef AUTOBOOST_UTF8_END_NAMESPACE
+#undef AUTOBOOST_UTF8_DECL

--- a/contrib/autoboost/libs/filesystem/windows_file_codecvt.cpp
+++ b/contrib/autoboost/libs/filesystem/windows_file_codecvt.cpp
@@ -1,0 +1,76 @@
+//  filesystem windows_file_codecvt.cpp  -----------------------------------------//
+
+//  Copyright Beman Dawes 2009
+
+//  Distributed under the Boost Software License, Version 1.0.
+//  See http://www.boost.org/LICENSE_1_0.txt
+
+//  Library home page: http://www.boost.org/libs/filesystem
+
+//--------------------------------------------------------------------------------------//
+
+// define AUTOBOOST_FILESYSTEM_SOURCE so that <autoboost/system/config.hpp> knows
+// the library is being built (possibly exporting rather than importing code)
+#include "stdafx.h"
+#define AUTOBOOST_FILESYSTEM_SOURCE
+
+#ifndef AUTOBOOST_SYSTEM_NO_DEPRECATED
+# define AUTOBOOST_SYSTEM_NO_DEPRECATED
+#endif
+
+#include <autoboost/filesystem/config.hpp>
+#include <cwchar>  // for mbstate_t
+
+#ifdef AUTOBOOST_WINDOWS_API
+
+#include "windows_file_codecvt.hpp"
+
+// Versions of MinGW prior to GCC 4.6 requires this
+#ifndef WINVER
+# define WINVER 0x0500
+#endif
+
+#include <windows.h>
+
+  std::codecvt_base::result windows_file_codecvt::do_in(
+    std::mbstate_t &,
+    const char* from, const char* from_end, const char*& from_next,
+    wchar_t* to, wchar_t* to_end, wchar_t*& to_next) const
+  {
+    UINT codepage = AreFileApisANSI() ? CP_ACP : CP_OEMCP;
+
+    int count;
+    if ((count = ::MultiByteToWideChar(codepage, MB_PRECOMPOSED, from,
+      from_end - from, to, to_end - to)) == 0)
+    {
+      return error;  // conversion failed
+    }
+
+    from_next = from_end;
+    to_next = to + count;
+    *to_next = L'\0';
+    return ok;
+ }
+
+  std::codecvt_base::result windows_file_codecvt::do_out(
+    std::mbstate_t &,
+    const wchar_t* from, const wchar_t* from_end, const wchar_t*  & from_next,
+    char* to, char* to_end, char* & to_next) const
+  {
+    UINT codepage = AreFileApisANSI() ? CP_ACP : CP_OEMCP;
+
+    int count;
+    if ((count = ::WideCharToMultiByte(codepage, WC_NO_BEST_FIT_CHARS, from,
+      from_end - from, to, to_end - to, 0, 0)) == 0)
+    {
+      return error;  // conversion failed
+    }
+
+    from_next = from_end;
+    to_next = to + count;
+    *to_next = '\0';
+    return ok;
+  }
+
+  # endif  // AUTOBOOST_WINDOWS_API
+

--- a/contrib/autoboost/libs/filesystem/windows_file_codecvt.hpp
+++ b/contrib/autoboost/libs/filesystem/windows_file_codecvt.hpp
@@ -1,0 +1,56 @@
+//  filesystem windows_file_codecvt.hpp  -----------------------------------------------//
+
+//  Copyright Beman Dawes 2009
+
+//  Distributed under the Boost Software License, Version 1.0.
+//  See http://www.boost.org/LICENSE_1_0.txt
+
+//  Library home page: http://www.boost.org/libs/filesystem
+
+#ifndef AUTOBOOST_FILESYSTEM3_WIN_FILE_CODECVT_HPP
+#define AUTOBOOST_FILESYSTEM3_WIN_FILE_CODECVT_HPP
+
+#include <autoboost/filesystem/config.hpp>
+#include <locale>
+
+  //------------------------------------------------------------------------------------//
+  //                                                                                    //
+  //                          class windows_file_codecvt                                //
+  //                                                                                    //
+  //  Warning: partial implementation; even do_in and do_out only partially meet the    //
+  //  standard library specifications as the "to" buffer must hold the entire result.   //
+  //                                                                                    //
+  //------------------------------------------------------------------------------------//
+
+  class AUTOBOOST_FILESYSTEM_DECL windows_file_codecvt
+    : public std::codecvt< wchar_t, char, std::mbstate_t >
+  {
+  public:
+    explicit windows_file_codecvt(std::size_t refs = 0)
+        : std::codecvt<wchar_t, char, std::mbstate_t>(refs) {}
+  protected:
+
+    virtual bool do_always_noconv() const throw() { return false; }
+
+    //  seems safest to assume variable number of characters since we don't
+    //  actually know what codepage is active
+    virtual int do_encoding() const throw() { return 0; }
+
+    virtual std::codecvt_base::result do_in(std::mbstate_t& state,
+      const char* from, const char* from_end, const char*& from_next,
+      wchar_t* to, wchar_t* to_end, wchar_t*& to_next) const;
+
+    virtual std::codecvt_base::result do_out(std::mbstate_t & state,
+      const wchar_t* from, const wchar_t* from_end, const wchar_t*& from_next,
+      char* to, char* to_end, char*& to_next) const;
+
+    virtual std::codecvt_base::result do_unshift(std::mbstate_t&,
+        char* /*from*/, char* /*to*/, char* & /*next*/) const  { return ok; }
+
+    virtual int do_length(std::mbstate_t&,
+      const char* /*from*/, const char* /*from_end*/, std::size_t /*max*/) const  { return 0; }
+
+    virtual int do_max_length() const throw () { return 0; }
+  };
+
+#endif  // AUTOBOOST_FILESYSTEM3_WIN_FILE_CODECVT_HPP

--- a/src/autowiring/C++11/cpp11.h
+++ b/src/autowiring/C++11/cpp11.h
@@ -343,6 +343,11 @@
   #define _WEBSOCKETPP_CPP11_SYSTEM_ERROR_
 #endif
 
+/**
+ * Filesystem
+ */
+#define FILESYSTEM_HEADER <autowiring/C++11/filesystem.h>
+
 /*********************
  * Deprecation convenience macro
  *********************/

--- a/src/autowiring/C++11/filesystem.h
+++ b/src/autowiring/C++11/filesystem.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#ifdef _MSC_VER
+#include <filesystem>
+namespace awfsnamespace = std::tr2::sys;
+#else
+// Experimental filesystem library is rare everywhere else, we have to resort to autoboost
+#include <autoboost/filesystem/config.hpp>
+#include <autoboost/filesystem/convenience.hpp>
+#include <autoboost/filesystem/operations.hpp>
+#include <autoboost/filesystem/path.hpp>
+namespace awfsnamespace = autoboost::filesystem;
+#endif
+
+namespace std {
+  namespace filesystem {
+    using awfsnamespace::path;
+    using awfsnamespace::wpath;
+    using awfsnamespace::basename;
+    using awfsnamespace::create_directory;
+    using awfsnamespace::current_path;
+    using awfsnamespace::exists;
+    using awfsnamespace::initial_path;
+    using awfsnamespace::is_directory;
+    using awfsnamespace::is_empty;
+    using awfsnamespace::remove;
+    using awfsnamespace::remove_all;
+    using awfsnamespace::rename;
+
+#ifdef _MSC_VER
+    template<class _Path>
+    _Path canonical(const _Path& _Pval, const _Path& _Pbase = current_path<_Path>())
+    {
+      return awfsnamespace::complete(_Pval, _Pbase);
+    }
+#else
+    using awfsnamespace::canonical;
+#endif
+  }
+}

--- a/src/autowiring/C++11/filesystem.h
+++ b/src/autowiring/C++11/filesystem.h
@@ -1,3 +1,4 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 #ifdef _MSC_VER

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -194,6 +194,29 @@ add_conditional_sources(
 
 add_conditional_sources(
   Autowiring_SRCS
+  "ON"
+  GROUP_NAME "Autoboost"
+  FILES
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/codecvt_error_category.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/operations.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/path.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/path_traits.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/portability.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/unique_path.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/utf8_codecvt_facet.cpp
+)
+
+add_conditional_sources(
+  Autowiring_SRCS
+  "MSVC"
+  GROUP_NAME "Autoboost"
+  FILES
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/windows_file_codecvt.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/windows_file_codecvt.hpp
+)
+
+add_conditional_sources(
+  Autowiring_SRCS
   "TRUE"
   GROUP_NAME "C++11"
   FILES
@@ -214,6 +237,7 @@ add_conditional_sources(
   C++11/chrono_with_profiling_clock.h
   C++11/cpp11.h
   C++11/empty_file.h
+  C++11/filesystem.h
   C++11/make_unique.h
   C++11/memory.h
   C++11/memory_nostl11.h
@@ -279,8 +303,11 @@ add_library(Autowiring STATIC ${Autowiring_SRCS})
 
 target_include_directories(
   Autowiring
+  PRIVATE
+  .
   PUBLIC
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/contrib/autoboost>"
+  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>"
   INTERFACE
   "$<INSTALL_INTERFACE:include>"
 )

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -43,6 +43,7 @@ set(AutowiringTest_SRCS
   DtorCorrectnessTest.cpp
   ExceptionFilterTest.cpp
   FactoryTest.cpp
+  FileSystemHeaderTest.cpp
   GlobalInitTest.hpp
   GlobalInitTest.cpp
   HeteroBlockTest.cpp

--- a/src/autowiring/test/FileSystemHeaderTest.cpp
+++ b/src/autowiring/test/FileSystemHeaderTest.cpp
@@ -1,3 +1,4 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/C++11/cpp11.h>
 #include <gtest/gtest.h>

--- a/src/autowiring/test/FileSystemHeaderTest.cpp
+++ b/src/autowiring/test/FileSystemHeaderTest.cpp
@@ -1,0 +1,18 @@
+#include "stdafx.h"
+#include <autowiring/C++11/cpp11.h>
+#include <gtest/gtest.h>
+#include <autoboost/filesystem/config.hpp>
+#include <autoboost/filesystem/convenience.hpp>
+#include <autoboost/filesystem/operations.hpp>
+#include <autoboost/filesystem/path.hpp>
+#include FILESYSTEM_HEADER
+
+class FileSystemHeaderTest:
+  public testing::Test
+{};
+
+TEST_F(FileSystemHeaderTest, PathPropertiesTest) {
+  std::filesystem::path p = "abc/def.jpg";
+  ASSERT_STREQ(".jpg", p.extension().c_str());
+  ASSERT_STREQ("def.jpg", p.filename().c_str());
+}

--- a/src/autowiring/thread_specific_ptr.h
+++ b/src/autowiring/thread_specific_ptr.h
@@ -17,7 +17,7 @@
 namespace autowiring {
 
 // <summary>
-// Holds a ptr in thread local storage. Same interface as boost::thread_specific_ptr
+// Holds a ptr in thread local storage. Same interface as autoboost::thread_specific_ptr
 // </summary>
 template<typename T>
 class thread_specific_ptr {


### PR DESCRIPTION
This is a useful experimental feature that has broad support.  Adding a shim header here allows some clients to eliminate a boost dependency.