### PR TITLE
Fix `SetThreadPriority` comment

### DIFF
--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -39,6 +39,10 @@ void BasicThread::DoRun(std::shared_ptr<CoreObject>&& refTracker) {
   if(GetName())
     SetCurrentThreadName();
 
+  // Update the thread priority.  This value may have been assigned before we started.  In that case,
+  // we want to be sure we get the correct value assigned eventually.
+  SetThreadPriority(m_priority);
+
   // Now we wait for the thread to be good to go:
   try {
     Run();

--- a/src/autowiring/BasicThread.h
+++ b/src/autowiring/BasicThread.h
@@ -146,8 +146,7 @@ protected:
   /// Sets the thread priority of this thread
   /// </summary>
   /// <remarks>
-  /// This method must only be called from the running thread's context, and then, only inside
-  /// the ElevatePriority constructor
+  /// This method can only be safely called after the thread is already running.  Calling it before
   /// </remarks>
   void SetThreadPriority(ThreadPriority threadPriority);
 

--- a/src/autowiring/BasicThread.h
+++ b/src/autowiring/BasicThread.h
@@ -146,7 +146,9 @@ protected:
   /// Sets the thread priority of this thread
   /// </summary>
   /// <remarks>
-  /// This method can only be safely called after the thread is already running.  Calling it before
+  /// This method may be called while the thread is running, or before it starts to run.  If it is
+  /// invoked before the thread starts to run, the thread will take on the specified priority when
+  /// it is started.
   /// </remarks>
   void SetThreadPriority(ThreadPriority threadPriority);
 


### PR DESCRIPTION
The constraint described by this comment is no longer valid as of #853, fix it, and also allow users to set the thread priority before the thread is ever initiated.