### PR TITLE
Fix `canonical` declaration

### DIFF
--- a/src/autowiring/C++11/filesystem.h
+++ b/src/autowiring/C++11/filesystem.h
@@ -66,11 +66,15 @@ namespace std {
     using awfsnamespace::rename;
 
 #ifdef _MSC_VER
+#if _MSC_VER >= 1900
+    using std::experimental::filesystem::canonical;
+#else
     template<class _Path>
     _Path canonical(const _Path& _Pval, const _Path& _Pbase = current_path<_Path>())
     {
       return awfsnamespace::complete(_Pval, _Pbase);
     }
+#endif
 #else
     using awfsnamespace::canonical;
 #endif


### PR DESCRIPTION
This name is provided by `std::experimental::canonical` in msvc2015