### PR TITLE
Add missing chrono_types header

### DIFF
--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -61,6 +61,7 @@ set(Autowiring_SRCS
   callable.h
   CallExtractor.h
   CallExtractor.cpp
+  chrono_types.h
   config.h
   config_descriptor.h
   config_descriptor.cpp

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -50,6 +50,7 @@ set(Autowiring_SRCS
   AutowiringDebug.cpp
   autowiring_error.cpp
   autowiring_error.h
+  basic_timer.h
   BasicThread.cpp
   BasicThread.h
   BasicThreadStateBlock.cpp


### PR DESCRIPTION
This header must be included in the sources list or it won't be installed