### PR TITLE
Eliminate AutoPacket::Unsatisfiable

### DIFF
--- a/src/autowiring/AutoPacket.h
+++ b/src/autowiring/AutoPacket.h
@@ -444,16 +444,6 @@ public:
   /// form std::shared_ptr<const T> to be called, if the remainder of their inputs are available.
   /// </remarks>
   template<class T>
-  void DEPRECATED(Unsatisfiable(void), "Unsatisfiable is deprecated; use MarkUnsatisfiable instead.");
-
-  /// <summary>
-  /// Marks the named decoration as unsatisfiable
-  /// </summary>
-  /// <remarks>
-  /// Marking a decoration as unsatisfiable immediately causes any filters with an input of the
-  /// form std::shared_ptr<const T> to be called, if the remainder of their inputs are available.
-  /// </remarks>
-  template<class T>
   void MarkUnsatisfiable(void) {
     MarkUnsatisfiable(DecorationKey(auto_id_t<T>{}, 0));
   }
@@ -911,8 +901,3 @@ public:
     return packet.shared_from_this();
   }
 };
-
-template<class T>
-void AutoPacket::Unsatisfiable(void) {
-  MarkUnsatisfiable(DecorationKey(auto_id_t<T>{}, 0));
-}


### PR DESCRIPTION
This method has been deprecated since #627, v0.7.1, and is superceded by `AutoPacket::MarkUnsatisfiable`