### PR TITLE
Add ancestor count concept

### DIFF
--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -55,7 +55,8 @@ static thread_specific_ptr<std::shared_ptr<CoreContext>> autoCurrentContext;
 CoreContext::CoreContext(const std::shared_ptr<CoreContext>& pParent, t_childList::iterator backReference, auto_id sigilType) :
   m_pParent(pParent),
   m_backReference(backReference),
-  m_sigilType(sigilType),
+  SigilType(sigilType),
+  AncestorCount(pParent ? pParent->AncestorCount + 1 : 0),
   m_stateBlock(std::make_shared<CoreContextStateBlock>(pParent ? pParent->m_stateBlock : nullptr))
 {}
 

--- a/src/autowiring/CoreContext.h
+++ b/src/autowiring/CoreContext.h
@@ -147,15 +147,18 @@ public:
   /// \sa AutoGlobalContext, GlobalCoreContext
   static std::shared_ptr<CoreContext> GetGlobal(void);
 
+  // The number of ancestors of this context.  The global context is defined to have zero ancestors.
+  const size_t AncestorCount = 0;
+
+  // Sigil type, used during bolting
+  const auto_id SigilType;
+
 protected:
   // A pointer to the parent context
   const std::shared_ptr<CoreContext> m_pParent;
 
   // Back-referencing iterator which refers to ourselves in our parent's child list:
   const t_childList::iterator m_backReference;
-
-  // Sigil type, used during bolting
-  const auto_id m_sigilType;
 
   // State block for this context:
   std::shared_ptr<autowiring::CoreContextStateBlock> m_stateBlock;
@@ -394,7 +397,7 @@ public:
   /// The number of child contexts of this context.
   size_t GetChildCount(void) const;
   /// The type used as a sigil when creating this class, if any.
-  auto_id GetSigilType(void) const { return m_sigilType; }
+  auto_id GetSigilType(void) const { return SigilType; }
   /// The Context iterator for the parent context's children, pointing to this context.
   t_childList::iterator GetBackReference(void) const { return m_backReference; }
   /// A shared reference to the parent context of this context.
@@ -411,7 +414,7 @@ public:
 
   /// True if the sigil type of this CoreContext matches the specified sigil type.
   template<class Sigil>
-  bool Is(void) const { return m_sigilType == auto_id_t<Sigil>{}; }
+  bool Is(void) const { return SigilType == auto_id_t<Sigil>{}; }
 
   /// <summary>
   /// The first child in the set of this context's children.

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -698,3 +698,20 @@ TEST_F(CoreContextTest, SimultaneousMultiInject) {
   // Verify that there's no config block still present
   ASSERT_NO_THROW(ctxt->Config.Get("c"));
 }
+
+
+TEST_F(CoreContextTest, AncestorCount) {
+  AutoCurrentContext ctxt;
+
+  size_t ancestorCount = 0;
+  for (std::shared_ptr<CoreContext> cur = ctxt->GetParentContext(); cur; cur = cur->GetParentContext())
+    ancestorCount++;
+  ASSERT_EQ(ancestorCount, ctxt->AncestorCount) << "Manual traversal of the ancestor count did not match the annotated count";
+
+  auto child1 = ctxt->Create<void>();
+  auto child2 = child1->Create<void>();
+  auto child3 = child2->Create<void>();
+  ASSERT_EQ(ctxt->AncestorCount + 1, child1->AncestorCount);
+  ASSERT_EQ(ctxt->AncestorCount + 2, child2->AncestorCount);
+  ASSERT_EQ(ctxt->AncestorCount + 3, child3->AncestorCount);
+}

--- a/src/autowiring/test/GlobalInitTest.cpp
+++ b/src/autowiring/test/GlobalInitTest.cpp
@@ -15,6 +15,7 @@ void GlobalInitTest::SetUp(void) {
 
 void GlobalInitTest::TearDown(void) {
   std::shared_ptr<GlobalCoreContext> glbl = AutoGlobalContext();
+  ASSERT_EQ(0U, glbl->AncestorCount) << "Global context ancestor count must be exactly zero";
 
   {
     // Always drop the global context when tests are done


### PR DESCRIPTION
Useful in cases where we want to enumerate contexts and keep track of how deep we are, as in the case of printing a tree representation of contexts.