### PR TITLE
Fix rounding error

### DIFF
--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -130,15 +130,15 @@ namespace autowiring {
       int power = static_cast<int>(std::log10(value));
 
       // We will be assembling the number backwards, need to keep track of the
-      // current digit
+      // index of the current digit in the reassembled number.
       int curDigit = std::numeric_limits<type>::digits10 - power;
 
       // We only want a certain number of digits, this digit count will fit in
       // a large integer and elimintes the loss of precision we experience when
       // using floating point math to try to do digit shifts
-      uint64_t digits = static_cast<uint64_t>(value * std::pow(10.0, curDigit));
+      uint64_t digits = static_cast<uint64_t>(value * std::pow(10.0, curDigit) + 0.5);
 
-      // Trailing zero introduction
+      // Trailing zero introduction for integer multiples of 10
       if (power > std::numeric_limits<type>::digits10)
         retVal.append(power - std::numeric_limits<type>::digits10, '0');
 

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -47,6 +47,7 @@ set(AutowiringTest_SRCS
   GlobalInitTest.cpp
   HeteroBlockTest.cpp
   InterlockedRoutinesTest.cpp
+  MarshallerTest.cpp
   MultiInheritTest.cpp
   ObjectPoolTest.cpp
   ObservableTest.cpp

--- a/src/autowiring/test/MarshallerTest.cpp
+++ b/src/autowiring/test/MarshallerTest.cpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include <autowiring/marshaller.h>
+
+class MarshallerTest:
+  public testing::Test
+{};
+
+TEST_F(MarshallerTest, DoubleMarshalTest) {
+  autowiring::builtin_marshaller<double, void> b;
+
+  double x = -0.00899999999999999;
+  std::string val = b.marshal(&x);
+  ASSERT_STREQ("-0.00899999999999999", val.c_str());
+}


### PR DESCRIPTION
This problem causes imprecise serialization round trips for floating-point config fields