### PR TITLE
Add nullptr_t overload to AnySharedPointer

### DIFF
--- a/src/autowiring/AnySharedPointer.h
+++ b/src/autowiring/AnySharedPointer.h
@@ -92,6 +92,10 @@ public:
     return m_ptr == rhs;
   }
 
+  bool operator==(std::nullptr_t) const {
+    return !m_ptr;
+  }
+
   bool operator!=(std::nullptr_t) const {
     return !!m_ptr;
   }

--- a/src/autowiring/AnySharedPointer.h
+++ b/src/autowiring/AnySharedPointer.h
@@ -124,7 +124,12 @@ public:
   // Allows dynamic assignment of the type directly from an auto_id field
   void operator=(auto_id ti) {
     m_ti = ti;
-    m_ptr.reset();
+    m_ptr = {};
+  }
+
+  void operator=(std::nullptr_t) {
+    m_ti = auto_id{ nullptr };
+    m_ptr = {};
   }
 
   /// <summary>

--- a/src/autowiring/AnySharedPointer.h
+++ b/src/autowiring/AnySharedPointer.h
@@ -128,7 +128,7 @@ public:
   }
 
   void operator=(std::nullptr_t) {
-    m_ti = auto_id{ nullptr };
+    m_ti = {};
     m_ptr = {};
   }
 

--- a/src/autowiring/AnySharedPointer.h
+++ b/src/autowiring/AnySharedPointer.h
@@ -9,6 +9,9 @@ public:
   AnySharedPointer(void) = default;
   AnySharedPointer(AnySharedPointer&& rhs);
   AnySharedPointer(const AnySharedPointer& rhs) = default;
+  AnySharedPointer(std::nullptr_t) :
+    AnySharedPointer()
+  {}
 
   template<class T>
   AnySharedPointer(const std::shared_ptr<T>& rhs) :

--- a/src/autowiring/test/AnySharedPointerTest.cpp
+++ b/src/autowiring/test/AnySharedPointerTest.cpp
@@ -254,6 +254,7 @@ TEST_F(AnySharedPointerTest, NullAfterMove) {
 
 TEST_F(AnySharedPointerTest, NullPtrConstruction) {
   AnySharedPointer x{ nullptr };
+  ASSERT_EQ(auto_id_t<void>{}, auto_id{}) << "Default auto_id is expected to be void";
   ASSERT_EQ(auto_id_t<void>{}, x.type()) << "nullptr type_id should have been void";
 
   AnySharedPointer y;

--- a/src/autowiring/test/AnySharedPointerTest.cpp
+++ b/src/autowiring/test/AnySharedPointerTest.cpp
@@ -262,5 +262,7 @@ TEST_F(AnySharedPointerTest, NullPtrConstruction) {
 
   ASSERT_EQ(x, y) << "Nullptr initialization was not null";
   ASSERT_EQ(x, z) << "Nullptr assignment was not null";
+  ASSERT_EQ(auto_id_t<void>{}, x.type());
   ASSERT_EQ(auto_id_t<void>{}, y.type());
+  ASSERT_EQ(auto_id_t<void>{}, z.type());
 }

--- a/src/autowiring/test/AnySharedPointerTest.cpp
+++ b/src/autowiring/test/AnySharedPointerTest.cpp
@@ -129,7 +129,7 @@ TEST_F(AnySharedPointerTest, TrivialRelease) {
 
   ASSERT_TRUE(a.unique()) << "Expected reassignment of a slot to release a formerly held instance";
   ASSERT_FALSE(b.unique()) << "Expected slot to hold a reference to the second specified instance";
-  
+
   // Now release, and verify that a release actually took place
   slot.reset();
   ASSERT_TRUE(b.unique()) << "Releasing a slot did not actually release the held value as expected";
@@ -250,4 +250,17 @@ TEST_F(AnySharedPointerTest, NullAfterMove) {
   AnySharedPointer p3;
   p3 = std::move(p2);
   ASSERT_FALSE(p2) << "Move assignment of AnySharedPointer did not nullify rhs";
+}
+
+TEST_F(AnySharedPointerTest, NullPtrConstruction) {
+  AnySharedPointer x{ nullptr };
+  ASSERT_EQ(auto_id_t<void>{}, x.type()) << "nullptr type_id should have been void";
+
+  AnySharedPointer y;
+  AnySharedPointer z;
+  y = nullptr;
+
+  ASSERT_EQ(x, y) << "Nullptr initialization was not null";
+  ASSERT_EQ(x, z) << "Nullptr assignment was not null";
+  ASSERT_EQ(auto_id_t<void>{}, y.type());
 }


### PR DESCRIPTION
Should be allowed, sometimes there are runtime settings where `nullptr_t` is desired.