### PR TITLE
Fix Android build

### DIFF
--- a/cmake-modules/AddPCH.cmake
+++ b/cmake-modules/AddPCH.cmake
@@ -1,18 +1,12 @@
 #MSVC pch macro.  Copied from http://pastebin.com/84dm5rXZ and modified by Walter Gray
-macro(add_pch SourcesVar PrecompiledHeader PrecompiledSource)
+macro(add_pch TargetName PrecompiledHeader PrecompiledSource)
   if(MSVC)
-    set_source_files_properties(${PrecompiledSource}
-        PROPERTIES
-        COMPILE_FLAGS "/Yc${PrecompiledHeader}"
-        )
-    foreach( src_file ${${SourcesVar}} )
-        set_source_files_properties(
-            ${src_file}
-            PROPERTIES
-            COMPILE_FLAGS "/Yu${PrecompiledHeader}"
-            )
-    endforeach( src_file ${${SourcesVar}} )
-    list(APPEND ${SourcesVar} ${PrecompiledHeader} ${PrecompiledSource})
-    add_compile_options(/Yu)
+    set_source_files_properties(
+      ${PrecompiledSource}
+      PROPERTIES
+      COMPILE_FLAGS "/Yc${PrecompiledHeader}"
+    )
+    target_sources(${TargetName} PRIVATE ${PrecompiledHeader} ${PrecompiledSource})
+    target_compile_definitions(${TargetName} PRIVATE "/Yu${PrecompiledHeader}")
   endif(MSVC)
 endmacro(add_pch)

--- a/contrib/autoboost/libs/filesystem/codecvt_error_category.cpp
+++ b/contrib/autoboost/libs/filesystem/codecvt_error_category.cpp
@@ -8,8 +8,6 @@
 //  Library home page at http://www.boost.org/libs/filesystem
 
 //--------------------------------------------------------------------------------------//
-
-#include "stdafx.h"
 #include <autoboost/config/warning_disable.hpp>
 
 // define AUTOBOOST_FILESYSTEM_SOURCE so that <autoboost/filesystem/config.hpp> knows

--- a/contrib/autoboost/libs/filesystem/operations.cpp
+++ b/contrib/autoboost/libs/filesystem/operations.cpp
@@ -11,7 +11,6 @@
 //--------------------------------------------------------------------------------------//
 
 //  define 64-bit offset macros BEFORE including boost/config.hpp (see ticket #5355)
-#include "stdafx.h"
 #if !(defined(__HP_aCC) && defined(_ILP32) && !defined(_STATVFS_ACPP_PROBLEMS_FIXED))
 #define _FILE_OFFSET_BITS 64 // at worst, these defines may have no effect,
 #endif

--- a/contrib/autoboost/libs/filesystem/path.cpp
+++ b/contrib/autoboost/libs/filesystem/path.cpp
@@ -9,7 +9,6 @@
 
 //  Old standard library configurations, particularly MingGW, don't support wide strings.
 //  Report this with an explicit error message.
-#include "stdafx.h"
 #include <autoboost/config.hpp>
 # if defined( AUTOBOOST_NO_STD_WSTRING )
 #   error Configuration not supported: Boost.Filesystem V3 and later requires std::wstring support

--- a/contrib/autoboost/libs/filesystem/path_traits.cpp
+++ b/contrib/autoboost/libs/filesystem/path_traits.cpp
@@ -11,7 +11,6 @@
 
 // define AUTOBOOST_FILESYSTEM_SOURCE so that <autoboost/system/config.hpp> knows
 // the library is being built (possibly exporting rather than importing code)
-#include "stdafx.h"
 #define AUTOBOOST_FILESYSTEM_SOURCE
 
 #ifndef AUTOBOOST_SYSTEM_NO_DEPRECATED

--- a/contrib/autoboost/libs/filesystem/portability.cpp
+++ b/contrib/autoboost/libs/filesystem/portability.cpp
@@ -11,7 +11,6 @@
 
 // define AUTOBOOST_FILESYSTEM_SOURCE so that <autoboost/filesystem/config.hpp> knows
 // the library is being built (possibly exporting rather than importing code)
-#include "stdafx.h"
 #define AUTOBOOST_FILESYSTEM_SOURCE
 
 #ifndef AUTOBOOST_SYSTEM_NO_DEPRECATED

--- a/contrib/autoboost/libs/filesystem/unique_path.cpp
+++ b/contrib/autoboost/libs/filesystem/unique_path.cpp
@@ -11,7 +11,6 @@
 
 // define AUTOBOOST_FILESYSTEM_SOURCE so that <autoboost/filesystem/config.hpp> knows
 // the library is being built (possibly exporting rather than importing code)
-#include "stdafx.h"
 #define AUTOBOOST_FILESYSTEM_SOURCE
 
 #ifndef AUTOBOOST_SYSTEM_NO_DEPRECATED

--- a/contrib/autoboost/libs/filesystem/utf8_codecvt_facet.cpp
+++ b/contrib/autoboost/libs/filesystem/utf8_codecvt_facet.cpp
@@ -5,7 +5,6 @@
 
 // For HP-UX, request that WCHAR_MAX and WCHAR_MIN be defined as macros,
 // not casts. See ticket 5048
-#include "stdafx.h"
 #define _INCLUDE_STDCSOURCE_199901
 
 #ifndef AUTOBOOST_SYSTEM_NO_DEPRECATED

--- a/contrib/autoboost/libs/filesystem/windows_file_codecvt.cpp
+++ b/contrib/autoboost/libs/filesystem/windows_file_codecvt.cpp
@@ -11,7 +11,6 @@
 
 // define AUTOBOOST_FILESYSTEM_SOURCE so that <autoboost/system/config.hpp> knows
 // the library is being built (possibly exporting rather than importing code)
-#include "stdafx.h"
 #define AUTOBOOST_FILESYSTEM_SOURCE
 
 #ifndef AUTOBOOST_SYSTEM_NO_DEPRECATED

--- a/contrib/autoboost/libs/system/src/error_code.cpp
+++ b/contrib/autoboost/libs/system/src/error_code.cpp
@@ -11,7 +11,6 @@
 
 // define AUTOBOOST_SYSTEM_SOURCE so that <autoboost/system/config.hpp> knows
 // the library is being built (possibly exporting rather than importing code)
-#include "stdafx.h"
 #define AUTOBOOST_SYSTEM_SOURCE
 
 #include <autoboost/system/error_code.hpp>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,8 @@ include_directories(
   .
 )
 
+add_subdirectory(autoboost)
 add_subdirectory(autonet)
-add_subdirectory(autowiring)
 add_subdirectory(autotesting)
+add_subdirectory(autowiring)
 add_subdirectory(benchmark)

--- a/src/autoboost/CMakeLists.txt
+++ b/src/autoboost/CMakeLists.txt
@@ -1,0 +1,61 @@
+add_conditional_sources(
+  Autoboost_SRCS
+  "ON"
+  GROUP_NAME "Autoboost"
+  FILES
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/system/src/error_code.cpp
+)
+
+add_conditional_sources(
+  Autoboost_SRCS
+  "NOT MSVC"
+  GROUP_NAME "Autoboost"
+  FILES
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/chrono/src/process_cpu_clocks.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/chrono/src/thread_clock.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/chrono/src/chrono.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/thread/src/pthread/once_atomic.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/thread/src/pthread/thread.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/thread/src/future.cpp
+)
+
+add_conditional_sources(
+  Autoboost_SRCS
+  "ON"
+  GROUP_NAME "Autoboost"
+  FILES
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/codecvt_error_category.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/operations.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/path.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/path_traits.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/portability.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/unique_path.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/utf8_codecvt_facet.cpp
+)
+
+add_conditional_sources(
+  Autoboost_SRCS
+  "MSVC"
+  GROUP_NAME "Autoboost"
+  FILES
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/windows_file_codecvt.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/windows_file_codecvt.hpp
+)
+
+add_library(Autoboost STATIC ${Autoboost_SRCS})
+
+target_include_directories(
+  Autoboost
+  PUBLIC
+  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/contrib/autoboost>"
+)
+
+#
+# Install library
+#
+install(TARGETS Autoboost EXPORT AutowiringTargets
+  DESTINATION lib
+  COMPONENT autowiring
+  CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES}
+)
+install_headers(TARGET Autoboost DESTINATION include/autowiring COMPONENT autowiring)

--- a/src/autonet/CMakeLists.txt
+++ b/src/autonet/CMakeLists.txt
@@ -13,10 +13,8 @@ set(AutoNet_SRCS
   ${PROJECT_SOURCE_DIR}/contrib/json11/json11.hpp
 )
 
-# All include files are located in /autowiring from here, so prepend that to all sources
-add_pch(AutoNet_SRCS "stdafx.h" "stdafx.cpp")
-
 add_library(AutoNet STATIC ${AutoNet_SRCS})
+add_pch(AutoNet "stdafx.h" "stdafx.cpp")
 target_link_libraries(AutoNet PRIVATE Autowiring)
 set_target_properties(AutoNet PROPERTIES INTERFACE_LINK_LIBRARIES Autowiring)
 

--- a/src/autonet/test/CMakeLists.txt
+++ b/src/autonet/test/CMakeLists.txt
@@ -10,9 +10,8 @@ set(AutoNetTest_SRCS
   WebsocketTest.cpp
 )
 
-add_pch(AutoNetTest_SRCS "stdafx.h" "stdafx.cpp")
-
 add_executable(AutoNetTest ${AutoNetTest_SRCS})
+add_pch(AutoNetTest "stdafx.h" "stdafx.cpp")
 target_link_libraries(AutoNetTest AutoTesting AutoNet Autowiring)
 
 # This is a unit test, let CMake know this

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -173,50 +173,6 @@ set(Autowiring_SRCS
 
 add_conditional_sources(
   Autowiring_SRCS
-  "ON"
-  GROUP_NAME "Autoboost"
-  FILES
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/system/src/error_code.cpp
-)
-
-add_conditional_sources(
-  Autowiring_SRCS
-  "NOT MSVC"
-  GROUP_NAME "Autoboost"
-  FILES
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/chrono/src/process_cpu_clocks.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/chrono/src/thread_clock.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/chrono/src/chrono.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/thread/src/pthread/once_atomic.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/thread/src/pthread/thread.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/thread/src/future.cpp
-)
-
-add_conditional_sources(
-  Autowiring_SRCS
-  "ON"
-  GROUP_NAME "Autoboost"
-  FILES
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/codecvt_error_category.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/operations.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/path.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/path_traits.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/portability.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/unique_path.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/utf8_codecvt_facet.cpp
-)
-
-add_conditional_sources(
-  Autowiring_SRCS
-  "MSVC"
-  GROUP_NAME "Autoboost"
-  FILES
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/windows_file_codecvt.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/windows_file_codecvt.hpp
-)
-
-add_conditional_sources(
-  Autowiring_SRCS
   "TRUE"
   GROUP_NAME "C++11"
   FILES
@@ -288,12 +244,59 @@ if(WIN32 AND NOT BUILD_64_BIT)
   enable_language(ASM_MASM)
 endif()
 
-add_conditional_sources(Autowiring_SRCS "NOT WIN32 AND NOT APPLE"
+add_conditional_sources(
+  Autowiring_SRCS
+  "NOT WIN32 AND NOT APPLE"
   GROUP_NAME "Linux Source"
   FILES CoreThreadLinux.cpp
 )
 
 add_pch(Autowiring_SRCS "stdafx.h" "stdafx.cpp")
+
+# We don't want these source files to be compiled with a PCH, so we include them after the pch statement
+add_conditional_sources(
+  Autowiring_SRCS
+  "ON"
+  GROUP_NAME "Autoboost"
+  FILES
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/system/src/error_code.cpp
+)
+
+add_conditional_sources(
+  Autowiring_SRCS
+  "NOT MSVC"
+  GROUP_NAME "Autoboost"
+  FILES
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/chrono/src/process_cpu_clocks.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/chrono/src/thread_clock.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/chrono/src/chrono.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/thread/src/pthread/once_atomic.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/thread/src/pthread/thread.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/thread/src/future.cpp
+)
+
+add_conditional_sources(
+  Autowiring_SRCS
+  "ON"
+  GROUP_NAME "Autoboost"
+  FILES
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/codecvt_error_category.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/operations.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/path.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/path_traits.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/portability.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/unique_path.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/utf8_codecvt_facet.cpp
+)
+
+add_conditional_sources(
+  Autowiring_SRCS
+  "MSVC"
+  GROUP_NAME "Autoboost"
+  FILES
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/windows_file_codecvt.cpp
+  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/windows_file_codecvt.hpp
+)
 
 #
 # Configure library
@@ -303,8 +306,6 @@ add_library(Autowiring STATIC ${Autowiring_SRCS})
 
 target_include_directories(
   Autowiring
-  PRIVATE
-  .
   PUBLIC
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/contrib/autoboost>"
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>"

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -251,63 +251,17 @@ add_conditional_sources(
   FILES CoreThreadLinux.cpp
 )
 
-add_pch(Autowiring_SRCS "stdafx.h" "stdafx.cpp")
-
-# We don't want these source files to be compiled with a PCH, so we include them after the pch statement
-add_conditional_sources(
-  Autowiring_SRCS
-  "ON"
-  GROUP_NAME "Autoboost"
-  FILES
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/system/src/error_code.cpp
-)
-
-add_conditional_sources(
-  Autowiring_SRCS
-  "NOT MSVC"
-  GROUP_NAME "Autoboost"
-  FILES
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/chrono/src/process_cpu_clocks.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/chrono/src/thread_clock.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/chrono/src/chrono.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/thread/src/pthread/once_atomic.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/thread/src/pthread/thread.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/thread/src/future.cpp
-)
-
-add_conditional_sources(
-  Autowiring_SRCS
-  "ON"
-  GROUP_NAME "Autoboost"
-  FILES
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/codecvt_error_category.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/operations.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/path.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/path_traits.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/portability.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/unique_path.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/utf8_codecvt_facet.cpp
-)
-
-add_conditional_sources(
-  Autowiring_SRCS
-  "MSVC"
-  GROUP_NAME "Autoboost"
-  FILES
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/windows_file_codecvt.cpp
-  ${PROJECT_SOURCE_DIR}/contrib/autoboost/libs/filesystem/windows_file_codecvt.hpp
-)
-
 #
 # Configure library
 #
 
 add_library(Autowiring STATIC ${Autowiring_SRCS})
+add_pch(Autowiring "stdafx.h" "stdafx.cpp")
+target_link_libraries(Autowiring INTERFACE Autoboost)
 
 target_include_directories(
   Autowiring
   PUBLIC
-  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/contrib/autoboost>"
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>"
   INTERFACE
   "$<INSTALL_INTERFACE:include>"
@@ -317,7 +271,7 @@ target_include_directories(
 find_package(Threads)
 if(Threads_FOUND)
   if(CMAKE_USE_PTHREADS_INIT)
-    target_link_libraries(Autowiring ${CMAKE_THREAD_LIBS_INIT})
+    target_link_libraries(Autowiring INTERFACE ${CMAKE_THREAD_LIBS_INIT})
   endif()
 endif()
 

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -91,12 +91,12 @@ set(AutowiringFixture_SRCS
   SelfSelectingFixture.cpp
 )
 
-add_pch(AutowiringFixture_SRCS "stdafx.h" "stdafx.cpp")
 add_library(AutowiringFixture ${AutowiringFixture_SRCS})
+add_pch(AutowiringFixture stdafx.h stdafx.cpp)
 target_include_directories(AutowiringFixture PRIVATE "${CMAKE_SOURCE_DIR}/contrib/autoboost")
 
-add_pch(AutowiringTest_SRCS "stdafx.h" "stdafx.cpp")
 add_executable(AutowiringTest ${AutowiringTest_SRCS})
+add_pch(AutowiringTest stdafx.h stdafx.cpp)
 target_link_libraries(AutowiringTest Autowiring AutowiringFixture AutoTesting)
 target_include_directories(AutowiringTest PRIVATE "${CMAKE_SOURCE_DIR}/contrib/autoboost")
 

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -16,6 +16,6 @@ set(AutoBench_SRCS
   PrintableDuration.h
 )
 
-add_pch(AutoBench_SRCS "stdafx.h" "stdafx.cpp")
 add_executable(AutoBench ${AutoBench_SRCS})
+add_pch(AutoBench "stdafx.h" "stdafx.cpp")
 target_link_libraries(AutoBench Autowiring AutowiringFixture AutoTesting)


### PR DESCRIPTION
Do not specify the current working directory as an include path, this jacks up the android build due to our use of the "signal.h" filename.