### PR TITLE
Move post-construction after everything

### DIFF
--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -798,6 +798,7 @@ void CoreContext::UpdateDeferredElements(std::unique_lock<std::mutex>&& lk, cons
     }
     lk.unlock();
 
+    // Fire off notifications that satisfaction has taken place
     for (auto e: entries)
       e->onSatisfied();
   }

--- a/src/autowiring/test/PostConstructTest.cpp
+++ b/src/autowiring/test/PostConstructTest.cpp
@@ -427,3 +427,19 @@ TEST_F(PostConstructTest, CorrectContextAssignment) {
 
   ASSERT_EQ(child, currentCtxt) << "Current context was not correctly assigned in a post-satisfied NotifyWhenAutowired handler";
 }
+
+namespace {
+  class ThrowsInAutoInit {
+  public:
+    void AutoInit(void) {
+      throw std::runtime_error("Failure!");
+    }
+  };
+}
+
+TEST_F(PostConstructTest, ThrowingAutoInit) {
+  AutoCurrentContext ctxt;
+  ASSERT_FALSE(ctxt->IsShutdown());
+  ASSERT_THROW(AutoRequired<ThrowsInAutoInit>{}, std::runtime_error);
+  ASSERT_TRUE(ctxt->IsShutdown());
+}

--- a/src/autowiring/test/PostConstructTest.cpp
+++ b/src/autowiring/test/PostConstructTest.cpp
@@ -348,19 +348,6 @@ TEST_F(PostConstructTest, PostConstructGetsCalled) {
   ASSERT_TRUE(cwai->m_postConstructed) << "Auto-initialization routine was not called on an initializable type";
 }
 
-struct PostConstructThrowsException {
-  void AutoInit(void) const {
-    throw std::runtime_error("Autoinit crashing for no reason");
-  }
-};
-
-TEST_F(PostConstructTest, PostConstructCanSafelyThrow) {
-  ASSERT_ANY_THROW(AutoRequired<PostConstructThrowsException>()) << "AutoInit call threw an exception, but it was incorrectly eaten by Autowiring";
-
-  Autowired<PostConstructThrowsException> pcte;
-  ASSERT_FALSE(pcte.IsAutowired()) << "A context member which threw an exception post-construction was incorrectly introduced into a context";
-}
-
 namespace {
   class EmptyType : public CoreObject {};
 }


### PR DESCRIPTION
`AutoInit` post-construction should occur after injection is guaranteed, so that for a particular context and type, `AutoInit` is called exactly once.  If this invocation of `AutoInit` throws an exception, the context should be shut down.