### PR TITLE
Eliminate extra std::condition_variable

### DIFF
--- a/src/autowiring/AutoPacketFactory.h
+++ b/src/autowiring/AutoPacketFactory.h
@@ -30,9 +30,6 @@ private:
   // Lock for this type
   mutable std::mutex m_lock;
 
-  // State change notification
-  std::condition_variable m_stateCondition;
-
   // Internal outstanding reference for issued packet:
   std::weak_ptr<void> m_outstandingInternal;
 

--- a/src/autowiring/CoreRunnable.cpp
+++ b/src/autowiring/CoreRunnable.cpp
@@ -33,6 +33,7 @@ bool CoreRunnable::Start(std::shared_ptr<CoreObject> outstanding) {
     OnStop(false);
   }
 
+  m_cv.notify_all();
   return true;
 }
 
@@ -50,10 +51,10 @@ void CoreRunnable::Stop(bool graceful) {
     std::shared_ptr<CoreObject> outstanding;
     std::lock_guard<std::mutex>{m_lock},
     outstanding.swap(m_outstanding);
-
-    // Everything looks good now
-    m_cv.notify_all();
   }
+
+  // Everything looks good now
+  m_cv.notify_all();
 }
 
 bool CoreRunnable::ThreadSleep(std::chrono::nanoseconds timeout) {


### PR DESCRIPTION
We have an `std::condition_variable` in `CoreRunnable`, which `AutoPacketFactory` inherits, and this variable deals with vigilance state changes in `CoreRunnable`.  The condition variable in `AutoPacketFactory` does the same thing, so we should be able to combine them.