### PR TITLE
Extend hung runnable printouts

### DIFF
--- a/src/autotesting/AutowiringEnclosure.h
+++ b/src/autotesting/AutowiringEnclosure.h
@@ -55,10 +55,18 @@ namespace autowiring {
     };
 
     std::ostream& operator<<(std::ostream& os, const hung& lhs) {
-      auto runnables = lhs.ctxt.GetRunnables();
-      for (CoreRunnable* runnable : runnables)
-        if (runnable->IsRunning())
-          os << autowiring::demangle(typeid(*runnable)) << '\n';
+      std::string tabLvl;
+      for (auto ctxt : ContextEnumerator{ lhs.ctxt }) {
+        auto runnables = lhs.ctxt.GetRunnables();
+        if (runnables.empty())
+          continue;
+
+        tabLvl.assign(" ", ctxt->AncestorCount);
+        os << tabLvl << autowiring::demangle(ctxt->SigilType) << '\n';
+        for (CoreRunnable* runnable : runnables)
+          if (runnable->IsRunning())
+            os << tabLvl << autowiring::demangle(typeid(*runnable)) << '\n';
+      }
       return os;
     }
   }

--- a/src/autowiring/CoreContext.h
+++ b/src/autowiring/CoreContext.h
@@ -477,7 +477,7 @@ public:
   ///
   /// \code
   /// AutoCreateContext myContext;
-  /// AutoCreateContextT<MySigil> myMarkedContext;
+  /// AutoCreateContextT&lt;MySigil&rt; myMarkedContext;
   /// \endcode
   /// </remarks>
   template<class T>


### PR DESCRIPTION
`AutowiringEnclosure` should print out all children of the current context which are hung at the time a hang case is detected, along with the sigil types of these contexts.