### PR TITLE
Correct invalid deferred destruction

### DIFF
--- a/src/autowiring/CoreContext.h
+++ b/src/autowiring/CoreContext.h
@@ -590,6 +590,10 @@ public:
         return memo.m_value.template as<T>();
     }
 
+    // Need the memo for the actual type at this point, if we don't hold this down then this
+    // entry might not get constructed.
+    auto& memo = FindByType(auto_id_t<typename CreationRules::TActual>{}, true);
+
     // We must make ourselves current for the remainder of this call:
     CurrentContextPusher pshr(shared_from_this());
     std::shared_ptr<typename CreationRules::TActual> retVal(
@@ -613,7 +617,6 @@ public:
       // we will simply eat this exception, and handle it silently by returning the type that
       // someone else has already attempted to construct, as per the documented behavior of
       // Construct.
-      auto& memo = FindByType(auto_id_t<typename CreationRules::TActual>{}, true);
       retVal = memo.m_value.template as<typename CreationRules::TActual>();
     }
 

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -636,3 +636,47 @@ TEST_F(CoreContextTest, AwaitTimed) {
 
   injector.join();
 }
+
+namespace {
+  class HoldsMutexAndCount {
+  public:
+    int initCount = 0;
+    int instanceCount = 0;
+    std::mutex lk;
+  };
+
+  class DelaysWithNwa {
+  public:
+    DelaysWithNwa(void) {
+      std::lock_guard<std::mutex>{ hmac->lk };
+
+      hmac->initCount++;
+      hmac->instanceCount++;
+    }
+
+    virtual ~DelaysWithNwa(void) {
+      hmac->instanceCount--;
+    }
+
+    AutoRequired<HoldsMutexAndCount> hmac;
+  };
+}
+
+TEST_F(CoreContextTest, SimultaneousMultiInject) {
+  AutoCreateContext ctxt;
+  AutoRequired<HoldsMutexAndCount> hmac{ ctxt };
+
+  std::unique_lock<std::mutex> lk{ hmac->lk };
+  std::thread a([ctxt] { ctxt->Inject<DelaysWithNwa>(); });
+  std::thread b([ctxt] { ctxt->Inject<DelaysWithNwa>(); });
+  lk.unlock();
+
+  a.join();
+  b.join();
+
+  // Two initializations should have taken place due to the barrier
+  ASSERT_EQ(2, hmac->initCount);
+
+  // Only one of those two instances should still be around
+  ASSERT_EQ(1, hmac->instanceCount);
+}


### PR DESCRIPTION
In the case of an injection race, the thread that loses the race must immediately tear down the object which was not successfully injected.  Fix this bug and guard with a new test.