### PR TITLE
Eliminate use of `std::to_string`

### DIFF
--- a/src/autowiring/test/AutoConfig_FromTableTest.cpp
+++ b/src/autowiring/test/AutoConfig_FromTableTest.cpp
@@ -105,7 +105,10 @@ TEST_F(AutoConfig_FromTableTest, HeirarchialAssignment) {
     AutoRequired<UserTest> ut{ child };
     ASSERT_EQ(user_key["user_name"], ut->user_name);
     ASSERT_EQ(user_key["user_email"], ut->user_email);
-    ASSERT_EQ(user_key["user_age"], std::to_string(ut->user_age));
+
+    std::stringstream ss;
+    ss << ut->user_age;
+    ASSERT_EQ(user_key["user_age"], ss.str());
     ASSERT_EQ(user_key["user_valid"] == "true", ut->user_valid);
   }
 }


### PR DESCRIPTION
This method isn't supported in Android.  Remove our use of it until a shim is created, or support is provided.