### PR TITLE
Fix 32/64 cast warning

### DIFF
--- a/contrib/autoboost/libs/filesystem/unique_path.cpp
+++ b/contrib/autoboost/libs/filesystem/unique_path.cpp
@@ -109,8 +109,7 @@ void system_crypt_random(void* buf, std::size_t len, autoboost::system::error_co
 
   if (!errval)
   {
-    BOOL gen_ok = ::CryptGenRandom(handle, len, static_cast<unsigned char*>(buf));
-    if (!gen_ok)
+    if (!::CryptGenRandom(handle, (DWORD)len, static_cast<unsigned char*>(buf)))
       errval = ::GetLastError();
     ::CryptReleaseContext(handle, 0);
   }

--- a/contrib/autoboost/libs/filesystem/windows_file_codecvt.cpp
+++ b/contrib/autoboost/libs/filesystem/windows_file_codecvt.cpp
@@ -40,7 +40,7 @@
 
     int count;
     if ((count = ::MultiByteToWideChar(codepage, MB_PRECOMPOSED, from,
-      from_end - from, to, to_end - to)) == 0)
+      (int)(from_end - from), to, (int)(to_end - to))) == 0)
     {
       return error;  // conversion failed
     }
@@ -60,7 +60,7 @@
 
     int count;
     if ((count = ::WideCharToMultiByte(codepage, WC_NO_BEST_FIT_CHARS, from,
-      from_end - from, to, to_end - to, 0, 0)) == 0)
+      (int)(from_end - from), to, (int)(to_end - to), 0, 0)) == 0)
     {
       return error;  // conversion failed
     }

--- a/contrib/websocketpp/websocketpp/common/md5.hpp
+++ b/contrib/websocketpp/websocketpp/common/md5.hpp
@@ -364,7 +364,7 @@ void md5_append(md5_state_t *pms, md5_byte_t const * data, size_t nbytes) {
     return;
 
     /* Update the message length. */
-    pms->count[1] += nbytes >> 29;
+    pms->count[1] += static_cast<md5_word_t>(nbytes >> 29);
     pms->count[0] += nbits;
     if (pms->count[0] < nbits)
     pms->count[1]++;

--- a/contrib/websocketpp/websocketpp/frame.hpp
+++ b/contrib/websocketpp/websocketpp/frame.hpp
@@ -826,7 +826,7 @@ inline size_t byte_mask_circ(uint8_t * input, uint8_t * output, size_t length,
     size_t prepared_key)
 {
     uint32_converter key;
-    key.i = prepared_key;
+    key.i = static_cast<uint32_t>(prepared_key);
 
     for (size_t i = 0; i < length; ++i) {
         output[i] = input[i] ^ key.c[i % 4];

--- a/contrib/websocketpp/websocketpp/sha1/sha1.hpp
+++ b/contrib/websocketpp/websocketpp/sha1/sha1.hpp
@@ -173,7 +173,7 @@ inline void calc(void const * src, size_t bytelength, unsigned char * hash) {
         innerHash(result, w);
         clearWBuffert(w);
     }
-    w[15] = bytelength << 3;
+    w[15] = static_cast<unsigned int>(bytelength << 3);
     innerHash(result, w);
 
     // Store hash in result pointer, and make sure we get in in the correct

--- a/src/benchmark/Benchmark.cpp
+++ b/src/benchmark/Benchmark.cpp
@@ -3,7 +3,7 @@
 #include "Benchmark.h"
 #include "PrintableDuration.h"
 
-static const size_t sc_ncbOuterLoop =
+static const int sc_ncbOuterLoop =
 #ifdef _DEBUG
   100;
 #else
@@ -15,7 +15,7 @@ BenchmarkEntry::BenchmarkEntry(const char* name, void(*pfnBM)(Stopwatch&)) :
 {
   // Benchmark the whole function call
   Stopwatch sw;
-  for (size_t i = sc_ncbOuterLoop; i--;)
+  for (int i = sc_ncbOuterLoop; i--;)
     pfnBM(sw);
 
   // Difference over scale


### PR DESCRIPTION
These were revealed recently by trying to build with VS2015, correct by adding casts or changing types as appropriate.