### PR TITLE
Add support for VS2015

### DIFF
--- a/src/autowiring/C++11/filesystem.h
+++ b/src/autowiring/C++11/filesystem.h
@@ -15,13 +15,19 @@ namespace awfsnamespace = autoboost::filesystem;
 
 namespace std {
   namespace filesystem {
+#ifdef _MSC_VER
+#if _MSC_VER >= 1900
     using awfsnamespace::path;
-    using awfsnamespace::wpath;
-    using awfsnamespace::basename;
+#else
+    using path = awfsnamespace::wpath;
+#endif
+#else
+    using path = awfsnamespace::wpath;
+#endif
+
     using awfsnamespace::create_directory;
     using awfsnamespace::current_path;
     using awfsnamespace::exists;
-    using awfsnamespace::initial_path;
     using awfsnamespace::is_directory;
     using awfsnamespace::is_empty;
     using awfsnamespace::remove;

--- a/src/autowiring/test/FileSystemHeaderTest.cpp
+++ b/src/autowiring/test/FileSystemHeaderTest.cpp
@@ -14,6 +14,6 @@ class FileSystemHeaderTest:
 
 TEST_F(FileSystemHeaderTest, PathPropertiesTest) {
   std::filesystem::path p = "abc/def.jpg";
-  ASSERT_STREQ(".jpg", p.extension().c_str());
-  ASSERT_STREQ("def.jpg", p.filename().c_str());
+  ASSERT_STREQ(L".jpg", p.extension().c_str());
+  ASSERT_STREQ(L"def.jpg", p.filename().c_str());
 }

--- a/src/autowiring/test/FileSystemHeaderTest.cpp
+++ b/src/autowiring/test/FileSystemHeaderTest.cpp
@@ -14,6 +14,6 @@ class FileSystemHeaderTest:
 
 TEST_F(FileSystemHeaderTest, PathPropertiesTest) {
   std::filesystem::path p = "abc/def.jpg";
-  ASSERT_STREQ(L".jpg", p.extension().c_str());
-  ASSERT_STREQ(L"def.jpg", p.filename().c_str());
+  ASSERT_EQ(std::filesystem::path{ ".jpg" }, p.extension().c_str());
+  ASSERT_EQ(std::filesystem::path{ "def.jpg" }, p.filename().c_str());
 }


### PR DESCRIPTION
The latest standard uses `wchar_t` as the underlying type for `std::filesystem::path`, and deprecates `std::filesystem::wpath`.  Update the shim header to reflect this change.