### PR TITLE
Correct exception safety in ConfigRegistry

### DIFF
--- a/src/autowiring/ConfigRegistry.cpp
+++ b/src/autowiring/ConfigRegistry.cpp
@@ -5,6 +5,7 @@
 using namespace autowiring;
 
 std::atomic<config_registry_entry_base*> autowiring::g_pFirstEntry;
+const config_descriptor config_registry_entry_default::desc = {};
 
 config_registry_entry_base::config_registry_entry_base(void) {
   while (!g_pFirstEntry.compare_exchange_weak(pFlink, this));

--- a/src/autowiring/CoreObjectDescriptor.h
+++ b/src/autowiring/CoreObjectDescriptor.h
@@ -52,7 +52,7 @@ struct CoreObjectDescriptor {
     pBasicThread(autowiring::fast_pointer_cast<::BasicThread>(value)),
     pFilter(autowiring::fast_pointer_cast<::ExceptionFilter>(value)),
     pBoltBase(autowiring::fast_pointer_cast<::BoltBase>(value)),
-    pConfigDesc(config_registry_entry<T>::desc()),
+    pConfigDesc(&config_registry_entry<T>::desc),
     primitiveOffset(
       reinterpret_cast<size_t>(
         static_cast<T*>(

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -673,6 +673,8 @@ namespace {
 
 TEST_F(CoreContextTest, SimultaneousMultiInject) {
   AutoCreateContext ctxt;
+  ctxt->Config.Set("c", "10");
+
   AutoRequired<HoldsMutexAndCount> hmac{ ctxt };
 
   std::unique_lock<std::mutex> lk{ hmac->lk };

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -661,6 +661,13 @@ namespace {
     }
 
     AutoRequired<HoldsMutexAndCount> hmac;
+    int c = 100;
+
+    static autowiring::config_descriptor GetConfigDescriptor(void) {
+      return{
+        { "c", &DelaysWithNwa::c }
+      };
+    }
   };
 }
 
@@ -685,4 +692,7 @@ TEST_F(CoreContextTest, SimultaneousMultiInject) {
 
   // Only one of those two instances should still be around
   ASSERT_EQ(1, hmac->instanceCount);
+
+  // Verify that there's no config block still present
+  ASSERT_NO_THROW(ctxt->Config.Get("c"));
 }


### PR DESCRIPTION
During construction race, it is possible that an object is registered with `ConfigRegistry` twice.  When the object losing the race is destroyed, a dangling pointer dereference or a multi-presence exception may be thrown in `ConfigRegistry`.

Fix this problem by implementing proper rollback.