### PR TITLE
Make greater use of autowiring namespace

### DIFF
--- a/src/autonet/AutoNetServer.h
+++ b/src/autonet/AutoNetServer.h
@@ -81,7 +81,7 @@ public:
       event,
       std::forward<Fx&&>(handler),
       &Fx::operator(),
-      typename make_index_tuple<Decompose<decltype(&Fx::operator())>::N>::type()
+      typename autowiring::make_index_tuple<autowiring::Decompose<decltype(&Fx::operator())>::N>::type()
     );
   }
 

--- a/src/autonet/AutoNetServer.h
+++ b/src/autonet/AutoNetServer.h
@@ -104,7 +104,7 @@ private:
 
   // Extract arguments from list of strings, parse and pass to handler
   template<typename Fx, typename... Args, int... N>
-  void AddEventHandler(const std::string& event, Fx&& handler, void (Fx::*pfn)(Args...) const, index_tuple<N...>) {
+  void AddEventHandler(const std::string& event, Fx&& handler, void (Fx::*pfn)(Args...) const, autowiring::index_tuple<N...>) {
     AddEventHandlerInternal(
       event,
       [this, handler, pfn] (const std::vector<std::string>& args) {

--- a/src/autonet/AutoNetServerImpl.cpp
+++ b/src/autonet/AutoNetServerImpl.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include FUTURE_HEADER
 
+using namespace autowiring;
 using json11::Json;
 
 #ifdef _MSC_VER

--- a/src/autonet/AutoNetServerImpl.hpp
+++ b/src/autonet/AutoNetServerImpl.hpp
@@ -8,8 +8,9 @@
 #include SYSTEM_ERROR_HEADER
 #include ARRAY_HEADER
 
-struct CoreObjectDescriptor;
-struct TypeIdentifierBase;
+namespace autowiring {
+  struct CoreObjectDescriptor;
+}
 
 // Protocol layer for AutoNet
 class AutoNetServerImpl:
@@ -63,7 +64,7 @@ public:
   /// </summary>
   /// <param name="ctxt">Context containing the object</param>
   /// <param name="obj">The object</param>
-  void NewObject(CoreContext& ctxt, const CoreObjectDescriptor& obj);
+  void NewObject(CoreContext& ctxt, const autowiring::CoreObjectDescriptor& obj);
 
 protected:
   /// <summary>

--- a/src/autowiring/AnySharedPointer.cpp
+++ b/src/autowiring/AnySharedPointer.cpp
@@ -2,6 +2,8 @@
 #include "stdafx.h"
 #include "AnySharedPointer.h"
 
+using namespace autowiring;
+
 AnySharedPointer::AnySharedPointer(AnySharedPointer&& rhs) :
   m_ti(rhs.m_ti),
   m_ptr(std::move(rhs.m_ptr))

--- a/src/autowiring/AutoFilterArgument.h
+++ b/src/autowiring/AutoFilterArgument.h
@@ -3,6 +3,8 @@
 #include "auto_arg.h"
 #include <typeinfo>
 
+namespace autowiring {
+
 /// <summary>
 /// AutoFilter argument disposition
 /// </summary>
@@ -58,3 +60,5 @@ struct AutoFilterArgumentT:
     )
   {}
 };
+
+}

--- a/src/autowiring/AutoFilterDescriptor.cpp
+++ b/src/autowiring/AutoFilterDescriptor.cpp
@@ -2,6 +2,8 @@
 #include "stdafx.h"
 #include "AutoFilterDescriptor.h"
 
+using namespace autowiring;
+
 AutoFilterDescriptorStub::AutoFilterDescriptorStub(auto_id type, autowiring::altitude altitude, const AutoFilterArgument* pArgs, bool deferred, autowiring::t_extractedCall pCall) :
   m_type(type),
   m_altitude(altitude),
@@ -11,7 +13,7 @@ AutoFilterDescriptorStub::AutoFilterDescriptorStub(auto_id type, autowiring::alt
 {
   for(auto pArg = m_pArgs; *pArg; pArg++) {
     m_arity++;
-      
+
     // time shifted arguments arn't required
     if (pArg->is_input)
       ++m_requiredCount;

--- a/src/autowiring/AutoFilterDescriptor.h
+++ b/src/autowiring/AutoFilterDescriptor.h
@@ -10,6 +10,8 @@
 #include "is_shared_ptr.h"
 #include MEMORY_HEADER
 
+namespace autowiring {
+
 /// <summary>
 /// The unbound part of an AutoFilter, includes everything except the AnySharedPointer representing the filter proper
 /// </summary>
@@ -255,26 +257,24 @@ public:
   bool operator!=(const AutoFilterDescriptor& rhs) const { return !(*this == rhs); }
 };
 
-namespace autowiring {
-  namespace detail {
-    /// <summary>
-    /// Alias for AutoFilterDescriptor(ptr)
-    /// </summary>
-    template<class T>
-    AutoFilterDescriptor MakeAFDescriptor(const std::shared_ptr<T>& ptr, std::true_type) {
-      return AutoFilterDescriptor(ptr);
-    }
+namespace detail {
+  /// <summary>
+  /// Alias for AutoFilterDescriptor(ptr)
+  /// </summary>
+  template<class T>
+  AutoFilterDescriptor MakeAFDescriptor(const std::shared_ptr<T>& ptr, std::true_type) {
+    return AutoFilterDescriptor(ptr);
+  }
 
-    /// <summary>
-    /// Utility routine to support the creation of an AutoFilterDescriptor from T::AutoFilter
-    /// </summary>
-    /// <remarks>
-    /// This method will return an empty descriptor in the case that T::AutoFilter is not defined
-    /// </remarks>
-    template<class T>
-    AutoFilterDescriptor MakeAFDescriptor(const std::shared_ptr<T>&, std::false_type) {
-      return AutoFilterDescriptor();
-    }
+  /// <summary>
+  /// Utility routine to support the creation of an AutoFilterDescriptor from T::AutoFilter
+  /// </summary>
+  /// <remarks>
+  /// This method will return an empty descriptor in the case that T::AutoFilter is not defined
+  /// </remarks>
+  template<class T>
+  AutoFilterDescriptor MakeAFDescriptor(const std::shared_ptr<T>&, std::false_type) {
+    return AutoFilterDescriptor();
   }
 }
 
@@ -289,11 +289,13 @@ AutoFilterDescriptor MakeAutoFilterDescriptor(const std::shared_ptr<T>& ptr) {
   return autowiring::detail::MakeAFDescriptor(ptr, std::integral_constant<bool, has_autofilter<T>::value>());
 }
 
+}
+
 namespace std {
   template<>
-  struct hash<AutoFilterDescriptor>
+  struct hash<autowiring::AutoFilterDescriptor>
   {
-    size_t operator()(const AutoFilterDescriptor& subscriber) const {
+    size_t operator()(const autowiring::AutoFilterDescriptor& subscriber) const {
       return (size_t) subscriber.GetAutoFilter().ptr();
     }
   };

--- a/src/autowiring/AutoFuture.cpp
+++ b/src/autowiring/AutoFuture.cpp
@@ -2,6 +2,8 @@
 #include "stdafx.h"
 #include "AutoFuture.h"
 
+using namespace autowiring;
+
 AutoFuture::AutoFuture(void){}
 
 AutoFuture::~AutoFuture(void){}

--- a/src/autowiring/AutoFuture.h
+++ b/src/autowiring/AutoFuture.h
@@ -4,6 +4,8 @@
 #include "fast_pointer_cast.h"
 #include <vector>
 
+namespace autowiring {
+
 /// <summary>
 /// Represents a collection of CoreThread entities that can be waited upon
 /// </summary>
@@ -46,3 +48,5 @@ public:
     return true;
   }
 };
+
+}

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -74,7 +74,7 @@ DecorationDisposition& AutoPacket::DecorateImmediateUnsafe(const DecorationKey& 
 
   if (dec.m_state != DispositionState::Unsatisfied) {
     std::stringstream ss;
-    ss << "Cannot perform immediate decoration with type " << autowiring::demangle(key.id)
+    ss << "Cannot perform immediate decoration with type " << demangle(key.id)
        << ", the requested decoration already exists";
     throw autowiring_error(ss.str());
   }
@@ -98,7 +98,7 @@ void AutoPacket::AddSatCounterUnsafe(SatCounter& satCounter) {
     if (pCur->is_input) {
       if (entry.m_publishers.size() > 1 && !pCur->is_multi) {
         std::stringstream ss;
-        ss << "Cannot add listener for multi-broadcast type " << autowiring::demangle(pCur->id);
+        ss << "Cannot add listener for multi-broadcast type " << demangle(pCur->id);
         throw autowiring_error(ss.str());
       }
       if (entry.m_state == DispositionState::Complete) {
@@ -116,7 +116,7 @@ void AutoPacket::AddSatCounterUnsafe(SatCounter& satCounter) {
       while (it != entry.m_modifiers.end()) {
         if (it->altitude == satCounter.GetAltitude()) {
           std::stringstream ss;
-          ss << "Added multiple rvalue decorations with same altitudes for type " << autowiring::demangle(pCur->id);
+          ss << "Added multiple rvalue decorations with same altitudes for type " << demangle(pCur->id);
           throw autowiring_error(ss.str());
         }
 
@@ -145,7 +145,7 @@ void AutoPacket::AddSatCounterUnsafe(SatCounter& satCounter) {
             for (auto pOther = subscriber.satCounter->GetAutoFilterArguments(); *pOther; pOther++) {
               if (pOther->id == pCur->id && !pOther->is_multi) {
                 std::stringstream ss;
-                ss << "Added identical data broadcasts of type " << autowiring::demangle(pCur->id) << " with existing subscriber.";
+                ss << "Added identical data broadcasts of type " << demangle(pCur->id) << " with existing subscriber.";
                 throw autowiring_error(ss.str());
               }
             }
@@ -153,7 +153,7 @@ void AutoPacket::AddSatCounterUnsafe(SatCounter& satCounter) {
 
           if (!entry.m_modifiers.empty()) {
             std::stringstream ss;
-            ss << "Added identical data broadcasts of type " << autowiring::demangle(pCur->id) << " with existing modifier.";
+            ss << "Added identical data broadcasts of type " << demangle(pCur->id) << " with existing modifier.";
             throw autowiring_error(ss.str());
           }
         }
@@ -170,7 +170,7 @@ void AutoPacket::AddSatCounterUnsafe(SatCounter& satCounter) {
 void AutoPacket::DetectCycle(SatCounter& satCounter, std::unordered_set<SatCounter*>& tempVisited, std::unordered_set<SatCounter*>& permVisited) {
   if (tempVisited.count(&satCounter)) {
     std::stringstream ss;
-    ss << "Detected cycle in the auto filter graph involving type " << autowiring::demangle(satCounter.GetType());
+    ss << "Detected cycle in the auto filter graph involving type " << demangle(satCounter.GetType());
     throw autowiring_error(ss.str());
   }
 
@@ -461,10 +461,10 @@ void AutoPacket::DecorateNoPriors(const AnySharedPointer& ptr, DecorationKey key
       std::stringstream ss;
       if (disposition->m_decorations.empty())
         // Completed with no decorations, unsatisfiable
-        ss << "Cannot check out decoration of type " << autowiring::demangle(ptr)
+        ss << "Cannot check out decoration of type " << demangle(ptr)
           << ", it has been marked unsatisfiable";
       else
-        ss << "Cannot decorate this packet with type " << autowiring::demangle(ptr)
+        ss << "Cannot decorate this packet with type " << demangle(ptr)
           << ", the requested decoration is already satisfied";
       throw autowiring_error(ss.str());
     }
@@ -545,13 +545,13 @@ const SatCounter& AutoPacket::GetSatisfaction(auto_id subscriber) const {
 
 void AutoPacket::ThrowNotDecoratedException(const DecorationKey& key) {
   std::stringstream ss;
-  ss << "Attempted to obtain a type " << autowiring::demangle(key.id) << " which was not decorated on this packet";
+  ss << "Attempted to obtain a type " << demangle(key.id) << " which was not decorated on this packet";
   throw autowiring_error(ss.str());
 }
 
 void AutoPacket::ThrowMultiplyDecoratedException(const DecorationKey& key) {
   std::stringstream ss;
-  ss << "Attempted to obtain a type " << autowiring::demangle(key.id) << " which was decorated more than once on this packet";
+  ss << "Attempted to obtain a type " << demangle(key.id) << " which was decorated more than once on this packet";
   throw autowiring_error(ss.str());
 }
 
@@ -684,7 +684,7 @@ bool AutoPacket::Wait(std::condition_variable& cv, const AutoFilterArgument* inp
       stub,
       AutoFilterDescriptorStub(
         auto_id_t<AutoPacketFactory>{},
-        autowiring::altitude::Dispatch,
+        altitude::Dispatch,
         inputs,
         false,
         [] (const void* pObj, AutoPacket&) {

--- a/src/autowiring/AutoPacket.h
+++ b/src/autowiring/AutoPacket.h
@@ -716,7 +716,7 @@ public:
   bool Wait(std::condition_variable& cv)
   {
     static const autowiring::AutoFilterArgument inputs [] = {
-      static_cast<auto_arg<Decorations>*>(nullptr)...,
+      static_cast<autowiring::auto_arg<Decorations>*>(nullptr)...,
       autowiring::AutoFilterArgument()
     };
 
@@ -781,7 +781,7 @@ public:
   /// </summary>
   template<typename Fx, typename... InArgs, typename... Outputs>
   void Call(Fx&& fx, void (Fx::*memfn)(InArgs...) const, Outputs&... outputs) {
-    typedef typename make_index_tuple<Decompose<decltype(&Fx::operator())>::N>::type t_index;
+    typedef typename autowiring::make_index_tuple<autowiring::Decompose<decltype(&Fx::operator())>::N>::type t_index;
 
     // Completely unnecessary.  Call will avoid making unneeded copies, and this is guaranteed
     // by a unit test.  Dereference your shared pointers before passing them in.
@@ -839,7 +839,7 @@ namespace autowiring {
     Arg,
     autowiring::tuple<Outputs...>,
     typename std::enable_if<
-      auto_arg<Arg>::is_output &&
+    autowiring::auto_arg<Arg>::is_output &&
       find<
         typename std::decay<Arg>::type,
         typename std::decay<Outputs>::type...
@@ -860,7 +860,7 @@ namespace autowiring {
     Arg,
     Pack,
     typename std::enable_if<
-      !auto_arg<Arg>::is_output
+      !autowiring::auto_arg<Arg>::is_output
     >::type
   >
   {

--- a/src/autowiring/AutoPacket.h
+++ b/src/autowiring/AutoPacket.h
@@ -622,7 +622,7 @@ public:
   template<class Fx>
   const AutoPacket& operator+=(Fx&& fx) const {
     static_assert(
-      !autowiring::Decompose<decltype(&Fx::operator())>::template any<arg_is_out>::value,
+      !autowiring::Decompose<decltype(&Fx::operator())>::template any<autowiring::arg_is_out>::value,
       "Cannot add an AutoFilter to a const AutoPacket if any of its arguments are output types"
     );
     *const_cast<AutoPacket*>(this) += std::forward<Fx&&>(fx);
@@ -873,49 +873,52 @@ namespace autowiring {
   };
 }
 
-/// <summary>
-/// AutoPacket specialization
-/// </summary>
-/// <remarks>
-/// Because this type is immediately satisfied, it is neither an input nor an output
-/// </remarks>
-template<>
-class autowiring::auto_arg<AutoPacket&>
-{
-public:
-  typedef AutoPacket& type;
-  typedef AutoPacket& arg_type;
-  typedef auto_id_t<AutoPacket> id_type;
-  static const bool is_input = false;
-  static const bool is_output = false;
-  static const bool is_rvalue = false;
-  static const bool is_shared = false;
-  static const bool is_multi = false;
-  static const int tshift = 0;
+namespace autowiring {
 
-  static AutoPacket& arg(AutoPacket& packet) {
-    return packet;
-  }
-};
+  /// <summary>
+  /// AutoPacket specialization
+  /// </summary>
+  /// <remarks>
+  /// Because this type is immediately satisfied, it is neither an input nor an output
+  /// </remarks>
+  template<>
+  class auto_arg<AutoPacket&>
+  {
+  public:
+    typedef AutoPacket& type;
+    typedef AutoPacket& arg_type;
+    typedef auto_id_t<AutoPacket> id_type;
+    static const bool is_input = false;
+    static const bool is_output = false;
+    static const bool is_rvalue = false;
+    static const bool is_shared = false;
+    static const bool is_multi = false;
+    static const int tshift = 0;
 
-/// <summary>
-/// AutoPacket specialization for shared pointer
-/// </summary>
-template<>
-class autowiring::auto_arg<std::shared_ptr<AutoPacket>>
-{
-public:
-  typedef AutoPacket& type;
-  typedef AutoPacket& arg_type;
-  typedef AutoPacket id_type;
-  static const bool is_input = false;
-  static const bool is_output = false;
-  static const bool is_rvalue = false;
-  static const bool is_shared = false;
-  static const bool is_multi = false;
-  static const int tshift = 0;
+    static AutoPacket& arg(AutoPacket& packet) {
+      return packet;
+    }
+  };
 
-  static std::shared_ptr<AutoPacket> arg(AutoPacket& packet) {
-    return packet.shared_from_this();
-  }
-};
+  /// <summary>
+  /// AutoPacket specialization for shared pointer
+  /// </summary>
+  template<>
+  class auto_arg<std::shared_ptr<AutoPacket>>
+  {
+  public:
+    typedef AutoPacket& type;
+    typedef AutoPacket& arg_type;
+    typedef AutoPacket id_type;
+    static const bool is_input = false;
+    static const bool is_output = false;
+    static const bool is_rvalue = false;
+    static const bool is_shared = false;
+    static const bool is_multi = false;
+    static const int tshift = 0;
+
+    static std::shared_ptr<AutoPacket> arg(AutoPacket& packet) {
+      return packet.shared_from_this();
+    }
+  };
+}

--- a/src/autowiring/AutoPacket.h
+++ b/src/autowiring/AutoPacket.h
@@ -554,13 +554,13 @@ public:
     // None of the inputs may be shared pointers--if any of the inputs are shared pointers, they must be attached
     // to this packet via Decorate, or else dereferenced and used that way.
     static_assert(
-      !autowiring::is_any<is_shared_ptr<T>::value, is_shared_ptr<Ts>::value...>::value,
+      !autowiring::is_any<autowiring::is_shared_ptr<T>::value, autowiring::is_shared_ptr<Ts>::value...>::value,
       "DecorateImmediate must not be used to attach a shared pointer, use Decorate on such a decoration instead"
     );
 
     // Perform standard decoration with a short initialization:
     std::unique_lock<std::mutex> lk(m_lock);
-    DecorationDisposition* pTypeSubs[1 + sizeof...(Ts)] = {
+    autowiring::DecorationDisposition* pTypeSubs[1 + sizeof...(Ts)] = {
       &DecorateImmediateUnsafe(autowiring::DecorationKey(auto_id_t<T>(), 0), &immed),
       &DecorateImmediateUnsafe(autowiring::DecorationKey(auto_id_t<Ts>(), 0), &immeds)...
     };
@@ -569,9 +569,9 @@ public:
     MakeAtExit([this, &pTypeSubs] {
       // Mark entries as unsatisfiable:
       // IMPORTANT: isCheckedOut = true prevents subsequent decorations of this type
-      for(DecorationDisposition*  pEntry : pTypeSubs) {
+      for(autowiring::DecorationDisposition* pEntry : pTypeSubs) {
         pEntry->m_pImmediate = nullptr;
-        pEntry->m_state = DispositionState::Complete;
+        pEntry->m_state = autowiring::DispositionState::Complete;
       }
 
       // Now trigger a rescan to hit any deferred, unsatisfiable entries:
@@ -622,7 +622,7 @@ public:
   template<class Fx>
   const AutoPacket& operator+=(Fx&& fx) const {
     static_assert(
-      !Decompose<decltype(&Fx::operator())>::template any<arg_is_out>::value,
+      !autowiring::Decompose<decltype(&Fx::operator())>::template any<arg_is_out>::value,
       "Cannot add an AutoFilter to a const AutoPacket if any of its arguments are output types"
     );
     *const_cast<AutoPacket*>(this) += std::forward<Fx&&>(fx);
@@ -760,7 +760,7 @@ public:
     // Completely unnecessary.  Call will avoid making unneeded copies, and this is guaranteed
     // by a unit test.  Dereference your shared pointers before passing them in.
     static_assert(
-      !autowiring::is_any<is_shared_ptr<Outputs>::value...>::value,
+      !autowiring::is_any<autowiring::is_shared_ptr<Outputs>::value...>::value,
       "Do not use shared pointer arguments as output arguments with Call"
     );
 
@@ -786,7 +786,7 @@ public:
     // Completely unnecessary.  Call will avoid making unneeded copies, and this is guaranteed
     // by a unit test.  Dereference your shared pointers before passing them in.
     static_assert(
-      !autowiring::is_any<is_shared_ptr<Outputs>::value...>::value,
+      !autowiring::is_any<autowiring::is_shared_ptr<Outputs>::value...>::value,
       "Do not use shared pointer arguments as output arguments with Call"
     );
 

--- a/src/autowiring/AutoPacket.h
+++ b/src/autowiring/AutoPacket.h
@@ -23,42 +23,18 @@
 class AutoPacketInternal;
 class AutoPacketFactory;
 class CoreContext;
-struct AutoFilterDescriptor;
-
-template<class T>
-class auto_arg;
 
 namespace autowiring {
   template<class MemFn, class Index>
   struct CE;
 
-  template<typename T>
-  struct is_shared_ptr:
-    std::false_type
-  {};
-
-  template<typename T>
-  struct is_shared_ptr<std::shared_ptr<T>> :
-    std::true_type
-  {};
-
-  template<typename T>
-  struct is_shared_ptr<std::shared_ptr<const T>> :
-    std::true_type
-  {};
-
-  template<typename T>
-  struct is_shared_ptr<const T> :
-    is_shared_ptr<T>
-  {};
-
-  template<typename T>
-  struct is_shared_ptr<T&> :
-    is_shared_ptr<T>
-  {};
-
   template<typename Arg, typename Pack, typename = void>
   struct choice;
+
+  struct AutoFilterDescriptor;
+
+  template<class T>
+  class auto_arg;
 }
 
 /// <summary>
@@ -72,7 +48,7 @@ namespace autowiring {
 /// </remarks>
 class AutoPacket:
   public std::enable_shared_from_this<AutoPacket>,
-  public TeardownNotifier
+  public autowiring::TeardownNotifier
 {
 public:
   AutoPacket(const AutoPacket& rhs) = delete;
@@ -85,7 +61,7 @@ public:
   // The set of decorations currently attached to this object, and the associated lock:
   // Decorations are indexed first by type and second by pipe terminating type, if any.
   // NOTE: This is a disambiguation of function reference assignment, and avoids use of constexp.
-  typedef std::unordered_map<DecorationKey, DecorationDisposition> t_decorationMap;
+  typedef std::unordered_map<autowiring::DecorationKey, autowiring::DecorationDisposition> t_decorationMap;
 
 protected:
   // A pointer back to the factory that created us. Used for recording lifetime statistics.
@@ -101,7 +77,7 @@ protected:
   const std::shared_ptr<void> m_outstanding;
 
   // Pointer to a forward linked list of saturation counters, constructed when the packet is created
-  SatCounter* m_firstCounter = nullptr;
+  autowiring::SatCounter* m_firstCounter = nullptr;
 
   t_decorationMap m_decoration_map;
 
@@ -115,30 +91,30 @@ protected:
   /// available.  Thus, callers are either satisfied at the point of decoration, or will not be satisfied for that
   /// type.
   /// </remarks>
-  DecorationDisposition& DecorateImmediateUnsafe(const DecorationKey& key, const void* pvImmed);
+  autowiring::DecorationDisposition& DecorateImmediateUnsafe(const autowiring::DecorationKey& key, const void* pvImmed);
 
   /// <summary>
   /// Adds all AutoFilter argument information for a recipient
   /// </summary>
-  void AddSatCounterUnsafe(SatCounter& satCounter);
+  void AddSatCounterUnsafe(autowiring::SatCounter& satCounter);
 
   /// <summary>
   /// Remove all AutoFilter argument information for a recipient
-  void RemoveSatCounterUnsafe(const SatCounter& satCounter);
+  void RemoveSatCounterUnsafe(const autowiring::SatCounter& satCounter);
 
   /// <summary>
   /// Detect cycle in the auto filter graph using DFS
-  void DetectCycle(SatCounter& satCounter, std::unordered_set<SatCounter*>& tempVisited, std::unordered_set<SatCounter*>& permVisited);
+  void DetectCycle(autowiring::SatCounter& satCounter, std::unordered_set<autowiring::SatCounter*>& tempVisited, std::unordered_set<autowiring::SatCounter*>& permVisited);
 
   /// <summary>
   /// Marks the specified entry as being unsatisfiable
   /// </summary>
-  void MarkUnsatisfiable(const DecorationKey& key);
+  void MarkUnsatisfiable(const autowiring::DecorationKey& key);
 
   /// <summary>
   /// Marks timeshifted decorations on successor packets as unsatisfiable
   /// </summary>
-  void MarkSuccessorsUnsatisfiable(DecorationKey type);
+  void MarkSuccessorsUnsatisfiable(autowiring::DecorationKey type);
 
   /// <summary>
   /// Updates subscriber statuses given that the specified type information has been satisfied
@@ -149,7 +125,7 @@ protected:
   /// This method results in a call to the AutoFilter method on any subscribers which are
   /// satisfied by this decoration.  This method must be called with m_lock held.
   /// </remarks>
-  void UpdateSatisfactionUnsafe(std::unique_lock<std::mutex> lk, const DecorationDisposition& disposition);
+  void UpdateSatisfactionUnsafe(std::unique_lock<std::mutex> lk, const autowiring::DecorationDisposition& disposition);
 
   /// <summary>
   /// Performs a "satisfaction pulse", which will avoid notifying any deferred filters
@@ -158,21 +134,21 @@ protected:
   /// A satisfaction pulse will call any AutoFilter instances which are satisfied by the
   /// decoration of the passed decoration types.
   /// </remarks>
-  void PulseSatisfactionUnsafe(std::unique_lock<std::mutex> lk, DecorationDisposition* pTypeSubs [], size_t nInfos);
+  void PulseSatisfactionUnsafe(std::unique_lock<std::mutex> lk, autowiring::DecorationDisposition* pTypeSubs [], size_t nInfos);
 
   /// <summary>Unsynchronized runtime counterpart to Has</summary>
-  bool HasUnsafe(const DecorationKey& key) const;
+  bool HasUnsafe(const autowiring::DecorationKey& key) const;
 
   /// <summary>
   /// Performs a decoration operation but does not attach priors to successors.
   /// </summary>
-  void DecorateNoPriors(const AnySharedPointer& ptr, DecorationKey key);
+  void DecorateNoPriors(const AnySharedPointer& ptr, autowiring::DecorationKey key);
 
   /// <summary>Runtime counterpart to Decorate</summary>
-  void Decorate(const AnySharedPointer& ptr, DecorationKey key);
+  void Decorate(const AnySharedPointer& ptr, autowiring::DecorationKey key);
 
   /// <summary>Runtime counterpart to RemoveDecoration</summary>
-  void RemoveDecoration(DecorationKey key);
+  void RemoveDecoration(autowiring::DecorationKey key);
 
   /// <summary>
   /// The portion of Successor that must run under a lock
@@ -183,29 +159,29 @@ protected:
   /// Retrieves the decoration disposition corresponding to some type
   /// </summary>
   /// <returns>The disposition, if the decoration exists and is satisfied, otherwise nullptr</returns>
-  const DecorationDisposition* GetDisposition(const DecorationKey& ti) const;
+  const autowiring::DecorationDisposition* GetDisposition(const autowiring::DecorationKey& ti) const;
 
   /// <returns>True if the indicated type has been requested for use by some consumer</returns>
-  bool HasSubscribers(const DecorationKey& key) const;
+  bool HasSubscribers(const autowiring::DecorationKey& key) const;
 
   /// <returns>Zero if there are no publishers, otherwise the number of publishers</returns>
-  size_t HasPublishers(const DecorationKey& key) const;
+  size_t HasPublishers(const autowiring::DecorationKey& key) const;
 
   /// <returns>A reference to the satisfaction counter for the specified type</returns>
   /// <remarks>
   /// If the type is not a subscriber GetSatisfaction().GetType() == nullptr will be true
   /// </remarks>
-  const SatCounter& GetSatisfaction(auto_id subscriber) const;
+  const autowiring::SatCounter& GetSatisfaction(auto_id subscriber) const;
 
   /// <summary>
   /// Throws a formatted runtime error corresponding to the case where an absent decoration was demanded
   /// </summary>
-  static void ThrowNotDecoratedException(const DecorationKey& key);
+  static void ThrowNotDecoratedException(const autowiring::DecorationKey& key);
 
   /// <summary>
   /// Throws a formatted runtime error corresponding to the case where a decoration was demanded and more than one such decoration was present
   /// </summary>
-  static void ThrowMultiplyDecoratedException(const DecorationKey& key);
+  static void ThrowMultiplyDecoratedException(const autowiring::DecorationKey& key);
 
 public:
   /// <returns>
@@ -623,21 +599,21 @@ public:
   /// This method is idempotent. The returned Recipient structure may be used to remove
   /// the recipient safely at any point.
   /// </remarks>
-  const SatCounter* AddRecipient(const AutoFilterDescriptor& descriptor);
+  const autowiring::SatCounter* AddRecipient(const autowiring::AutoFilterDescriptor& descriptor);
 
   /// <summary>
   /// Removes a previously added packet recipient
   /// The user is responsible to free the memeory for recipient.
   /// TODO: seems like a bad design, need refactor
   /// </summary>
-  void RemoveRecipient(const SatCounter& recipient);
+  void RemoveRecipient(const autowiring::SatCounter& recipient);
 
   /// <summary>
   /// Convenience overload, identical in behavior to AddRecipient
   /// </summary>
   template<class Fx>
-  const SatCounter* operator+=(Fx&& fx) {
-    return AddRecipient(AutoFilterDescriptor(std::forward<Fx&&>(fx)));
+  const autowiring::SatCounter* operator+=(Fx&& fx) {
+    return AddRecipient({ std::forward<Fx&&>(fx) });
   }
 
   /// <summary>
@@ -658,7 +634,7 @@ public:
   /// If the type is not a subscriber GetSatisfaction().GetType() == nullptr will be true
   /// </remarks>
   template<class T>
-  inline const SatCounter& GetSatisfaction(void) const { return GetSatisfaction(auto_id_t<T>{}); }
+  inline const autowiring::SatCounter& GetSatisfaction(void) const { return GetSatisfaction(auto_id_t<T>{}); }
 
   /// <summary>
   /// Returns the next packet that will be issued by the packet factory in this context relative to this context
@@ -703,7 +679,7 @@ public:
   /// by this filter have been satisfied on this packet.  When this function returns, the specified filter will have
   /// been called.
   /// </remarks>
-  bool Wait(std::condition_variable& cv, const AutoFilterArgument* inputs, std::chrono::nanoseconds duration = std::chrono::nanoseconds::max());
+  bool Wait(std::condition_variable& cv, const autowiring::AutoFilterArgument* inputs, std::chrono::nanoseconds duration = std::chrono::nanoseconds::max());
 
   /// <summary>
   /// Blocks until the passed lambda function can be called
@@ -770,7 +746,7 @@ public:
   static AutoPacket& CurrentPacket(void);
 
   template<typename Fn, typename Args, int... N>
-  static void CallWithChoiceTuple(Fn& fn, Args&& args, index_tuple<N...>) {
+  static void CallWithChoiceTuple(Fn& fn, Args&& args, autowiring::index_tuple<N...>) {
     fn(autowiring::get<N>(args).value...);
   }
 
@@ -779,7 +755,7 @@ public:
   /// </summary>
   template<typename... InArgs, typename... Outputs>
   void Call(void(*pfn)(InArgs...), Outputs&... outputs) {
-    typedef typename make_index_tuple<sizeof...(InArgs)>::type t_index;
+    typedef typename autowiring::make_index_tuple<sizeof...(InArgs)>::type t_index;
 
     // Completely unnecessary.  Call will avoid making unneeded copies, and this is guaranteed
     // by a unit test.  Dereference your shared pointers before passing them in.
@@ -904,7 +880,7 @@ namespace autowiring {
 /// Because this type is immediately satisfied, it is neither an input nor an output
 /// </remarks>
 template<>
-class auto_arg<AutoPacket&>
+class autowiring::auto_arg<AutoPacket&>
 {
 public:
   typedef AutoPacket& type;
@@ -926,7 +902,7 @@ public:
 /// AutoPacket specialization for shared pointer
 /// </summary>
 template<>
-class auto_arg<std::shared_ptr<AutoPacket>>
+class autowiring::auto_arg<std::shared_ptr<AutoPacket>>
 {
 public:
   typedef AutoPacket& type;

--- a/src/autowiring/AutoPacketFactory.cpp
+++ b/src/autowiring/AutoPacketFactory.cpp
@@ -6,6 +6,8 @@
 #include "SatCounter.h"
 #include <cmath>
 
+using namespace autowiring;
+
 AutoPacketFactory::AutoPacketFactory(void):
   ContextMember("AutoPacketFactory")
 {}

--- a/src/autowiring/AutoPacketFactory.cpp
+++ b/src/autowiring/AutoPacketFactory.cpp
@@ -209,9 +209,9 @@ void AutoPacketFactory::ResetPacketStatistics(void) {
   m_packetDurationSqSum = 0.0;
 }
 
-template struct SlotInformationStump<AutoPacketFactory, false>;
+template struct autowiring ::SlotInformationStump<AutoPacketFactory, false>;
 template std::shared_ptr<AutoPacketFactory> autowiring::fast_pointer_cast<AutoPacketFactory, CoreObject>(const std::shared_ptr<CoreObject>& Other);
-template class RegType<AutoPacketFactory>;
+template class autowiring::RegType<AutoPacketFactory>;
 template struct autowiring::fast_pointer_cast_blind<CoreObject, AutoPacketFactory>;
 template struct autowiring::fast_pointer_cast_initializer<CoreObject, AutoPacketFactory>;
 template struct autowiring::fast_pointer_cast_blind<AutoPacketFactory, CoreObject>;

--- a/src/autowiring/AutoPacketFactory.h
+++ b/src/autowiring/AutoPacketFactory.h
@@ -29,13 +29,13 @@ public:
 private:
   // Lock for this type
   mutable std::mutex m_lock;
-  
+
   // State change notification
   std::condition_variable m_stateCondition;
 
   // Internal outstanding reference for issued packet:
   std::weak_ptr<void> m_outstandingInternal;
-  
+
   // The most recently issued packet:
   std::weak_ptr<AutoPacketInternal> m_curPacket;
 
@@ -43,7 +43,7 @@ private:
   std::shared_ptr<AutoPacketInternal> m_nextPacket;
 
   // Collection of known subscribers
-  typedef std::set<AutoFilterDescriptor> t_autoFilterSet;
+  typedef std::set<autowiring::AutoFilterDescriptor> t_autoFilterSet;
   t_autoFilterSet m_autoFilters;
 
   // Accumulators used to compute statistics about AutoPacket lifespan.
@@ -70,13 +70,13 @@ public:
   /// <returns>
   /// A copy of all AutoFilter instances on this class
   /// </returns>
-  std::vector<AutoFilterDescriptor> GetAutoFilters(void) const;
+  std::vector<autowiring::AutoFilterDescriptor> GetAutoFilters(void) const;
 
   /// <summary>
   /// Creates a linked list of saturation counters
   /// </summary>
   /// <returns>The first element in the list, or nullptr if the list is empty</returns>
-  SatCounter* CreateSatCounterList(void) const;
+  autowiring::SatCounter* CreateSatCounterList(void) const;
 
   // CoreRunnable overrides:
   bool OnStart(void) override;
@@ -101,7 +101,7 @@ public:
   /// <remarks>
   /// This method is idempotent
   /// </remarks>
-  const AutoFilterDescriptor& AddSubscriber(const AutoFilterDescriptor& rhs);
+  const autowiring::AutoFilterDescriptor& AddSubscriber(const autowiring::AutoFilterDescriptor& rhs);
 
   /// <summary>
   /// Convenience override of AddSubscriber
@@ -111,8 +111,8 @@ public:
   /// For this call to be valid, T::AutoFilter must be defined and must be a compliant AutoFilter
   /// </remarks>
   template<class T>
-  AutoFilterDescriptor AddSubscriber(const std::shared_ptr<T>& rhs) {
-    return AddSubscriber(AutoFilterDescriptor(rhs));
+  autowiring::AutoFilterDescriptor AddSubscriber(const std::shared_ptr<T>& rhs) {
+    return AddSubscriber({ rhs });
   }
 
   /// <summary>
@@ -124,7 +124,7 @@ public:
   /// AutoFilter on it.  Only packets that are issued after this method returns will lack the presence of
   /// the autoFilter described by the parameter.
   /// </remarks>
-  void RemoveSubscriber(const AutoFilterDescriptor& autoFilter);
+  void RemoveSubscriber(const autowiring::AutoFilterDescriptor& autoFilter);
 
   struct AutoPacketFactoryExpression {
     AutoPacketFactoryExpression(AutoPacketFactory& factory, autowiring::altitude altitude):
@@ -136,7 +136,7 @@ public:
     autowiring::altitude altitude;
 
     template<class Fx>
-    AutoFilterDescriptor operator,(Fx&& fx) {
+    autowiring::AutoFilterDescriptor operator,(Fx&& fx) {
       return factory.AddSubscriber(AutoFilterDescriptor(std::forward<Fx&&>(fx), altitude));
     }
   };
@@ -152,14 +152,14 @@ public:
   /// This method provides a way to attach a lambda function directly to the factory
   /// </remarks>
   template<class Fx>
-  AutoFilterDescriptor operator+= (Fx&& fx) {
-    return AddSubscriber(AutoFilterDescriptor(std::forward<Fx&&>(fx)));
+  autowiring::AutoFilterDescriptor operator+= (Fx&& fx) {
+    return AddSubscriber({ std::forward<Fx&&>(fx) });
   }
 
   /// <summary>
   /// Overloaded counterpart to RemoveSubscriber
   /// </summary>
-  void operator-=(const AutoFilterDescriptor& desc);
+  void operator-=(const autowiring::AutoFilterDescriptor& desc);
 
 protected:
   /// <summary>
@@ -168,7 +168,7 @@ protected:
   /// <remarks>
   /// If a matching description was not found GetTypeDescriptor(type).GetAutoFilterTypeInfo() == nullptr
   /// </remarks>
-  AutoFilterDescriptor GetTypeDescriptorUnsafe(auto_id nodeType);
+  autowiring::AutoFilterDescriptor GetTypeDescriptorUnsafe(auto_id nodeType);
 
   static bool IsAutoPacketType(const std::type_info& dataType);
 
@@ -232,9 +232,9 @@ public:
 // @cond
 // Extern explicit template instantiation declarations added to prevent
 // exterior instantation of internally used template instances
-extern template struct SlotInformationStump<AutoPacketFactory, false>;
+extern template struct autowiring::SlotInformationStump<AutoPacketFactory, false>;
 extern template std::shared_ptr<AutoPacketFactory> autowiring::fast_pointer_cast<AutoPacketFactory, CoreObject>(const std::shared_ptr<CoreObject>& Other);
-extern template class RegType<AutoPacketFactory>;
+extern template class autowiring::RegType<AutoPacketFactory>;
 extern template struct autowiring::fast_pointer_cast_blind<CoreObject, AutoPacketFactory>;
 extern template struct autowiring::fast_pointer_cast_initializer<CoreObject, AutoPacketFactory>;
 extern template struct autowiring::fast_pointer_cast_blind<AutoPacketFactory, CoreObject>;

--- a/src/autowiring/AutoPacketFactory.h
+++ b/src/autowiring/AutoPacketFactory.h
@@ -137,7 +137,7 @@ public:
 
     template<class Fx>
     autowiring::AutoFilterDescriptor operator,(Fx&& fx) {
-      return factory.AddSubscriber(AutoFilterDescriptor(std::forward<Fx&&>(fx), altitude));
+      return factory.AddSubscriber(autowiring::AutoFilterDescriptor(std::forward<Fx&&>(fx), altitude));
     }
   };
 

--- a/src/autowiring/AutoPacketGraph.cpp
+++ b/src/autowiring/AutoPacketGraph.cpp
@@ -13,6 +13,8 @@
 #include FUNCTIONAL_HEADER
 #include STL_UNORDERED_SET
 
+using namespace autowiring;
+
 AutoPacketGraph::AutoPacketGraph(void)
 {
   AutoCurrentContext()->newObject += [this] (const CoreObjectDescriptor&) { LoadEdges(); };

--- a/src/autowiring/AutoPacketGraph.h
+++ b/src/autowiring/AutoPacketGraph.h
@@ -23,7 +23,7 @@ struct DeliveryEdge
   auto_id type_info;
 
   // The AutoFilterDescriptor
-  AutoFilterDescriptor descriptor;
+  autowiring::AutoFilterDescriptor descriptor;
 
   // Specifies if the argument is an input (type -> descriptor) or output (descriptor -> type)
   // or rvalue (type <-> descriptor)
@@ -84,9 +84,9 @@ protected:
   /// <summary>
   /// Record the delivery of a packet and increment the number of times the packet has been delivered
   /// </summary>
-  void RecordDelivery(auto_id id, const AutoFilterDescriptor& descriptor, DeliveryEdge::ArgType arg_type);
+  void RecordDelivery(auto_id id, const autowiring::AutoFilterDescriptor& descriptor, DeliveryEdge::ArgType arg_type);
 
-  void NewObject(CoreContext&, const CoreObjectDescriptor&);
+  void NewObject(CoreContext&, const autowiring::CoreObjectDescriptor&);
 
   /// CoreRunnable overrides
   virtual bool OnStart(void) override;

--- a/src/autowiring/AutoPacketInternal.cpp
+++ b/src/autowiring/AutoPacketInternal.cpp
@@ -6,6 +6,8 @@
 #include "SatCounter.h"
 #include <algorithm>
 
+using namespace autowiring;
+
 AutoPacketInternal::AutoPacketInternal(AutoPacketFactory& factory, std::shared_ptr<void>&& outstanding) :
   AutoPacket(factory, std::move(outstanding))
 {}

--- a/src/autowiring/AutoPacketInternal.hpp
+++ b/src/autowiring/AutoPacketInternal.hpp
@@ -24,7 +24,7 @@ public:
   void Initialize(bool isFirstPacket);
 
   /// <summary>
-  /// 
+  ///
   /// </summary>
   std::shared_ptr<AutoPacketInternal> SuccessorInternal(void);
 };

--- a/src/autowiring/AutowirableSlot.cpp
+++ b/src/autowiring/AutowirableSlot.cpp
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <stdexcept>
 
+using namespace autowiring;
 using namespace std;
 
 void DeferrableAutowiring::Handler::operator()() {
@@ -16,7 +17,7 @@ void DeferrableAutowiring::Handler::operator()() {
   // only sets the size to zero.
   auto autowired_notifications =
     (
-      std::lock_guard<autowiring::spin_lock>{ parent.m_lock },
+      std::lock_guard<spin_lock>{ parent.m_lock },
       std::move(parent.m_autowired_notifications)
     );
 }
@@ -34,7 +35,7 @@ DeferrableAutowiring::DeferrableAutowiring(AnySharedPointer&& witness, const std
 
   // We need to know when the type itself becomes available:
   MemoEntry& memo = context->FindByType(witness.type(), false);
-  autowiring::registration_t reg =
+  registration_t reg =
     memo.onSatisfied += Handler{ *this, memo };
 
   if (!reg)
@@ -64,11 +65,11 @@ void DeferrableAutowiring::reset(void) {
   // Local versions of the members we are clearing out
   std::weak_ptr<CoreContext> contextWeak;
   AnySharedPointer ptr;
-  std::vector<autowiring::registration_t> autowired_notifications;
-  
+  std::vector<registration_t> autowired_notifications;
+
   // Move and handle resources under lock
   {
-    std::lock_guard<autowiring::spin_lock> lk{ m_lock };
+    std::lock_guard<spin_lock> lk{ m_lock };
     autowired_notifications = std::move(m_autowired_notifications);
     ptr = std::move(m_ptr);
     contextWeak = std::move(m_context);

--- a/src/autowiring/Autowired.h
+++ b/src/autowiring/Autowired.h
@@ -94,16 +94,16 @@ typedef AutoCreateContextT<void> AutoCreateContext;
 /// </remarks>
 template<typename T>
 class Autowired:
-  public AutowirableSlot<T>
+  public autowiring::AutowirableSlot<T>
 {
 public:
   Autowired(Autowired&&) = delete;
   Autowired(const Autowired& rhs) :
-    AutowirableSlot<T>(static_cast<AutowirableSlot<T>&>(rhs))
+    autowiring::AutowirableSlot<T>(static_cast<AutowirableSlot<T>&>(rhs))
   {}
 
   Autowired(const std::shared_ptr<CoreContext>& ctxt = CoreContext::CurrentContext()) :
-    AutowirableSlot<T>(ctxt)
+    autowiring::AutowirableSlot<T>(ctxt)
   {}
 
   operator const std::shared_ptr<T>&(void) const {

--- a/src/autowiring/Autowired.h
+++ b/src/autowiring/Autowired.h
@@ -99,7 +99,7 @@ class Autowired:
 public:
   Autowired(Autowired&&) = delete;
   Autowired(const Autowired& rhs) :
-    autowiring::AutowirableSlot<T>(static_cast<AutowirableSlot<T>&>(rhs))
+    autowiring::AutowirableSlot<T>(static_cast<autowiring::AutowirableSlot<T>&>(rhs))
   {}
 
   Autowired(const std::shared_ptr<CoreContext>& ctxt = CoreContext::CurrentContext()) :
@@ -181,7 +181,7 @@ public:
 
   void operator=(Autowired<T>&& rhs) = delete;
   void operator=(const Autowired<T>& rhs) {
-    *this = *static_cast<AutowirableSlot<T>*>(this);
+    *this = *static_cast<autowiring::AutowirableSlot<T>*>(this);
   }
 };
 

--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -134,7 +134,7 @@ const AutoFilterDescriptor* autowiring::dbg::DescriptorByName(const char* name) 
   if (!factory)
     return nullptr;
 
-  return DescriptorByName(name, factory->GetAutoFilters());
+  return ::DescriptorByName(name, factory->GetAutoFilters());
 }
 
 std::string autowiring::dbg::AutoFilterInfo(const char* name) {
@@ -146,7 +146,7 @@ std::string autowiring::dbg::AutoFilterInfo(const char* name) {
   const std::vector<AutoFilterDescriptor> descs = factory->GetAutoFilters();
 
   // Need the root descriptor first
-  const AutoFilterDescriptor* desc = DescriptorByName(name, descs);
+  const AutoFilterDescriptor* desc = ::DescriptorByName(name, descs);
   if (!desc)
     return "Filter not found";
 

--- a/src/autowiring/AutowiringDebug.h
+++ b/src/autowiring/AutowiringDebug.h
@@ -5,11 +5,12 @@
 #include <ostream>
 #include <memory>
 
-struct AutoFilterDescriptor;
 class AutoPacket;
 class CoreContext;
 
 namespace autowiring {
+  struct AutoFilterDescriptor;
+
   namespace dbg {
 
     /// <returns>

--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -12,6 +12,8 @@
 #include <cassert>
 #include ATOMIC_HEADER
 
+using namespace autowiring;
+
 static auto mainTID = std::this_thread::get_id();
 
 BasicThread::BasicThread(const char* pName):

--- a/src/autowiring/BasicThread.h
+++ b/src/autowiring/BasicThread.h
@@ -7,9 +7,12 @@
 #include MEMORY_HEADER
 #include MUTEX_HEADER
 
-struct BasicThreadStateBlock;
 class BasicThread;
 class CoreContext;
+
+namespace autowiring {
+  struct BasicThreadStateBlock;
+}
 
 /// <summary>
 /// Thread priority classifications from low to high.
@@ -115,7 +118,7 @@ protected:
   // Internally held thread status block.  This has to be a shared pointer because we need to signal
   // the held state condition after releasing all shared pointers to ourselves, and this could mean
   // we're actually signalling this event after we free ourselves.
-  const std::shared_ptr<BasicThreadStateBlock> m_state;
+  const std::shared_ptr<autowiring::BasicThreadStateBlock> m_state;
 
   // Flag indicating that this thread was started at some point
   bool m_wasStarted = false;

--- a/src/autowiring/BasicThreadStateBlock.cpp
+++ b/src/autowiring/BasicThreadStateBlock.cpp
@@ -2,6 +2,8 @@
 #include "stdafx.h"
 #include "BasicThreadStateBlock.h"
 
+using namespace autowiring;
+
 BasicThreadStateBlock::BasicThreadStateBlock(void)
 {}
 

--- a/src/autowiring/BasicThreadStateBlock.h
+++ b/src/autowiring/BasicThreadStateBlock.h
@@ -4,6 +4,8 @@
 #include MUTEX_HEADER
 #include THREAD_HEADER
 
+namespace autowiring {
+
 struct BasicThreadStateBlock:
   std::enable_shared_from_this<BasicThreadStateBlock>
 {
@@ -20,3 +22,5 @@ struct BasicThreadStateBlock:
   // Completion condition, true when this thread is no longer running and has run at least once
   bool m_completed = false;
 };
+
+}

--- a/src/autowiring/Bolt.h
+++ b/src/autowiring/Bolt.h
@@ -32,7 +32,7 @@ public:
     return false;
   }
 
-  static_assert(!is_any_same<void, Sigil...>::value, "Can't use 'void' as a sigil type");
+  static_assert(!autowiring::is_any_same<void, Sigil...>::value, "Can't use 'void' as a sigil type");
 };
 
 template<>

--- a/src/autowiring/ContextEnumerator.cpp
+++ b/src/autowiring/ContextEnumerator.cpp
@@ -3,6 +3,8 @@
 #include "ContextEnumerator.h"
 #include "CoreContext.h"
 
+using namespace autowiring;
+
 ContextEnumerator::ContextEnumerator(void) :
   m_root(CoreContext::CurrentContext())
 {}

--- a/src/autowiring/ContextMember.h
+++ b/src/autowiring/ContextMember.h
@@ -11,7 +11,7 @@ class CoreContext;
 /// </summary>
 class ContextMember:
   public CoreObject,
-  public TeardownNotifier,
+  public autowiring::TeardownNotifier,
   public std::enable_shared_from_this<ContextMember>
 {
 protected:

--- a/src/autowiring/CoreContext.h
+++ b/src/autowiring/CoreContext.h
@@ -885,7 +885,7 @@ public:
   /// </remarks>
   template<class T>
   void AddSnooper(const std::shared_ptr<T>& pSnooper) {
-    AddSnooper(CoreObjectDescriptor(pSnooper, (T*)nullptr));
+    AddSnooper(autowiring::CoreObjectDescriptor(pSnooper, (T*)nullptr));
   }
 
   /// <summary>
@@ -894,7 +894,7 @@ public:
   template<class T>
   void AddSnooper(const Autowired<T>& snooper) {
     AddSnooper(
-      CoreObjectDescriptor(
+      autowiring::CoreObjectDescriptor(
         static_cast<const std::shared_ptr<T>&>(snooper),
         (T*)nullptr
       )
@@ -914,7 +914,7 @@ public:
   /// </remarks>
   template<class T>
   void RemoveSnooper(const std::shared_ptr<T>& pSnooper) {
-    RemoveSnooper(CoreObjectDescriptor(pSnooper, (T*)nullptr));
+    RemoveSnooper(autowiring::CoreObjectDescriptor(pSnooper, (T*)nullptr));
   }
 
   /// <summary>
@@ -923,7 +923,7 @@ public:
   template<class T>
   void RemoveSnooper(const Autowired<T>& snooper) {
     RemoveSnooper(
-      CoreObjectDescriptor(
+      autowiring::CoreObjectDescriptor(
         static_cast<const std::shared_ptr<T>&>(snooper),
         (T*)nullptr
       )
@@ -951,7 +951,7 @@ public:
     // Ensure we instantiate casters for type T, regardless of whether the listener intends to use it
     autowiring::instantiate<T>();
 
-    MemoEntry& memo = FindByType(auto_id_t<T>{});
+    autowiring::MemoEntry& memo = FindByType(auto_id_t<T>{});
     CurrentContextPusher pshr(*this);
     memo.onSatisfied += std::forward<Fn&&>(listener);
   }

--- a/src/autowiring/CoreContextStateBlock.h
+++ b/src/autowiring/CoreContextStateBlock.h
@@ -5,25 +5,26 @@
 #include MUTEX_HEADER
 
 class CoreContext;
-struct CoreContextStateBlock;
 
 namespace autowiring {
-  /// <summary>
-  /// Container type used for state block referencing
-  /// </summary>
-  class RunCounter:
-    public CoreObject
-  {
-  public:
-    RunCounter(const std::shared_ptr<CoreContextStateBlock>& stateBlock, const std::shared_ptr<CoreContext>& owner);
-    ~RunCounter(void);
 
-  private:
-    const std::shared_ptr<CoreContextStateBlock> stateBlock;
-    const std::shared_ptr<RunCounter> parentCount;
-    std::shared_ptr<CoreContext> owner;
-  };
-}
+struct CoreContextStateBlock;
+
+/// <summary>
+/// Container type used for state block referencing
+/// </summary>
+class RunCounter:
+  public CoreObject
+{
+public:
+  RunCounter(const std::shared_ptr<CoreContextStateBlock>& stateBlock, const std::shared_ptr<CoreContext>& owner);
+  ~RunCounter(void);
+
+private:
+  const std::shared_ptr<CoreContextStateBlock> stateBlock;
+  const std::shared_ptr<RunCounter> parentCount;
+  std::shared_ptr<CoreContext> owner;
+};
 
 struct CoreContextStateBlock:
   std::enable_shared_from_this<CoreContextStateBlock>
@@ -61,3 +62,4 @@ public:
   std::shared_ptr<autowiring::RunCounter> IncrementOutstandingThreadCount(std::shared_ptr<CoreContext> owner);
 };
 
+}

--- a/src/autowiring/CoreJob.cpp
+++ b/src/autowiring/CoreJob.cpp
@@ -4,6 +4,8 @@
 #include "CoreContext.h"
 #include FUTURE_HEADER
 
+using namespace autowiring;
+
 // Arm doesn't have std::future, but does have std::chrono. We need to convert from std::chrono
 // to autoboost::chrono when passing arguments to "std::future"(alias to autoboost::future) on arm.
 #if __ANDROID__ && !GCC_CHECK(4, 9)

--- a/src/autowiring/CoreObjectDescriptor.h
+++ b/src/autowiring/CoreObjectDescriptor.h
@@ -17,15 +17,15 @@
 #include MEMORY_HEADER
 
 namespace autowiring {
-  /// <summary>
-  /// Instantiates all casters and traits for type T
-  /// </summary>
-  template<typename T>
-  void instantiate(void) {
-    (void)fast_pointer_cast_initializer<CoreObject, T>::sc_init;
-    (void)fast_pointer_cast_initializer<T, CoreObject>::sc_init;
-    (void)auto_id_t_init<T>::init;
-  }
+
+/// <summary>
+/// Instantiates all casters and traits for type T
+/// </summary>
+template<typename T>
+void instantiate(void) {
+  (void)fast_pointer_cast_initializer<CoreObject, T>::sc_init;
+  (void)fast_pointer_cast_initializer<T, CoreObject>::sc_init;
+  (void)auto_id_t_init<T>::init;
 }
 
 /// <summary>
@@ -45,14 +45,14 @@ struct CoreObjectDescriptor {
     stump(&SlotInformationStump<T>::s_stump),
     value(value),
     subscriber(MakeAutoFilterDescriptor<T>(value)),
-    pConfigWatcher(autowiring::fast_pointer_cast<autowiring::ConfigWatcherBase>(value)),
-    pCoreObject(autowiring::fast_pointer_cast<CoreObject>(value)),
-    pContextMember(autowiring::fast_pointer_cast<ContextMember>(value)),
-    pCoreRunnable(autowiring::fast_pointer_cast<CoreRunnable>(value)),
-    pBasicThread(autowiring::fast_pointer_cast<BasicThread>(value)),
-    pFilter(autowiring::fast_pointer_cast<ExceptionFilter>(value)),
-    pBoltBase(autowiring::fast_pointer_cast<BoltBase>(value)),
-    pConfigDesc(autowiring::config_registry_entry<T>::desc()),
+    pConfigWatcher(autowiring::fast_pointer_cast<ConfigWatcherBase>(value)),
+    pCoreObject(autowiring::fast_pointer_cast<::CoreObject>(value)),
+    pContextMember(autowiring::fast_pointer_cast<::ContextMember>(value)),
+    pCoreRunnable(autowiring::fast_pointer_cast<::CoreRunnable>(value)),
+    pBasicThread(autowiring::fast_pointer_cast<::BasicThread>(value)),
+    pFilter(autowiring::fast_pointer_cast<::ExceptionFilter>(value)),
+    pBoltBase(autowiring::fast_pointer_cast<::BoltBase>(value)),
+    pConfigDesc(config_registry_entry<T>::desc()),
     primitiveOffset(
       reinterpret_cast<size_t>(
         static_cast<T*>(
@@ -110,7 +110,7 @@ struct CoreObjectDescriptor {
   ///
   /// The linked list is guaranteed to be in reverse-sorted order
   /// </remarks>
-  const SlotInformationStumpBase* stump;
+  const autowiring::SlotInformationStumpBase* stump;
 
   // A holder to store the original shared pointer, to ensure that type information propagates
   // correctly on the right-hand side of our map
@@ -120,17 +120,19 @@ struct CoreObjectDescriptor {
   AutoFilterDescriptor subscriber;
 
   // There are a lot of interfaces we support, here they all are:
-  std::shared_ptr<autowiring::ConfigWatcherBase> pConfigWatcher;
-  std::shared_ptr<CoreObject> pCoreObject;
-  std::shared_ptr<ContextMember> pContextMember;
-  std::shared_ptr<CoreRunnable> pCoreRunnable;
-  std::shared_ptr<BasicThread> pBasicThread;
-  std::shared_ptr<ExceptionFilter> pFilter;
-  std::shared_ptr<BoltBase> pBoltBase;
+  std::shared_ptr<ConfigWatcherBase> pConfigWatcher;
+  std::shared_ptr<::CoreObject> pCoreObject;
+  std::shared_ptr<::ContextMember> pContextMember;
+  std::shared_ptr<::CoreRunnable> pCoreRunnable;
+  std::shared_ptr<::BasicThread> pBasicThread;
+  std::shared_ptr<::ExceptionFilter> pFilter;
+  std::shared_ptr<::BoltBase> pBoltBase;
 
   // Configuration descriptor, if the object provides one
-  const autowiring::config_descriptor* pConfigDesc;
+  const config_descriptor* pConfigDesc;
 
   // Distance from TActual to T
   size_t primitiveOffset;
 };
+
+}

--- a/src/autowiring/CoreRunnable.h
+++ b/src/autowiring/CoreRunnable.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include "C++11/cpp11.h"
 #include CHRONO_HEADER
 #include MEMORY_HEADER
 #include MUTEX_HEADER
@@ -17,7 +18,7 @@ class CoreRunnable {
 public:
   CoreRunnable(void);
   virtual ~CoreRunnable(void);
-  
+
 private:
   // Set to true if this runnable was ever signaled to start
   bool m_wasStarted = false;

--- a/src/autowiring/CreationRules.h
+++ b/src/autowiring/CreationRules.h
@@ -7,13 +7,14 @@
 
 class CoreContext;
 
+namespace autowiring {
+
 template<typename T>
 struct is_injectable
 {
-  static const bool value = autowiring::has_simple_constructor<T>::value || autowiring::has_static_new<T>::value;
+  static const bool value = has_simple_constructor<T>::value || has_static_new<T>::value;
 };
 
-namespace autowiring {
 enum class construction_strategy {
   // Just use new
   standard,
@@ -83,7 +84,7 @@ struct crh<construction_strategy::factory_new, T, Args...>
 {
   // Actual constructed type is directly the specified type
   typedef T TActual;
-  
+
   static_assert(
     std::is_base_of<CoreObject, T>::value,
     "If type T provides a static New method, then the constructed type MUST directly inherit Object"

--- a/src/autowiring/Decompose.h
+++ b/src/autowiring/Decompose.h
@@ -3,6 +3,8 @@
 #include "is_any.h"
 #include <typeinfo>
 
+namespace autowiring {
+
 template<class... Ts>
 struct TemplatePack {
   static const int N = sizeof...(Ts);
@@ -71,3 +73,5 @@ struct Decompose<R(*)(Args...)> :
   typedef void type;
   typedef R retType;
 };
+
+}

--- a/src/autowiring/DecorationDisposition.h
+++ b/src/autowiring/DecorationDisposition.h
@@ -7,6 +7,8 @@
 #include <set>
 #include <vector>
 
+namespace autowiring {
+
 struct SatCounter;
 
 struct DecorationKey {
@@ -28,15 +30,6 @@ struct DecorationKey {
     return id == rhs.id && tshift == rhs.tshift;
   }
 };
-
-namespace std {
-  template<>
-  struct hash<DecorationKey> {
-    size_t operator()(const DecorationKey& key) const {
-      return key.tshift + (size_t)key.id.block;
-    }
-  };
-}
 
 // The possible states for a DecorationDisposition
 enum class DispositionState {
@@ -195,3 +188,14 @@ struct DecorationDisposition
     m_state = DispositionState::Unsatisfied;
   }
 };
+
+}
+
+namespace std {
+  template<>
+  struct hash<autowiring::DecorationKey> {
+    size_t operator()(const autowiring::DecorationKey& key) const {
+      return key.tshift + (size_t)key.id.block;
+    }
+  };
+}

--- a/src/autowiring/DispatchQueue.cpp
+++ b/src/autowiring/DispatchQueue.cpp
@@ -4,6 +4,8 @@
 #include "at_exit.h"
 #include <assert.h>
 
+using namespace autowiring;
+
 DispatchQueue::DispatchQueue(void) {}
 
 DispatchQueue::DispatchQueue(size_t dispatchCap):

--- a/src/autowiring/DispatchQueue.h
+++ b/src/autowiring/DispatchQueue.h
@@ -48,11 +48,11 @@ protected:
   std::atomic<uint64_t> m_version{1};
 
   // The dispatch queue proper.  A vector is used, here, not a queue, because this collection is frequently emptied.
-  DispatchThunkBase* m_pHead = nullptr;
-  DispatchThunkBase* m_pTail = nullptr;
+  autowiring::DispatchThunkBase* m_pHead = nullptr;
+  autowiring::DispatchThunkBase* m_pTail = nullptr;
 
   // Priority queue of non-ready events:
-  std::priority_queue<DispatchThunkDelayed> m_delayedQueue;
+  std::priority_queue<autowiring::DispatchThunkDelayed> m_delayedQueue;
 
   // A lock held when the dispatch queue must be updated:
   std::mutex m_dispatchLock;
@@ -100,14 +100,14 @@ protected:
   void Pend(_Fx&& fx) {
     PendExisting(
       std::unique_lock<std::mutex>(m_dispatchLock),
-      new DispatchThunk<_Fx>(std::forward<_Fx&&>(fx))
+      new autowiring::DispatchThunk<_Fx>(std::forward<_Fx&&>(fx))
     );
   }
 
   /// <summary>
   /// Attaches an element to the end of the dispatch queue without any checks.
   /// </summary>
-  void PendExisting(std::unique_lock<std::mutex>&& lk, DispatchThunkBase* thunk);
+  void PendExisting(std::unique_lock<std::mutex>&& lk, autowiring::DispatchThunkBase* thunk);
 
   /// <summary>
   /// Updates the upper bound on the number of allowed pending dispatchers
@@ -238,7 +238,7 @@ public:
   /// <summary>
   /// Explicit overload for already-constructed dispatch thunk types
   /// </summary>
-  void AddExisting(std::unique_ptr<DispatchThunkBase>&& pBase) {
+  void AddExisting(std::unique_ptr<autowiring::DispatchThunkBase>&& pBase) {
     std::unique_lock<std::mutex> lk(m_dispatchLock);
     if (m_count < m_dispatchCap)
       PendExisting(std::move(lk), pBase.release());
@@ -364,7 +364,7 @@ public:
   /// <remarks>
   /// This overload will always succeed and does not consult the dispatch cap
   /// </remarks>
-  void operator+=(DispatchThunkDelayed&& rhs);
+  void operator+=(autowiring::DispatchThunkDelayed&& rhs);
 
   /// <summary>
   /// Generic overload which will pend an arbitrary dispatch type

--- a/src/autowiring/DispatchQueue.h
+++ b/src/autowiring/DispatchQueue.h
@@ -298,9 +298,9 @@ public:
     void operator,(_Fx&& fx) {
       // Let the parent handle this one directly after composing a delayed dispatch thunk r-value
       if (m_delay.count())
-        *m_pParent += DispatchThunkDelayed(
+        *m_pParent += autowiring::DispatchThunkDelayed(
           std::chrono::steady_clock::now() + m_delay,
-          new DispatchThunk<_Fx>(std::forward<_Fx&&>(fx))
+          new autowiring::DispatchThunk<_Fx>(std::forward<_Fx&&>(fx))
         );
       else
         *m_pParent += std::forward<_Fx&&>(fx);
@@ -322,9 +322,9 @@ public:
     template<class _Fx>
     void operator,(_Fx&& fx) {
       // Let the parent handle this one directly after composing a delayed dispatch thunk r-value
-      *m_pParent += DispatchThunkDelayed(
+      *m_pParent += autowiring::DispatchThunkDelayed(
         m_wakeup,
-        new DispatchThunk<_Fx>(std::forward<_Fx>(fx))
+        new autowiring::DispatchThunk<_Fx>(std::forward<_Fx>(fx))
       );
     }
   };

--- a/src/autowiring/DispatchQueue.h
+++ b/src/autowiring/DispatchQueue.h
@@ -371,11 +371,11 @@ public:
   /// </summary>
   template<class _Fx>
   bool operator+=(_Fx&& fx) {
-    static_assert(!std::is_base_of<DispatchThunkBase, _Fx>::value, "Overload resolution malfunction, must not doubly wrap a dispatch thunk");
+    static_assert(!std::is_base_of<autowiring::DispatchThunkBase, _Fx>::value, "Overload resolution malfunction, must not doubly wrap a dispatch thunk");
     static_assert(!std::is_pointer<_Fx>::value, "Cannot pend a pointer to a function, we must have direct ownership");
 
     // Create the thunk first to reduce the amount of time we spend in lock:
-    auto thunk = new DispatchThunk<_Fx>(std::forward<_Fx>(fx));
+    auto thunk = new autowiring::DispatchThunk<_Fx>(std::forward<_Fx>(fx));
 
     m_dispatchLock.lock();
     if (m_count >= m_dispatchCap) {

--- a/src/autowiring/DispatchThunk.h
+++ b/src/autowiring/DispatchThunk.h
@@ -3,6 +3,8 @@
 #include CHRONO_HEADER
 #include <memory>
 
+namespace autowiring {
+
 /// <summary>
 /// A simple virtual class used to hold a trivial thunk
 /// </summary>
@@ -80,3 +82,5 @@ public:
   }
   void operator=(const DispatchThunkDelayed&) const = delete;
 };
+
+}

--- a/src/autowiring/HeteroBlock.cpp
+++ b/src/autowiring/HeteroBlock.cpp
@@ -24,7 +24,7 @@ HeteroBlock::HeteroBlock(const HeteroBlockEntry* pFirst, const HeteroBlockEntry*
 
   // Allocate enough space for everything:
   size_t ncb = 0;
-  
+
   size_t temp;
   size_t* sizePrior = &temp;
 

--- a/src/autowiring/InterlockedExchange.h
+++ b/src/autowiring/InterlockedExchange.h
@@ -1,6 +1,8 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 
+namespace autowiring {
+
 /// <summary>
 /// Stores the passed value in the specified space, and returns the value that was previously located there
 /// </summary>
@@ -21,4 +23,6 @@ void* compare_exchange(void** dest, void* exchange, const void* comparand);
 template<class T>
 T* compare_exchange(const T*const* dest, T* exchange, const T* comparand) {
   return (T*)compare_exchange((void**) dest, exchange, comparand);
+}
+
 }

--- a/src/autowiring/InterlockedExchangeUnix.cpp
+++ b/src/autowiring/InterlockedExchangeUnix.cpp
@@ -2,14 +2,14 @@
 #include "stdafx.h"
 #include "InterlockedExchange.h"
 
-void* exchange_acquire(void** dest, void* exchange) {
+void* autowiring::exchange_acquire(void** dest, void* exchange) {
   return __sync_lock_test_and_set((void**)dest, exchange);
 }
 
-void* exchange_release(void** dest, void* exchange) {
+void* autowiring::exchange_release(void** dest, void* exchange) {
   return __sync_lock_test_and_set((void**)dest, exchange);
 }
 
-void* compare_exchange(void** dest, void* exchange, const void* comparand) {
+void* autowiring::compare_exchange(void** dest, void* exchange, const void* comparand) {
   return __sync_val_compare_and_swap((void**)dest, (void*)comparand, exchange);
 }

--- a/src/autowiring/InterlockedExchangeWin.cpp
+++ b/src/autowiring/InterlockedExchangeWin.cpp
@@ -3,19 +3,19 @@
 #include "InterlockedExchange.h"
 #include <windows.h>
 
-void* exchange_acquire(void** dest, void* exchange) {
+void* autowiring::exchange_acquire(void** dest, void* exchange) {
   return InterlockedExchangePointer(dest, exchange);
 }
 
-void* exchange_release(void** dest, void* exchange) {
+void* autowiring::exchange_release(void** dest, void* exchange) {
   return InterlockedExchangePointer(dest, exchange);
 }
 
-long interlocked_add(long* dest, long addBy) {
+long autowiring::interlocked_add(long* dest, long addBy) {
   return InterlockedExchangeAdd(dest, addBy);
 }
 
-void* compare_exchange(void** dest, void* exchange, const void* comparand) {
+void* autowiring::compare_exchange(void** dest, void* exchange, const void* comparand) {
   return InterlockedCompareExchangePointer(
     dest,
     exchange,

--- a/src/autowiring/MemoEntry.cpp
+++ b/src/autowiring/MemoEntry.cpp
@@ -2,4 +2,7 @@
 #include "stdafx.h"
 #include "MemoEntry.h"
 
+using namespace autowiring;
+
+
 MemoEntry::MemoEntry(void) {}

--- a/src/autowiring/MemoEntry.h
+++ b/src/autowiring/MemoEntry.h
@@ -4,6 +4,9 @@
 #include "once.h"
 
 class CoreContext;
+
+namespace autowiring {
+
 struct CoreObjectDescriptor;
 class DeferrableAutowiring;
 
@@ -30,3 +33,4 @@ struct MemoEntry {
   bool m_local = true;
 };
 
+}

--- a/src/autowiring/NullPool.h
+++ b/src/autowiring/NullPool.h
@@ -44,4 +44,5 @@ public:
   std::shared_ptr<void> Start(void) override;
   bool Submit(std::unique_ptr<DispatchThunkBase>&& thunk) override;
 };
+
 }

--- a/src/autowiring/ObjectPool.h
+++ b/src/autowiring/ObjectPool.h
@@ -41,7 +41,7 @@ class ObjectPool
 {
 public:
   ObjectPool(void) :
-    m_monitor(std::make_shared<ObjectPoolMonitorT<T>>(this, &DefaultInitialize<T>, &DefaultFinalize<T>)),
+    m_monitor(std::make_shared<autowiring::ObjectPoolMonitorT<T>>(this, &DefaultInitialize<T>, &DefaultFinalize<T>)),
     m_maxPooled(~0),
     m_limit(~0)
   {}

--- a/src/autowiring/ObjectPool.h
+++ b/src/autowiring/ObjectPool.h
@@ -58,7 +58,7 @@ public:
     const std::function<void(T&)>& initial = &DefaultInitialize<T>,
     const std::function<void(T&)>& final = &DefaultFinalize<T>
   ) :
-    m_monitor(std::make_shared<ObjectPoolMonitorT<T>>(this, initial, final)),
+    m_monitor(std::make_shared<autowiring::ObjectPoolMonitorT<T>>(this, initial, final)),
     m_maxPooled(maxPooled),
     m_limit(limit),
     m_placement(placement)
@@ -79,7 +79,7 @@ public:
     const std::function<void(T&)>& initial = &DefaultInitialize<T>,
     const std::function<void(T&)>& final = &DefaultFinalize<T>
   ) :
-    m_monitor(std::make_shared<ObjectPoolMonitorT<T>>(this, initial, final)),
+    m_monitor(std::make_shared<autowiring::ObjectPoolMonitorT<T>>(this, initial, final)),
     m_placement(placement)
   {}
 
@@ -96,7 +96,7 @@ public:
   }
 
 protected:
-  std::shared_ptr<ObjectPoolMonitorT<T>> m_monitor;
+  std::shared_ptr<autowiring::ObjectPoolMonitorT<T>> m_monitor;
   std::condition_variable m_setCondition;
 
   struct PoolEntry {
@@ -129,7 +129,7 @@ protected:
     }
 
     // Pointer to the monitor used to get us back to our pool when we're returned
-    const std::shared_ptr<ObjectPoolMonitorT<T>> monitor;
+    const std::shared_ptr<autowiring::ObjectPoolMonitorT<T>> monitor;
 
     // Pool version at the time of construction
     const size_t poolVersion;

--- a/src/autowiring/ObjectPoolMonitor.cpp
+++ b/src/autowiring/ObjectPoolMonitor.cpp
@@ -2,6 +2,8 @@
 #include "stdafx.h"
 #include "ObjectPoolMonitor.h"
 
+using namespace autowiring;
+
 ObjectPoolMonitor::ObjectPoolMonitor(void) {}
 
 void ObjectPoolMonitor::Abandon(void) {

--- a/src/autowiring/ObjectPoolMonitor.h
+++ b/src/autowiring/ObjectPoolMonitor.h
@@ -6,6 +6,8 @@
 template<class T>
 class ObjectPool;
 
+namespace autowiring {
+
 /// <summary>
 /// Interior state object of the object pool, provided to allow out-of-order teardown on the object pool
 /// </summary>
@@ -61,3 +63,5 @@ public:
   const std::function<void(T&)> initial;
   const std::function<void(T&)> fnl;
 };
+
+}

--- a/src/autowiring/SatCounter.h
+++ b/src/autowiring/SatCounter.h
@@ -2,6 +2,8 @@
 #pragma once
 #include "AutoFilterDescriptor.h"
 
+namespace autowiring {
+
 /// <summary>
 /// A single subscription counter entry
 /// </summary>
@@ -43,11 +45,13 @@ struct SatCounter:
   }
 };
 
+}
+
 namespace std {
   template<>
-  struct hash<SatCounter>
+  struct hash<autowiring::SatCounter>
   {
-    size_t operator()(const SatCounter& satCounter) const {
+    size_t operator()(const autowiring::SatCounter& satCounter) const {
       return (size_t)satCounter.GetAutoFilter().ptr();
     }
   };

--- a/src/autowiring/SlotInformation.cpp
+++ b/src/autowiring/SlotInformation.cpp
@@ -6,6 +6,8 @@
 #include "thread_specific_ptr.h"
 #include MEMORY_HEADER
 
+using namespace autowiring;
+
 // Special file-level allocation with a no-op dtor, because all stack locations are stack-allocated
 static autowiring::thread_specific_ptr<SlotInformationStackLocation> tss([](SlotInformationStackLocation*) {});
 

--- a/src/autowiring/SlotInformation.h
+++ b/src/autowiring/SlotInformation.h
@@ -5,6 +5,8 @@
 #include <typeinfo>
 #include MEMORY_HEADER
 
+namespace autowiring {
+
 class DeferrableAutowiring;
 
 /// <summary>
@@ -144,3 +146,5 @@ public:
   /// </summary>
   static void RegisterSlot(DeferrableAutowiring* pAutowiring);
 };
+
+}

--- a/src/autowiring/TeardownNotifier.cpp
+++ b/src/autowiring/TeardownNotifier.cpp
@@ -3,7 +3,9 @@
 #include "TeardownNotifier.h"
 #include "InterlockedExchange.h"
 
-TeardownNotifier::TeardownNotifier(void) 
+using namespace autowiring;
+
+TeardownNotifier::TeardownNotifier(void)
 {}
 
 TeardownNotifier::~TeardownNotifier(void) {

--- a/src/autowiring/TeardownNotifier.h
+++ b/src/autowiring/TeardownNotifier.h
@@ -3,6 +3,8 @@
 #include "C++11/cpp11.h"
 #include RVALUE_HEADER
 
+namespace autowiring {
+
 /// <summary>
 /// Maintains a list of lambdas to be invoked when the enclosing object is being destroyed
 /// </summary>
@@ -78,3 +80,4 @@ public:
     AddTeardownListenerInternal(new Entry<Fx>(std::forward<Fx&&>(listener)));
   }
 };
+}

--- a/src/autowiring/ThreadPool.h
+++ b/src/autowiring/ThreadPool.h
@@ -6,9 +6,10 @@
 #include MEMORY_HEADER
 
 class DispatchQueue;
-class DispatchThunkBase;
 
 namespace autowiring {
+
+class DispatchThunkBase;
 
 /// <summary>
 /// Generic interface for a thread pool

--- a/src/autowiring/TypeRegistry.cpp
+++ b/src/autowiring/TypeRegistry.cpp
@@ -2,6 +2,8 @@
 #include "stdafx.h"
 #include "TypeRegistry.h"
 
+using namespace autowiring;
+
 // Head of a linked list which will have node for every event type
 const TypeRegistryEntry* g_pFirstTypeEntry = nullptr;
 size_t g_typeEntryCount = 0;

--- a/src/autowiring/TypeRegistry.cpp
+++ b/src/autowiring/TypeRegistry.cpp
@@ -5,8 +5,8 @@
 using namespace autowiring;
 
 // Head of a linked list which will have node for every event type
-const TypeRegistryEntry* g_pFirstTypeEntry = nullptr;
-size_t g_typeEntryCount = 0;
+const TypeRegistryEntry* autowiring::g_pFirstTypeEntry = nullptr;
+size_t autowiring::g_typeEntryCount = 0;
 
 TypeRegistryEntry::TypeRegistryEntry(const std::type_info& ti) :
   pFlink(g_pFirstTypeEntry),

--- a/src/autowiring/TypeRegistry.h
+++ b/src/autowiring/TypeRegistry.h
@@ -6,9 +6,9 @@
 #include MEMORY_HEADER
 
 namespace autowiring {
-  template<typename T>
-  void InjectCurrent(void);
-}
+
+template<typename T>
+void InjectCurrent(void);
 
 struct TypeRegistryEntry:
   public TypeIdentifierBase
@@ -90,4 +90,4 @@ public:
 
 template<class T>
 const TypeRegistryEntryT<T> RegType<T>::r;
-
+}

--- a/src/autowiring/TypeUnifier.h
+++ b/src/autowiring/TypeUnifier.h
@@ -4,6 +4,7 @@
 #include RVALUE_HEADER
 #include TYPE_TRAITS_HEADER
 
+namespace autowiring {
 class TypeUnifier: public CoreObject {};
 
 template<class T>
@@ -40,3 +41,4 @@ template<class T>
 struct SelectTypeUnifier<T, false> {
   typedef TypeUnifierComplex<T> type;
 };
+}

--- a/src/autowiring/atomic_list.cpp
+++ b/src/autowiring/atomic_list.cpp
@@ -3,8 +3,7 @@
 #include "atomic_list.h"
 #include <mutex>
 
-using autowiring::callable_base;
-using autowiring::atomic_list;
+using namespace autowiring;
 
 atomic_list::~atomic_list(void) {
   callable_base* next;

--- a/src/autowiring/auto_arg.cpp
+++ b/src/autowiring/auto_arg.cpp
@@ -3,6 +3,8 @@
 #include "auto_arg.h"
 #include "CoreContext.h"
 
+using namespace autowiring;
+
 CoreContext& auto_arg<CoreContext&>::arg(AutoPacket&) {
   return *CoreContext::CurrentContext();
 }

--- a/src/autowiring/auto_arg.h
+++ b/src/autowiring/auto_arg.h
@@ -3,8 +3,11 @@
 #include "auto_id.h"
 
 class AutoPacket;
-template <class T> class auto_in;
 class CoreContext;
+
+namespace autowiring {
+
+template <class T> class auto_in;
 
 /*
  The auto_arg<T> classes are used to generate of auto_in and auto_out types
@@ -456,3 +459,5 @@ template<class T>
 struct arg_is_out {
   static const bool value = auto_arg<T>::is_output;
 };
+
+}

--- a/src/autowiring/auto_id.cpp
+++ b/src/autowiring/auto_id.cpp
@@ -17,7 +17,7 @@ const auto_id_block auto_id_t<void>::s_block{
   nullptr
 };
 
-int CreateIndex(void) {
+int autowiring::CreateIndex(void) {
   return s_index++;
 }
 

--- a/src/autowiring/auto_id.cpp
+++ b/src/autowiring/auto_id.cpp
@@ -2,29 +2,31 @@
 #include "stdafx.h"
 #include "auto_id.h"
 
+using namespace autowiring;
+
 // Index that will be given to the next auto_id instance.  Zero is reserved.
 static int s_index = 1;
 
-const autowiring::auto_id_block auto_id_t<void>::s_block{
+const auto_id_block auto_id_t<void>::s_block{
   0,
   &typeid(void),
-  &typeid(autowiring::s<void>),
+  &typeid(s<void>),
   0,
   0,
   nullptr,
   nullptr
 };
 
-int autowiring::CreateIndex(void) {
+int CreateIndex(void) {
   return s_index++;
 }
 
-std::shared_ptr<CoreObject> autowiring::auto_id_block::NullToObj(const std::shared_ptr<void>&)
+std::shared_ptr<CoreObject> auto_id_block::NullToObj(const std::shared_ptr<void>&)
 {
   return nullptr;
 }
 
-std::shared_ptr<void> autowiring::auto_id_block::NullFromObj(const std::shared_ptr<CoreObject>&)
+std::shared_ptr<void> auto_id_block::NullFromObj(const std::shared_ptr<CoreObject>&)
 {
   return nullptr;
 }

--- a/src/autowiring/auto_in.h
+++ b/src/autowiring/auto_in.h
@@ -6,6 +6,8 @@
 
 class AutoPacket;
 
+namespace autowiring {
+
 template<class T>
 class auto_arg;
 
@@ -69,3 +71,5 @@ template<class T>
 class auto_arg<auto_in<T>> :
   public auto_arg<T>
 {};
+
+}

--- a/src/autowiring/auto_out.h
+++ b/src/autowiring/auto_out.h
@@ -6,6 +6,8 @@
 
 class AutoPacket;
 
+namespace autowiring {
+
 template<class T>
 class auto_arg;
 
@@ -90,7 +92,7 @@ public:
       m_decoration = t;
     }
   };
-  
+
 private:
   std::shared_ptr<auto_out_impl> m_auto_out_impl;
 
@@ -136,3 +138,5 @@ public:
     // Do nothing -- auto_out does its own deferred decoration.
   }
 };
+
+}

--- a/src/autowiring/auto_prev.h
+++ b/src/autowiring/auto_prev.h
@@ -2,6 +2,8 @@
 #pragma once
 #include "auto_arg.h"
 
+namespace autowiring {
+
 template<class T>
 class auto_arg;
 
@@ -26,7 +28,7 @@ public:
   const T& operator*(void) const {
     return *value;
   }
-  
+
   const T* operator->(void) const {
     return value;
   }
@@ -56,3 +58,5 @@ public:
     return retVal;
   }
 };
+
+}

--- a/src/autowiring/auto_tuple.h
+++ b/src/autowiring/auto_tuple.h
@@ -30,7 +30,7 @@ namespace autowiring {
     static const bool value = false;
     static const size_t index = 0;
   };
-  
+
   template<typename T, typename Arg, typename... Args>
   struct find<T, Arg, Args...> {
     // Holds true if T is found, false otherwise

--- a/src/autowiring/autowiring_error.cpp
+++ b/src/autowiring/autowiring_error.cpp
@@ -4,6 +4,8 @@
 #include "demangle.h"
 #include <sstream>
 
+using namespace autowiring;
+
 autowiring_error::autowiring_error(const std::string& what):
   m_what(what)
 {}

--- a/src/autowiring/config_descriptor.cpp
+++ b/src/autowiring/config_descriptor.cpp
@@ -2,14 +2,16 @@
 #include "stdafx.h"
 #include "config_descriptor.h"
 
-autowiring::config_descriptor::t_mpType autowiring::config_descriptor::MakeFields(const std::initializer_list<config_field>& fields) {
+using namespace autowiring;
+
+config_descriptor::t_mpType autowiring::config_descriptor::MakeFields(const std::initializer_list<config_field>& fields) {
   t_mpType retVal;
-  for (const autowiring::config_field & field : fields)
+  for (const config_field & field : fields)
     retVal[field.name] = field;
   return retVal;
 }
 
-const autowiring::config_field& autowiring::config_descriptor::get(size_t offset) const {
+const config_field& config_descriptor::get(size_t offset) const {
   for (const auto& entry : fields)
     if (entry.second.offset == offset)
       return entry.second;

--- a/src/autowiring/deref_error.h
+++ b/src/autowiring/deref_error.h
@@ -3,13 +3,13 @@
 #include "autowiring_error.h"
 #include <typeinfo>
 
-template<class T>
-class AutowirableSlot;
-
 template<typename T>
 class AutowiredFast;
 
 namespace autowiring {
+  template<class T>
+  class AutowirableSlot;
+
   std::string GenerateExceptionTextAWF(const std::type_info& ti);
   std::string GenerateExceptionTextAW(const std::type_info& ti);
 

--- a/src/autowiring/has_autofilter.h
+++ b/src/autowiring/has_autofilter.h
@@ -4,6 +4,10 @@
 #include "Deferred.h"
 #include "is_any.h"
 
+class AutoPacket;
+
+namespace autowiring {
+
 //=======================================
 // Test whether return type is meaningful
 //=======================================
@@ -88,8 +92,6 @@ struct has_unambiguous_autofilter
       >::value;
 };
 
-class AutoPacket;
-
 // Inheriting from this class ensures the existence of a valid AutoFilter method.
 // This is used to distinguish between a no AutoFilter methods
 // and multiple AutoFilter definitions.
@@ -117,3 +119,5 @@ struct has_autofilter {
     "Cannot define more than one AutoFilter method and all AutoFilter methods must be public and all AutoFilter reference-output arguments must be completely defined"
   );
 };
+
+}

--- a/src/autowiring/has_autoinit.h
+++ b/src/autowiring/has_autoinit.h
@@ -2,6 +2,8 @@
 #pragma once
 #include "Decompose.h"
 
+namespace autowiring {
+
 template<class T>
 struct has_valid_autoinit {
   template<class Fn, Fn>
@@ -43,3 +45,4 @@ static void CallAutoInit(T& obj, std::true_type) {
 template<class T>
 static void CallAutoInit(T&, std::false_type) {}
 
+}

--- a/src/autowiring/has_static_new.h
+++ b/src/autowiring/has_static_new.h
@@ -4,38 +4,40 @@
 #include RVALUE_HEADER
 
 namespace autowiring {
-  /// <summary>
-  /// Utility helper structure for types which have a factory New routine
-  /// </summary>
-  /// <remarks>
-  /// A factory New routine is malformed when the return type is not implicitly castable to type T
-  /// </remarks>
-  template<class T, class Selector, class... Args>
-  struct has_well_formed_static_new {
-    static const bool value = std::is_convertible<
-      decltype(
-        T::New(
-          std::declval<Args>()...
-        )
-      ),
-      T*
-    >::value;
-  };
 
-  template<class T, class... Args>
-  struct has_well_formed_static_new<T, std::false_type, Args...> {
-    static const bool value = false;
-  };
+/// <summary>
+/// Utility helper structure for types which have a factory New routine
+/// </summary>
+/// <remarks>
+/// A factory New routine is malformed when the return type is not implicitly castable to type T
+/// </remarks>
+template<class T, class Selector, class... Args>
+struct has_well_formed_static_new {
+  static const bool value = std::is_convertible<
+    decltype(
+      T::New(
+        std::declval<Args>()...
+      )
+    ),
+    T*
+  >::value;
+};
 
-  template<typename T, typename... Args>
-  struct has_static_new
-  {
-    template<class U>
-    static std::true_type select(decltype(U::New(std::forward<Args>(*(typename std::remove_reference<Args>::type*)nullptr)...))*);
+template<class T, class... Args>
+struct has_well_formed_static_new<T, std::false_type, Args...> {
+  static const bool value = false;
+};
 
-    template<class U>
-    static std::false_type select(...);
+template<typename T, typename... Args>
+struct has_static_new
+{
+  template<class U>
+  static std::true_type select(decltype(U::New(std::forward<Args>(*(typename std::remove_reference<Args>::type*)nullptr)...))*);
 
-    static const bool value = has_well_formed_static_new<T, decltype(select<T>(nullptr)), Args...>::value;
-  };
+  template<class U>
+  static std::false_type select(...);
+
+  static const bool value = has_well_formed_static_new<T, decltype(select<T>(nullptr)), Args...>::value;
+};
+
 }

--- a/src/autowiring/has_validate.h
+++ b/src/autowiring/has_validate.h
@@ -1,6 +1,8 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 
+namespace autowiring {
+
 /// <summary>
 /// Detects whether the specified type T has a static method with the name Validate
 /// </summary>
@@ -27,6 +29,8 @@ struct CallValidate {
 template<class T, class Validator>
 struct CallValidate<T, Validator, true> {
   static bool Call(const T& obj) {
-    return Validator::Validate(obj); 
+    return Validator::Validate(obj);
   }
 };
+
+}

--- a/src/autowiring/hash_tuple.h
+++ b/src/autowiring/hash_tuple.h
@@ -7,18 +7,18 @@ namespace std
 {
   template<typename... Types>
   struct hash<std::tuple<Types...>> {
-    
+
     template<typename T, typename... Ts>
     static uint64_t hash_combine(const T& head, const Ts&... tail) {
       // Get hash for head and tail
       uint64_t head_hash = std::hash<T>()(head);
       uint64_t tail_hash = hash_combine(tail...);
-      
+
       // Add a pinch of salt and stir
       static const uint64_t salt = 0x278dde6e5fd29e00;
       return head_hash ^ (salt + (tail_hash << 6) + (tail_hash >> 2));
     }
-    
+
     // base case to hash std::tuple<>
     static uint64_t hash_combine(void) {
       return 0;

--- a/src/autowiring/index_tuple.h
+++ b/src/autowiring/index_tuple.h
@@ -1,6 +1,8 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 
+namespace autowiring {
+
 /// <summary>
 /// Utility type which enables the composition of a sequence [0, sizeof...(Ts))
 /// </summary>
@@ -22,3 +24,5 @@ static_assert(
   >::value,
   "Index tuple base case was not correctly specialized"
 );
+
+}

--- a/src/autowiring/is_any.h
+++ b/src/autowiring/is_any.h
@@ -3,6 +3,8 @@
 #include "C++11/cpp11.h"
 #include TYPE_TRAITS_HEADER
 
+namespace autowiring {
+
 /// <summary>
 /// Check if any T is true
 /// </summary>
@@ -53,3 +55,5 @@ struct is_any_repeated<T, U, Us...>:
     is_any_repeated<U, Us...>::value
   >
 {};
+
+}

--- a/src/autowiring/is_shared_ptr.h
+++ b/src/autowiring/is_shared_ptr.h
@@ -1,6 +1,8 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 
+namespace autowiring {
+
 template<class T>
 struct is_shared_ptr:
   public std::false_type
@@ -22,3 +24,5 @@ struct is_shared_ptr<std::shared_ptr<T>> :
 {
   typedef T type;
 };
+
+}

--- a/src/autowiring/optional.h
+++ b/src/autowiring/optional.h
@@ -3,13 +3,14 @@
 #include <memory>
 #include <stdexcept>
 
+namespace autowiring {
+
 /// <summary>
 /// Implements the "optional" concept
 /// </summary>
 /// <remarks>
 /// TODO:  Replace this with a typedef to std::optional once the STL provides it
 /// </remarks>
-namespace autowiring {
 template<typename T>
 struct optional {
 public:

--- a/src/autowiring/test/TestFixtures/SimpleObject.hpp
+++ b/src/autowiring/test/TestFixtures/SimpleObject.hpp
@@ -24,7 +24,7 @@ public:
 static_assert(
   std::is_same<
     SimpleObject,
-    typename SelectTypeUnifier<SimpleObject>::type
+    typename autowiring::SelectTypeUnifier<SimpleObject>::type
   >::value,
   "The SimpleObject was incorrectly identified as needing a type unifier"
 );

--- a/src/autowiring/test/UuidTest.cpp
+++ b/src/autowiring/test/UuidTest.cpp
@@ -10,14 +10,14 @@ DECLARE_UUID(MyX, "01234567-89AB-CDEF-FEDC-BA9876543210"){};
 
 TEST_F(UuidTest, VerifySimpleUuid) {
   // Verify table properties:
-  ASSERT_EQ(0xE, UUID_MAPPING_TABLE['e' - '0']) << "Hex character 'e' in the mapping table was not correctly mapped"; 
+  ASSERT_EQ(0xE, UUID_MAPPING_TABLE['e' - '0']) << "Hex character 'e' in the mapping table was not correctly mapped";
   ASSERT_EQ(0xA, UUID_MAPPING_TABLE['A' - '0']) << "Hex character 'A' in the mapping table was not correctly mapped";
-  
+
   // Verify the queried UUID:
   uuid test_uuid = uuid_of<MyX>::Uuid();
 
   ASSERT_EQ(0x1234567UL, test_uuid.Data1) << "Data1 was not defined properly";
-  
+
   ASSERT_EQ(0x89ABUL, test_uuid.Data2) << "Data2 was not defined properly";
   ASSERT_EQ(0xCDEFUL, test_uuid.Data3) << "Data3 was not defined properly";
   ASSERT_EQ(0x1032547698badcfe, (long long&) test_uuid.Data4) << "Data4 was not defined properly";

--- a/src/autowiring/test/stdafx.h
+++ b/src/autowiring/test/stdafx.h
@@ -13,6 +13,9 @@
   #include <mutex>
 #endif
 
+// ALL tests use the autowiring namespace
+using namespace autowiring;
+
 // Very unusual syntax -- function taking an array of fixed size, and returning
 // a character array of that same size
 template<class T, int n>

--- a/src/autowiring/thread_specific_ptr.h
+++ b/src/autowiring/thread_specific_ptr.h
@@ -23,42 +23,42 @@ template<typename T>
 class thread_specific_ptr {
 public:
   typedef void (*t_cleanupFunction)(T *);
-  
+
   thread_specific_ptr(void)
   {
     init();
   }
-  
+
   thread_specific_ptr(t_cleanupFunction cleanup):
     m_cleanupFunction(cleanup)
   {
     init();
   }
-  
+
   virtual ~thread_specific_ptr(){
     reset();
     freeTLS();
   }
-  
+
   T* get() const;
-  
+
   T* operator->() const {
     return get();
   }
-  
+
   T& operator*() const {
     return *get();
   }
-  
+
   T* release() {
     T* const temp = get();
     set(nullptr);
     return temp;
   }
-  
+
   void reset(T* new_value=nullptr) {
     T* const current_value = get();
-    
+
     if (current_value == new_value)
       return;
 
@@ -66,24 +66,24 @@ public:
     if (current_value && m_cleanupFunction)
       m_cleanupFunction(current_value);
   }
-  
+
 private:
   // Set thread specific value. Used by public facing "release" and "reset"
   void set(T* value);
-  
+
   // Initialize thread specific storage
   void init();
-  
+
   // Cleanup thread specific ptr when destoyed
   void freeTLS();
-  
+
   // Functions called the cleanup old value
   t_cleanupFunction m_cleanupFunction = [](T* p) { delete p; };
-  
+
   // Key to thread local storage
   TLS_KEY_TYPE m_key;
 };
-  
+
 } //namespace autowiring
 
 // Platform specifc functions

--- a/src/autowiring/uuid.h
+++ b/src/autowiring/uuid.h
@@ -136,13 +136,15 @@ struct uuid
 /// </summary>
 #define DECLARE_UUID(clazz, id) \
   class clazz; \
-  template<> \
-  struct uuid_of<clazz> \
-  { \
-    static const bool value = true; \
-    static const char* UuidStr(void) {return id;} \
-    static const uuid Uuid(void) { return uuid(id); }; \
-  }; \
+  namespace autowiring { \
+    template<> \
+    struct uuid_of<clazz> \
+    { \
+      static const bool value = true; \
+      static const char* UuidStr(void) {return id;} \
+      static const uuid Uuid(void) { return uuid(id); }; \
+    }; \
+  } \
   class DECL_UUID(id) clazz
 
 /// <summary>

--- a/src/autowiring/uuid.h
+++ b/src/autowiring/uuid.h
@@ -59,6 +59,8 @@
 /// </summary>
 #define UUID_KNOWN(clazz) uuid_of<clazz>::value
 
+namespace autowiring {
+
 #ifndef _MSC_VER
 struct UUID {
   unsigned long  Data1;
@@ -73,10 +75,10 @@ struct UUID {
 // of this name, as not all consumers of this header will be including Windows.h
 struct uuid
 {
-    unsigned long Data1;
-    unsigned short Data2;
-    unsigned short Data3;
-    unsigned long long Data4;
+  unsigned long Data1;
+  unsigned short Data2;
+  unsigned short Data3;
+  unsigned long long Data4;
   /// <summary>
   /// Trivial constructor
   /// </summary>
@@ -86,18 +88,18 @@ struct uuid
   /// Equality Operators [stubbed for unit-testing, need better implementations]
   /// </summary>
 
-  bool friend operator== (const uuid& lhs, const uuid& rhs){
-    return  (lhs.Data1 == rhs.Data1) && 
-            (lhs.Data2 == rhs.Data2) &&
-            (lhs.Data3 == rhs.Data3) && 
-            (lhs.Data4 == rhs.Data4);
+  bool friend operator== (const uuid& lhs, const uuid& rhs) {
+    return  (lhs.Data1 == rhs.Data1) &&
+      (lhs.Data2 == rhs.Data2) &&
+      (lhs.Data3 == rhs.Data3) &&
+      (lhs.Data4 == rhs.Data4);
   }
-  bool friend operator!= (const uuid& lhs, const uuid& rhs){return !(lhs == rhs);}
+  bool friend operator!= (const uuid& lhs, const uuid& rhs) { return !(lhs == rhs); }
 
   /// <summary>
   /// Convenience constructor:
   /// </summary>
-  uuid(unsigned long Data1,unsigned short Data2,unsigned short Data3, unsigned long long Data4)
+  uuid(unsigned long Data1, unsigned short Data2, unsigned short Data3, unsigned long long Data4)
   {
     this->Data1 = Data1;
     this->Data2 = Data2;
@@ -112,7 +114,7 @@ struct uuid
   /// Initializes UUIDs of the form:
   ///  58910B93-C20B-42C2-AD8E-B80587D89D87
   ///</remarks>
-  uuid(const char (&val)[37]) {
+  uuid(const char(&val)[37]) {
     *this = uuid(COMPOSE_UUID(val, 0));
   }
 
@@ -123,7 +125,7 @@ struct uuid
   /// Initializes UUIDs of the form:
   ///  {58910B93-C20B-42C2-AD8E-B80587D89D87}
   ///</remarks>
-  uuid(const char (&val)[39]) {
+  uuid(const char(&val)[39]) {
     *this = uuid(COMPOSE_UUID(val, 1));
   }
 };
@@ -152,7 +154,7 @@ template<class T>
 struct uuid_of
 {
   static const bool value = false;
-  static const char* UuidStr(void) {return nullptr;}
+  static const char* UuidStr(void) { return nullptr; }
 
   static uuid Uuid(void) {
     return uuid(0, 0, 0, 0);
@@ -173,3 +175,4 @@ struct uuid_hash {
     return (long long&)val.Data4;
   }
 };
+}

--- a/src/autowiring/var_logic.h
+++ b/src/autowiring/var_logic.h
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 
+namespace autowiring {
 /*
  Variadic generalizations of boolean operations.
  Single argument cases are equal to the argument.
@@ -28,3 +29,5 @@ template<bool Head, bool... Tail>
 struct var_and<Head, Tail...> {
   static const bool value = Head && var_and<Tail...>::value;
 };
+
+}


### PR DESCRIPTION
There are a lot of global names polluting the global namespace.  Move these to the autowiring namespace wherever appropriate.