### PR TITLE
Add copy constructor to optional

### DIFF
--- a/src/autowiring/optional.h
+++ b/src/autowiring/optional.h
@@ -30,6 +30,11 @@ public:
   {
     new(val) T{ std::move(value) };
   }
+  optional(const T& value) :
+    m_valid(true)
+  {
+    new(val) T{ value };
+  }
 
   ~optional(void) {
     if (m_valid)

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -53,6 +53,7 @@ set(AutowiringTest_SRCS
   ObjectPoolTest.cpp
   ObservableTest.cpp
   OnceTest.cpp
+  OptionalTest.cpp
   ParallelTest.cpp
   PostConstructTest.cpp
   SelfSelectingFixtureTest.cpp

--- a/src/autowiring/test/OptionalTest.cpp
+++ b/src/autowiring/test/OptionalTest.cpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include <autowiring/optional.h>
+
+class OptionalTest :
+  public testing::Test
+{};
+
+TEST_F(OptionalTest, PrimitiveCheck) {
+  optional<int> x;
+  ASSERT_FALSE(x);
+  x = 10;
+  ASSERT_TRUE(x);
+  x = 0;
+  ASSERT_TRUE(x);
+  x = {};
+  ASSERT_FALSE(x);
+}
+
+TEST_F(OptionalTest, DestructionCheck) {
+  auto x = std::make_shared<int>(100);
+  {
+    optional<std::shared_ptr<int>> y = x;
+    ASSERT_EQ(2L, x.use_count());
+    y = {};
+    ASSERT_TRUE(x.unique());
+  }
+  ASSERT_TRUE(x.unique());
+}
+
+TEST_F(OptionalTest, MoveCheck) {
+  std::unique_ptr<int> u{ new int{55} };
+
+  optional<std::unique_ptr<int>> v = std::move(u);
+  ASSERT_EQ(nullptr, u);
+  ASSERT_EQ(55, **v);
+}


### PR DESCRIPTION
We support move construction, might as well support copy construction as well.