### PR TITLE
Fix AutoNet regression

### DIFF
--- a/src/autonet/test/BreakpointTest.cpp
+++ b/src/autonet/test/BreakpointTest.cpp
@@ -45,7 +45,12 @@ class WaitsThenSimulatesResume:
   }
 };
 
+
+struct MySigil {};
+
 TEST_F(BreakpointTest, SimplePauseAndResume) {
+  AutoCreateContextT<MySigil> child;
+
   AutoCurrentContext()->Initiate();
   AutoRequired<ExposedAutoNetServer> autonet;
   AutoRequired<BreakpointThread> thread;

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -677,25 +677,14 @@ AnySharedPointer CoreContext::Await(auto_id id, std::chrono::nanoseconds timeout
   return memo.m_value;
 }
 
-void CoreContext::BuildCurrentState(void) {
-  auto glbl = GlobalCoreContext::Get();
-  if(m_pParent)
-    m_pParent->newContext(this);
+std::vector<const autowiring::CoreObjectDescriptor*> CoreContext::BuildObjectState(void) const {
+  std::vector<const autowiring::CoreObjectDescriptor*> retVal;
+  retVal.reserve(m_concreteTypes.size());
 
-  // Enumerate objects injected into this context
-  for(auto& object : m_concreteTypes)
-    newObject(object);
-
-  // Recurse on all children
   std::lock_guard<std::mutex> lk(m_stateBlock->m_lock);
-  for(const auto& c : m_children) {
-    auto cur = c.lock();
-    if(!cur)
-      continue;
-
-    // Recurse into the child instance:
-    cur->BuildCurrentState();
-  }
+  for(const auto& obj : m_concreteTypes)
+    retVal.push_back(&obj);
+  return retVal;
 }
 
 void CoreContext::Dump(std::ostream& os) const {

--- a/src/autowiring/CoreContext.h
+++ b/src/autowiring/CoreContext.h
@@ -683,11 +683,13 @@ public:
     return reg.m_value != nullptr;
   }
 
-  /// \internal
   /// <summary>
-  /// Sends AutowiringEvents to build current state.
+  /// Gets a snapshot of all of the objects currently in the context
   /// </summary>
-  void BuildCurrentState(void);
+  /// <summary>
+  /// The returned vector will only be valid for as long as this CoreContext is
+  /// </summary>
+  std::vector<const autowiring::CoreObjectDescriptor*> BuildObjectState(void) const;
 
   /// <summary>
   /// A copy of the current list of child CoreRunnables of this context.


### PR DESCRIPTION
This was not caused by the websocketpp update; rather, it was caused when CoreContext made a change to the way context state is constructed when `AutoFired` was deprecated.  Fixing this just involves moving the enumeration responsibility to AutoNet, where it probably belonged all along.

Fixes #922