### PR TITLE
Eliminate CoreContext::AddTeardownListener

### DIFF
--- a/src/autowiring/CoreContext.h
+++ b/src/autowiring/CoreContext.h
@@ -389,31 +389,6 @@ protected:
   template<class Factory>
   void RegisterFactory(const Factory&, autowiring::member_new_type<Factory, autowiring::factorytype::none>) {}
 
-  // Internal resolvers, used to determine which teardown style the user would like to use
-  /// \internal
-  template<class Fx>
-  void AddTeardownListener2(Fx&& fx, void (Fx::*)(void)) {
-    onTeardown += [fx](const CoreContext&) { fx(); };
-  }
-
-  /// \internal
-  template<class Fx>
-  void AddTeardownListener2(Fx&& fx, void (Fx::*)(const CoreContext&)) {
-    onTeardown += std::move(fx);
-  }
-
-  /// \internal
-  template<class Fx>
-  void AddTeardownListener2(Fx&& fx, void (Fx::*)(void) const) {
-    onTeardown += [fx](const CoreContext&) { fx(); };
-  }
-
-  /// \internal
-  template<class Fx>
-  void AddTeardownListener2(Fx&& fx, void (Fx::*)(const CoreContext&) const) {
-    onTeardown += std::move(fx);
-  }
-
 public:
   // Accessor methods:
   /// True if and only if this is the global context.
@@ -979,22 +954,11 @@ public:
   }
 
   /// <summary>
-  /// Adds a teardown notifier which receives a pointer to this context on destruction
-  /// </summary>
-  template<class Fx>
-  void DEPRECATED(AddTeardownListener(Fx&& fx), "Superceded by onTeardown");
-
-  /// <summary>
   /// Utility debug method for writing a snapshot of this context to the specified output stream
   /// </summary>
   void Dump(std::ostream& os) const;
 };
 
-
-template<class Fx>
-void CoreContext::AddTeardownListener(Fx&& fx) {
-  AddTeardownListener2<Fx>(std::forward<Fx&&>(fx), &Fx::operator());
-}
 
 namespace autowiring {
   /// <summary>

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -455,15 +455,14 @@ TEST_F(CoreContextTest, UnlinkOnTeardown) {
     ASSERT_TRUE(a->so.IsAutowired()) << "Root object pointer not correctly obtained";
     ASSERT_TRUE(b->so.IsAutowired()) << "Root object pointer not correctly obtained";
 
-    ctxt->AddTeardownListener(
-      [weakA, strongB] {
+    ctxt->onTeardown +=
+      [weakA, strongB] (const CoreContext&) {
         // Verify that nothing got screwed up at this point:
         auto a = weakA.lock();
         ASSERT_FALSE(weakA.expired()) << "Weak pointer expired prematurely";
         ASSERT_EQ(strongB, a->b) << "Unlink occurred prematurely";
         ASSERT_EQ(a, strongB->a) << "Unlink occured prematurely";
-      }
-    );
+      };
 
     // Set the flag at the last possible and to ensure things still get torn down
     ctxt->SetUnlinkOnTeardown(true);

--- a/src/autowiring/test/TeardownNotifierTest.cpp
+++ b/src/autowiring/test/TeardownNotifierTest.cpp
@@ -34,14 +34,14 @@ TEST_F(TeardownNotifierTest, ReferenceMemberInTeardown) {
     AutoRequired <SimpleMember> member;
     std::weak_ptr<SimpleMember> memberWeak(member);
 
-    ctxt->AddTeardownListener([memberWeak, &hit] {
+    ctxt->onTeardown += [memberWeak, &hit] (const CoreContext&) {
       try
       {
         if (!memberWeak.expired())
           hit = true;
       }
       catch (autowiring_error) {}
-    });
+    };
   }
 
   ASSERT_TRUE(hit) << "Failed to reference a member of a context in it's teardown listener";
@@ -53,10 +53,10 @@ TEST_F(TeardownNotifierTest, CanAutowireInTeardown) {
   {
     AutoCreateContext ctxt;
     AutoRequired<SimpleMember> sm(ctxt);
-    ctxt->AddTeardownListener([&foundSimpleMember, &calledNotifier](const CoreContext& ctxt) {
+    ctxt->onTeardown += [&foundSimpleMember, &calledNotifier](const CoreContext& ctxt) {
       foundSimpleMember = AutowiredFast<SimpleMember>(&ctxt).IsAutowired();
       calledNotifier = true;
-    });
+    };
   }
 
   ASSERT_TRUE(foundSimpleMember) << "Failed to find a context member in teardown with AutowiredFast";


### PR DESCRIPTION
This method has been deprecated since #713, v0.7.3, and has been superceded by `CoreContext::onTeardown`.