### PR TITLE
Eliminate throw_rethrowable

### DIFF
--- a/src/autowiring/AnySharedPointer.h
+++ b/src/autowiring/AnySharedPointer.h
@@ -46,7 +46,7 @@ public:
   /// Attempts to dynamically assign this slot to the specified object without changing the current type
   /// </summary>
   /// <returns>True if the assignment succeeds</returns>
-  bool try_assign(const std::shared_ptr<CoreObject>& rhs) {
+  bool try_assign(const std::shared_ptr<CoreObject>& rhs) AUTO_NOEXCEPT {
     if (!m_ti.block->pFromObj)
       return false;
     auto ptr = m_ti.block->pFromObj(rhs);

--- a/src/autowiring/C++11/cpp11.h
+++ b/src/autowiring/C++11/cpp11.h
@@ -16,7 +16,6 @@
 #endif
 
 // Deprecated macros, provided here until we can be sure that they aren't used downstream
-#define throw_rethrowable throw
 #define EXCEPTION_PTR_HEADER <stdexcept>
 
 #define IS_CLANG defined(__clang_major__)

--- a/src/autowiring/C++11/cpp11.h
+++ b/src/autowiring/C++11/cpp11.h
@@ -15,9 +15,6 @@
   #define STL11_ALLOWED 1
 #endif
 
-// Deprecated macros, provided here until we can be sure that they aren't used downstream
-#define EXCEPTION_PTR_HEADER <stdexcept>
-
 #define IS_CLANG defined(__clang_major__)
 #define CLANG_CHECK(maj, min) (__clang_major__ == maj && __clang_minor__ >= min || __clang_major__ > maj)
 #define GCC_CHECK(maj, min) (__GNUC__ == maj && __GNUC_MINOR__  >= min || __GNUC__ > maj)

--- a/src/autowiring/C++11/cpp11.h
+++ b/src/autowiring/C++11/cpp11.h
@@ -209,11 +209,17 @@
  * noexcept support
  *********************/
 #ifdef _MSC_VER
-  #define AUTOWIRE_cxx_noexcept 0
-  #define NOEXCEPT(x)
+  #if _MSC_VER >= 1900
+    #define AUTO_NOEXCEPT noexcept
+  #else
+    #define AUTO_NOEXCEPT throw()
+  #endif
 #else
-  #define AUTOWIRE_cxx_noexcept 1
-  #define NOEXCEPT(x) x noexcept
+  #if __has_feature(cxx_noexcept)
+    #define AUTO_NOEXCEPT noexcept
+  #else
+    #define AUTO_NOEXCEPT
+  #endif
 #endif
 
 /*********************

--- a/src/autowiring/auto_id.h
+++ b/src/autowiring/auto_id.h
@@ -36,8 +36,8 @@ namespace autowiring {
       pFromObj(NullFromObj)
     {}
 
-    static std::shared_ptr<CoreObject> NullToObj(const std::shared_ptr<void>&);
-    static std::shared_ptr<void> NullFromObj(const std::shared_ptr<CoreObject>&);
+    static std::shared_ptr<CoreObject> NullToObj(const std::shared_ptr<void>&) AUTO_NOEXCEPT;
+    static std::shared_ptr<void> NullFromObj(const std::shared_ptr<CoreObject>&) AUTO_NOEXCEPT;
 
     template<class T>
     auto_id_block(
@@ -64,8 +64,8 @@ namespace autowiring {
       const std::type_info* ti_synth,
       size_t ncb,
       size_t align,
-      std::shared_ptr<CoreObject>(*pToObj)(const std::shared_ptr<void>&),
-      std::shared_ptr<void>(*pFromObj)(const std::shared_ptr<CoreObject>&)
+      std::shared_ptr<CoreObject>(*pToObj)(const std::shared_ptr<void>&) AUTO_NOEXCEPT,
+      std::shared_ptr<void>(*pFromObj)(const std::shared_ptr<CoreObject>&) AUTO_NOEXCEPT
     ):
       index(index),
       ti(ti),
@@ -91,8 +91,8 @@ namespace autowiring {
     size_t align;
 
     // Generic fast casters to CoreObject
-    std::shared_ptr<CoreObject>(*pToObj)(const std::shared_ptr<void>&);
-    std::shared_ptr<void>(*pFromObj)(const std::shared_ptr<CoreObject>&);
+    std::shared_ptr<CoreObject>(*pToObj)(const std::shared_ptr<void>&) AUTO_NOEXCEPT;
+    std::shared_ptr<void>(*pFromObj)(const std::shared_ptr<CoreObject>&) AUTO_NOEXCEPT;
 
     bool operator==(const auto_id_block& rhs) const { return index == rhs.index && ti == rhs.ti; }
     bool operator!=(const auto_id_block& rhs) const { return !(*this == rhs); }

--- a/src/autowiring/auto_id.h
+++ b/src/autowiring/auto_id.h
@@ -51,10 +51,10 @@ namespace autowiring {
       ncb(sizeof(T)),
       align(safe_align_of<T>::value),
       pToObj(
-        reinterpret_cast<std::shared_ptr<CoreObject>(*)(const std::shared_ptr<void>&)>(pToObj)
+        reinterpret_cast<std::shared_ptr<CoreObject>(*)(const std::shared_ptr<void>&) AUTO_NOEXCEPT>(pToObj)
       ),
       pFromObj(
-        reinterpret_cast<std::shared_ptr<void>(*)(const std::shared_ptr<CoreObject>&)>(pFromObj)
+        reinterpret_cast<std::shared_ptr<void>(*)(const std::shared_ptr<CoreObject>&) AUTO_NOEXCEPT>(pFromObj)
       )
     {}
 

--- a/src/autowiring/signal.h
+++ b/src/autowiring/signal.h
@@ -405,7 +405,7 @@ namespace autowiring {
     /// </summary>
     /// <param name="args">
     template<typename... FnArgs>
-    void operator()(FnArgs&&... args) const {
+    void operator()(FnArgs&&... args) const AUTO_NOEXCEPT {
       for (;;) {
         SignalState state = SignalState::Free;
         if (m_state.compare_exchange_weak(state, SignalState::Asserting, std::memory_order_acquire, std::memory_order_relaxed)) {
@@ -422,7 +422,7 @@ namespace autowiring {
         case SignalState::Free:
         case SignalState::Updating:
           // Spurious failure, or insertion.
-          // We cannot delegate control to insertion, and spurious failure should be retried.
+          // We cannot delegate signalling to insertion, and spurious failure should be retried.
           continue;
         case SignalState::Asserting:
         case SignalState::Deferred:


### PR DESCRIPTION
This was added for systems that did not fully support C++11 exceptions.  It has been defined as `throw` for a long time, now, and is no longer used by anyone.