### PR TITLE
Fix VS2013 compatibility

### DIFF
--- a/src/autowiring/C++11/filesystem.h
+++ b/src/autowiring/C++11/filesystem.h
@@ -19,7 +19,35 @@ namespace std {
 #if _MSC_VER >= 1900
     using awfsnamespace::path;
 #else
-    using path = awfsnamespace::wpath;
+    class path :
+      public awfsnamespace::wpath
+    {
+    public:
+      path(void) = default;
+      path(const string_type& _Str) :
+        awfsnamespace::wpath(_Str)
+      {}
+      path(const path& _Right) :
+        awfsnamespace::wpath(_Right)
+      {}
+      path(const char* _Ptr) :
+        awfsnamespace::wpath(_Ptr, _Ptr + strlen(_Ptr))
+      {}
+      path(const wchar_t* _Ptr) :
+        awfsnamespace::wpath(_Ptr)
+      {}
+
+      basic_path& operator=(basic_path&& _Right) { *(awfsnamespace::wpath*)this = std::move(_Right); }
+      basic_path& operator=(const string_type& _Str) { *(awfsnamespace::wpath*)this = _Str; }
+      basic_path& operator=(const wchar_t* _Ptr) { *(awfsnamespace::wpath*)this = _Ptr; }
+
+      path extension(void) const {
+        return{ awfsnamespace::wpath::extension() };
+      }
+      path filename(void) const {
+        return{ awfsnamespace::wpath::filename() };
+      }
+    };
 #endif
 #else
     using path = awfsnamespace::wpath;

--- a/src/autowiring/test/FileSystemHeaderTest.cpp
+++ b/src/autowiring/test/FileSystemHeaderTest.cpp
@@ -13,7 +13,7 @@ class FileSystemHeaderTest:
 {};
 
 TEST_F(FileSystemHeaderTest, PathPropertiesTest) {
-  std::filesystem::path p = "abc/def.jpg";
-  ASSERT_EQ(std::filesystem::path{ ".jpg" }, p.extension().c_str());
-  ASSERT_EQ(std::filesystem::path{ "def.jpg" }, p.filename().c_str());
+  std::filesystem::path p{ "abc/def.jpg" };
+  ASSERT_EQ(std::filesystem::path{ L".jpg" }, p.extension());
+  ASSERT_EQ(std::filesystem::path{ L"def.jpg" }, p.filename());
 }


### PR DESCRIPTION
Need a full shim for std::filesystem::path for backwards-compatibility.