### PR TITLE
Add Await support to CoreContext

### DIFF
--- a/src/autowiring/CoreContext.h
+++ b/src/autowiring/CoreContext.h
@@ -635,7 +635,7 @@ public:
   /// </remarks>
   template<typename T>
   const std::shared_ptr<T>& Await(void) {
-    return Await(auto_id_t<T>{}).as<T>();
+    return Await(auto_id_t<T>{}).template as<T>();
   }
 
   /// <summary>
@@ -644,7 +644,7 @@ public:
   /// <returns>An instance of type T, or nullptr if the timeout has been reached</returns>
   template<typename T>
   std::shared_ptr<T> Await(std::chrono::nanoseconds timeout) {
-    return Await(auto_id_t<T>{}, timeout).as<T>();
+    return Await(auto_id_t<T>{}, timeout).template as<T>();
   }
 
   /// <summary>

--- a/src/autowiring/CoreContext.h
+++ b/src/autowiring/CoreContext.h
@@ -626,6 +626,38 @@ public:
   }
 
   /// <summary>
+  /// Similar to Inject, except will block until the specified type is available in the context
+  /// </summary>
+  /// <returns>An instance of type T</returns>
+  /// <remarks>
+  /// This method will throw an exception if the context is terminated when the call is made or while
+  /// waiting for injection to take place.
+  /// </remarks>
+  template<typename T>
+  const std::shared_ptr<T>& Await(void) {
+    return Await(auto_id_t<T>{}).as<T>();
+  }
+
+  /// <summary>
+  /// Timed version of Await
+  /// </summary>
+  /// <returns>An instance of type T, or nullptr if the timeout has been reached</returns>
+  template<typename T>
+  std::shared_ptr<T> Await(std::chrono::nanoseconds timeout) {
+    return Await(auto_id_t<T>{}, timeout).as<T>();
+  }
+
+  /// <summary>
+  /// Runtime Await variant
+  /// </summary>
+  AnySharedPointer Await(auto_id id);
+
+  /// <summary>
+  /// Runtime Await variant
+  /// </summary>
+  AnySharedPointer Await(auto_id id, std::chrono::nanoseconds timeout);
+
+  /// <summary>
   /// Injects a type into the current context.
   /// </summary>
   template<typename T>


### PR DESCRIPTION
Await allows a calling thread to block until the awaited type is injected, or the context is terminated.  This support is expected to be useful in unit test contexts, and also will be used to support single construction injection.