### PR TITLE
Add explicit operator bool overload

### DIFF
--- a/contrib/gtest-1.7.0/fused-src/gtest/gtest.h
+++ b/contrib/gtest-1.7.0/fused-src/gtest/gtest.h
@@ -19325,13 +19325,13 @@ class TestWithParam : public Test, public WithParamInterface<T> {
 // AssertionResult. For more information on how to use AssertionResult with
 // these macros see comments on that class.
 #define EXPECT_TRUE(condition) \
-  GTEST_TEST_BOOLEAN_(condition, #condition, false, true, \
+  GTEST_TEST_BOOLEAN_((bool)(condition), #condition, false, true, \
                       GTEST_NONFATAL_FAILURE_)
 #define EXPECT_FALSE(condition) \
   GTEST_TEST_BOOLEAN_(!(condition), #condition, true, false, \
                       GTEST_NONFATAL_FAILURE_)
 #define ASSERT_TRUE(condition) \
-  GTEST_TEST_BOOLEAN_(condition, #condition, false, true, \
+  GTEST_TEST_BOOLEAN_(((bool)(condition)), #condition, false, true, \
                       GTEST_FATAL_FAILURE_)
 #define ASSERT_FALSE(condition) \
   GTEST_TEST_BOOLEAN_(!(condition), #condition, true, false, \

--- a/src/autowiring/Autowired.h
+++ b/src/autowiring/Autowired.h
@@ -130,6 +130,10 @@ public:
   template<typename U>
   bool operator!=(const std::shared_ptr<U>& rhs) const { return this->m_ptr != rhs; }
 
+  explicit operator bool(void) const {
+    return this->operator const std::shared_ptr<T>&().get() != nullptr;
+  }
+
   operator T*(void) const {
     return this->operator const std::shared_ptr<T>&().get();
   }

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -396,8 +396,8 @@ TEST_F(AutoFilterTest, SingleImmediate) {
     Decoration<pattern> dec;
     packet->DecorateImmediate(dec);
 
-    ASSERT_TRUE(fgp->m_called == 1) << "Filter should called " << fgp->m_called << " times, expected 1";
-    ASSERT_TRUE(autowiring::get<0>(fgp->m_args).i == pattern) << "Filter argument yielded " << autowiring::get<0>(fgp->m_args).i << "expected " << pattern;
+    ASSERT_EQ(1, fgp->m_called) << "Filter should called " << fgp->m_called << " times, expected 1";
+    ASSERT_EQ(pattern, autowiring::get<0>(fgp->m_args).i) << "Filter argument yielded " << autowiring::get<0>(fgp->m_args).i << "expected " << pattern;
   }
   ASSERT_EQ(0, factory->GetOutstandingPacketCount()) << "Destroyed packet remains outstanding";
 


### PR DESCRIPTION
This is intended to silence performance warnings in VS2015.  Also make a change to the `ASSERT_TRUE` and `ASSERT_FALSE` macros in order to eliminate the performance warning.