### PR TITLE
Fix VS2013 filesystem shim header problems

### DIFF
--- a/src/autowiring/C++11/filesystem.h
+++ b/src/autowiring/C++11/filesystem.h
@@ -27,6 +27,9 @@ namespace std {
       path(const string_type& _Str) :
         awfsnamespace::wpath(_Str)
       {}
+      path(const awfsnamespace::wpath& _Right) :
+        awfsnamespace::wpath(_Right)
+      {}
       path(const path& _Right) :
         awfsnamespace::wpath(_Right)
       {}
@@ -38,7 +41,7 @@ namespace std {
       {}
 
       basic_path& operator=(basic_path&& _Right) { *(awfsnamespace::wpath*)this = std::move(_Right); }
-      basic_path& operator=(const string_type& _Str) { *(awfsnamespace::wpath*)this = _Str; }
+      basic_path& operator=(const string_type& _Str) { return *(awfsnamespace::wpath*)this = _Str; }
       basic_path& operator=(const wchar_t* _Ptr) { *(awfsnamespace::wpath*)this = _Ptr; }
 
       path extension(void) const {

--- a/src/autowiring/C++11/filesystem.h
+++ b/src/autowiring/C++11/filesystem.h
@@ -40,9 +40,9 @@ namespace std {
         awfsnamespace::wpath(_Ptr)
       {}
 
-      basic_path& operator=(basic_path&& _Right) { *(awfsnamespace::wpath*)this = std::move(_Right); }
+      basic_path& operator=(basic_path&& _Right) { return *(awfsnamespace::wpath*)this = std::move(_Right); }
       basic_path& operator=(const string_type& _Str) { return *(awfsnamespace::wpath*)this = _Str; }
-      basic_path& operator=(const wchar_t* _Ptr) { *(awfsnamespace::wpath*)this = _Ptr; }
+      basic_path& operator=(const wchar_t* _Ptr) { return *(awfsnamespace::wpath*)this = _Ptr; }
 
       path extension(void) const {
         return{ awfsnamespace::wpath::extension() };


### PR DESCRIPTION
Add a missing overload, fix missing return statement in filesystem shim header for VS2013