### PR TITLE
Adjust AutoPacketFactory::IsRunning behavior

### DIFF
--- a/src/autowiring/AutoPacketFactory.h
+++ b/src/autowiring/AutoPacketFactory.h
@@ -173,6 +173,9 @@ protected:
   static bool IsAutoPacketType(const std::type_info& dataType);
 
 public:
+  // CoreRunnable overrides:
+  bool IsRunning(void) const override;
+
   /// <returns>
   /// The most recently issued packet, or possibly nullptr if that packet has already been destroyed
   /// </returns>

--- a/src/autowiring/CoreRunnable.h
+++ b/src/autowiring/CoreRunnable.h
@@ -83,7 +83,7 @@ protected:
 public:
   // Accessor methods:
   /// Reports whether this runnable is currently running.
-  bool IsRunning(void) const;
+  virtual bool IsRunning(void) const;
   /// Reports whether this runnable was ever started.
   bool WasStarted(void) volatile const { return m_wasStarted; }
   /// Reports whether this runnable should stop.

--- a/src/autowiring/test/AutoPacketFactoryTest.cpp
+++ b/src/autowiring/test/AutoPacketFactoryTest.cpp
@@ -64,7 +64,7 @@ TEST_F(AutoPacketFactoryTest, WaitRunsDownAllPackets) {
 
   // Make the thread create and hold a packet, and then return
   AutoRequired<IssuesPacketWaitsThenQuits> ipwtq;
-  
+
   // Shutdown context
   AutoCurrentContext()->SignalShutdown();
 
@@ -99,7 +99,7 @@ TEST_F(AutoPacketFactoryTest, AutoPacketFactoryCycle) {
     CurrentContextPusher pshr(ctxt);
     AutoRequired<HoldsAutoPacketFactoryReference> hapfr(ctxt);
     ctxt->Initiate();
-    
+
     // A weak pointer is used to detect object destruction
     ctxtWeak = ctxt;
     hapfrWeak = hapfr;
@@ -242,4 +242,13 @@ TEST_F(AutoPacketFactoryTest, CurrentPacket) {
   ASSERT_EQ(packet, factory->CurrentPacket()) << "Current packet was not reported correctly as being issued to the known current packet";
   packet.reset();
   ASSERT_EQ(nullptr, factory->CurrentPacket()) << "A current packet was reported after the current packet has expired";
+}
+
+TEST_F(AutoPacketFactoryTest, IsRunningWhilePacketIssued) {
+  AutoCurrentContext ctxt;
+  ctxt->Initiate();
+  AutoRequired<AutoPacketFactory> factory;
+  auto packet = factory->NewPacket();
+  ctxt->SignalShutdown();
+  ASSERT_TRUE(factory->IsRunning()) << "Factory should be considered to be running as long as packets are outstanding";
 }


### PR DESCRIPTION
Factory should be considered to be running as long as packets are outstanding.