### PR TITLE
Eliminate ObjectPool constructing allocator

### DIFF
--- a/src/autowiring/optional.h
+++ b/src/autowiring/optional.h
@@ -51,6 +51,15 @@ public:
   }
   const T& value(void) const { return const_cast<optional*>(this)->value(); }
 
+  /// <summary>
+  /// Passes a pointer to the internal object space to the passed callback
+  /// </remarks>
+  template<typename Fn>
+  void placement(const Fn& placement) {
+    placement(reinterpret_cast<T*>(val));
+    m_valid = true;
+  }
+
   // Indirection operators:
   T* operator->(void) { return &value(); }
   const T* operator->(void) const { return &value(); }

--- a/src/autowiring/test/ObjectPoolTest.cpp
+++ b/src/autowiring/test/ObjectPoolTest.cpp
@@ -50,8 +50,10 @@ public:
   }
 
   static ObjectPool<LifeCycle>* NewObjectPool(size_t limit = ~0, size_t maxPooled = ~0) {
-    return new ObjectPool<LifeCycle>(limit, maxPooled,
-      [] { return new LifeCycle(); },
+    return new ObjectPool<LifeCycle>(
+      limit,
+      maxPooled,
+      [] (LifeCycle* ptr) { new (ptr) LifeCycle; },
       [] (LifeCycle& life) { life.Initialize(); },
       [] (LifeCycle& life) { life.Finalize(); }
     );
@@ -369,7 +371,8 @@ TEST_F(ObjectPoolTest, VerifyInitializerFinalizer) {
   auto termFlag = std::make_shared<bool>(false);
 
   ObjectPool<bool> pool(
-    &DefaultCreate<bool>,
+    autowiring::placement,
+    &DefaultPlacement<bool>,
     [initFlag](bool&) { *initFlag = true; },
     [termFlag](bool&) { *termFlag = true; }
   );


### PR DESCRIPTION
This allocator has been deprecated since #684, v0.7.2 and should be removed.  Commensurate with this removal, we should also implement the suggested performance enhancements that were blocked due to the necessity to support this legacy overload.

Fixes #681