### PR TITLE
Fix default placement ctor

### DIFF
--- a/src/autowiring/ObjectPool.h
+++ b/src/autowiring/ObjectPool.h
@@ -151,7 +151,11 @@ protected:
   size_t m_outstanding = 0;
 
   // Allocator, placement ctor:
-  std::function<void(T*)> m_placement{ [](T*) {} };
+  std::function<void(T*)> m_placement{
+    [](T* ptr) {
+      new (ptr) T;
+    }
+  };
 
   /// <summary>
   /// Creates a shared pointer to wrap the specified object while it is issued.

--- a/src/autowiring/test/ObjectPoolTest.cpp
+++ b/src/autowiring/test/ObjectPoolTest.cpp
@@ -404,3 +404,16 @@ TEST_F(ObjectPoolTest, PlacementConstructor) {
   auto obj = pool();
   ASSERT_EQ(110, *obj) << "Value was not correctly initialized";
 }
+
+namespace {
+  struct HasNonTrivialCtor {
+    uint64_t value = 0xDEADBEEFBAADF00DULL;
+  };
+}
+
+TEST_F(ObjectPoolTest, DefaultObjectsAreReallyConstructed) {
+  HasNonTrivialCtor sample;
+  ObjectPool<HasNonTrivialCtor> pool;
+  auto pObj = pool.Wait();
+  ASSERT_EQ(sample.value, pObj->value) << "Constructor for object pool member was not correctly invoked";
+}


### PR DESCRIPTION
The current implementation doesn't actually perform placement construction.  Fix this and guard with a test.