### PR TITLE
Fix double-decoration error

### DIFF
--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -279,9 +279,11 @@ void AutoPacket::UpdateSatisfactionUnsafe(std::unique_lock<std::mutex> lk, const
 
   // Recursively mark unsatisfiable any single-output arguments on these subscribers:
   std::vector<const AutoFilterArgument*> unsatOutputArgs;
-  auto MarkOutputsUnsat = [&unsatOutputArgs] (SatCounter satCounter) {
-    if (!satCounter.Decrement())
+  auto MarkOutputsUnsat = [&unsatOutputArgs] (SatCounter& satCounter) {
+    // make sure each satCounter only gets marked once
+    if (!satCounter.remaining)
       return;
+    satCounter.remaining = 0;
     const auto* args = satCounter.GetAutoFilterArguments();
     for (size_t i = satCounter.GetArity(); i--;) {
       // Only consider output arguments:

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -415,7 +415,10 @@ void AutoPacket::PulseSatisfactionUnsafe(std::unique_lock<std::mutex> lk, Decora
 
           // We only care about sat counters that aren't deferred--skip everyone else
           // Deferred calls will be too late.
-          !satCounter->IsDeferred()
+          !satCounter->IsDeferred() &&
+
+          // And we have something to decrement
+          satCounter->remaining
         )
         {
           if (satCounter->Decrement())

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -279,7 +279,9 @@ void AutoPacket::UpdateSatisfactionUnsafe(std::unique_lock<std::mutex> lk, const
 
   // Recursively mark unsatisfiable any single-output arguments on these subscribers:
   std::vector<const AutoFilterArgument*> unsatOutputArgs;
-  auto MarkOutputsUnsat = [&unsatOutputArgs] (const SatCounter& satCounter) {
+  auto MarkOutputsUnsat = [&unsatOutputArgs] (SatCounter satCounter) {
+    if (!satCounter.Decrement())
+      return;
     const auto* args = satCounter.GetAutoFilterArguments();
     for (size_t i = satCounter.GetArity(); i--;) {
       // Only consider output arguments:

--- a/src/autowiring/SatCounter.h
+++ b/src/autowiring/SatCounter.h
@@ -34,7 +34,7 @@ struct SatCounter:
   /// </summary>
   /// <returns>True if this decrement yielded satisfaction of all arguments</returns>
   bool Decrement(void) {
-    return !--remaining;
+    return remaining && !--remaining;
   }
 
   /// <summary>


### PR DESCRIPTION
The problem is if an auto filter has multiple inputs marked as unsatisfiable, each time it is marked as unsatisfiable, we call `IncProducerCount`, so the auto filter will become complete prematurely.
The fix is to make sure `IncProducerCount` only got called once for each auto filter, only when all its inputs are satisfied or marked as unsatisfiable.

- [x] fixes https://github.com/leapmotion/autowiring/issues/920