### PR TITLE
Add overload to ContextEnumerator to allow it to work from a reference

### DIFF
--- a/src/autowiring/ContextEnumerator.cpp
+++ b/src/autowiring/ContextEnumerator.cpp
@@ -9,6 +9,10 @@ ContextEnumerator::ContextEnumerator(void) :
   m_root(CoreContext::CurrentContext())
 {}
 
+ContextEnumerator::ContextEnumerator(CoreContext& root) :
+  m_root(root.shared_from_this())
+{}
+
 ContextEnumerator::ContextEnumerator(const std::shared_ptr<CoreContext>& root) :
   m_root(root)
 {}

--- a/src/autowiring/ContextEnumerator.h
+++ b/src/autowiring/ContextEnumerator.h
@@ -33,6 +33,11 @@ public:
   ContextEnumerator(void);
 
   /// <summary>
+  /// Constructs a context enumerator for the current context
+  /// </summary>
+  ContextEnumerator(CoreContext& root);
+
+  /// <summary>
   /// Constructs an enumerator which may enumerate all of the contexts rooted at the specified root
   /// </summary>
   /// <param name="root">The root context, optionally null, in which case this type is instantiated as an end-iterator</param>


### PR DESCRIPTION
Convenience routine, and it's also slightly more efficient than the other version, which may require a copy.