### PR TITLE
Eliminate invalid throw from destructor

### DIFF
--- a/src/autowiring/test/ObjectPoolTest.cpp
+++ b/src/autowiring/test/ObjectPoolTest.cpp
@@ -45,8 +45,6 @@ public:
 
   ~LifeCycle() {
     ++destructNum;
-    if (stage != pooled)
-      throw std::runtime_error("Destructor called before Finalize");
   }
 
   static ObjectPool<LifeCycle>* NewObjectPool(size_t limit = ~0, size_t maxPooled = ~0) {


### PR DESCRIPTION
This has been here for a long time, but is actually incorrect behavior, and a throw here would result in an invocation of `std::terminate`.