### PR TITLE
Add support for void AnySharedPointer

### DIFF
--- a/src/autowiring/AnySharedPointer.h
+++ b/src/autowiring/AnySharedPointer.h
@@ -68,6 +68,8 @@ public:
     return obj && try_assign(obj);
   }
 
+  const std::shared_ptr<void>& as_void(void) const { return m_ptr; }
+
   template<class T>
   const std::shared_ptr<T>& as(void) const {
     // The safety of this routine is verified by the AnySharedPointer unit tests

--- a/src/autowiring/test/AnySharedPointerTest.cpp
+++ b/src/autowiring/test/AnySharedPointerTest.cpp
@@ -267,3 +267,9 @@ TEST_F(AnySharedPointerTest, NullPtrConstruction) {
   ASSERT_EQ(auto_id_t<void>{}, y.type());
   ASSERT_EQ(auto_id_t<void>{}, z.type());
 }
+
+TEST_F(AnySharedPointerTest, VoidSharedPointer) {
+  auto p = std::make_shared<int>(101);
+  AnySharedPointer x = p;
+  ASSERT_EQ(std::static_pointer_cast<void>(p), x.as_void()) << "Void cast of shared pointer did not hold the expected value";
+}


### PR DESCRIPTION
Allow users to retrieve `std::shared_ptr<void>` directly from an `AnySharedPointer`.