### PR TITLE
Eliminate MSVC warnings in websocketpp

### DIFF
--- a/contrib/websocketpp/websocketpp/frame.hpp
+++ b/contrib/websocketpp/websocketpp/frame.hpp
@@ -250,9 +250,7 @@ struct extended_header {
         int offset = copy_payload(payload_size);
 
         // Copy Masking Key
-        uint32_converter temp32;
-        temp32.i = masking_key;
-        std::copy(temp32.c,temp32.c+4,bytes+offset);
+        *(uint32_t*)bytes[offset] = masking_key;
     }
 
     uint8_t bytes[MAX_EXTENDED_HEADER_LENGTH];

--- a/contrib/websocketpp/websocketpp/processors/hybi00.hpp
+++ b/contrib/websocketpp/websocketpp/processors/hybi00.hpp
@@ -122,7 +122,7 @@ public:
 
         res.append_header(
             "Sec-WebSocket-Key3",
-            md5::md5_hash_string(std::string(key_final.data(),16))
+            md5::md5_hash_string(std::string(key_final.data(),key_final.size()))
         );
 
         res.append_header("Upgrade","WebSocket");


### PR DESCRIPTION
These warnings arose due to the upgrade to the latest websocketpp, fix them.