### PR TITLE
Fix Await overload return type.

### DIFF
--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -640,7 +640,7 @@ void CoreContext::AddBolt(const std::shared_ptr<BoltBase>& pBase) {
   }
 }
 
-AnySharedPointer CoreContext::Await(auto_id id) {
+const AnySharedPointer& CoreContext::Await(auto_id id) {
   std::unique_lock<std::mutex> lk(m_stateBlock->m_lock);
   MemoEntry& memo = FindByTypeUnsafe(id);
   if (!memo.m_value)

--- a/src/autowiring/CoreContext.h
+++ b/src/autowiring/CoreContext.h
@@ -659,7 +659,7 @@ public:
   /// <summary>
   /// Runtime Await variant
   /// </summary>
-  AnySharedPointer Await(auto_id id);
+  const AnySharedPointer& Await(auto_id id);
 
   /// <summary>
   /// Runtime Await variant


### PR DESCRIPTION
The return type for Await, here, is supposed to be a reference, because it's used in a byref sense by the caller.