### PR TITLE
Add tid to BasicThread, make debug lists more readable.

### DIFF
--- a/src/autotesting/AutowiringEnclosure.h
+++ b/src/autotesting/AutowiringEnclosure.h
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <autowiring/autowiring.h>
+#include <autowiring/AutowiringDebug.h>
 #include <autowiring/demangle.h>
 #include <autowiring/at_exit.h>
 #include MEMORY_HEADER
@@ -55,19 +56,7 @@ namespace autowiring {
     };
 
     std::ostream& operator<<(std::ostream& os, const hung& lhs) {
-      std::string tabLvl;
-      for (auto ctxt : ContextEnumerator{ lhs.ctxt }) {
-        auto runnables = lhs.ctxt.GetRunnables();
-        if (runnables.empty())
-          continue;
-
-        tabLvl.clear();
-        tabLvl.insert(0, ctxt->AncestorCount, ' ');
-        os << tabLvl << autowiring::demangle(ctxt->SigilType) << '\n';
-        for (CoreRunnable* runnable : runnables)
-          if (runnable->IsRunning())
-            os << tabLvl << autowiring::demangle(typeid(*runnable)) << '\n';
-      }
+      autowiring::dbg::PrintRunnables(os, lhs.ctxt);
       return os;
     }
   }
@@ -142,7 +131,7 @@ public:
     // Do not allow teardown to take more than 5 seconds.  This is considered a "timely teardown" limit.
     // If it takes more than this amount of time to tear down, the test case itself should invoke SignalShutdown
     // and Wait itself with the extended teardown period specified.
-    ASSERT_TRUE(ctxt->Wait(std::chrono::seconds(5))) << "Test case took too long to tear down, unit tests running after this point are untrustworthy.  Hung runnables:\n" << autowiring::testing::hung{ *ctxt };
+    ASSERT_TRUE(ctxt->Wait(std::chrono::seconds(5))) << "Test case took too long to tear down, unit tests running after this point are untrustworthy.  Runnable dump:\n" << autowiring::testing::hung{ *ctxt };
 
     // Global context should return to quiescence:
     if (!allowGlobalReferences)

--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -179,8 +179,10 @@ void autowiring::dbg::PrintRunnables(std::ostream& os, CoreContext& ctxt) {
           os << "[ STOPPED ]";
 
         // If we can get the tid, print that, otherwise just leave it blank
-        if (BasicThread* pThread = dynamic_cast<BasicThread*>(runnable))
-          os << "(tid: " << std::setw(5) << std::setfill(' ') << pThread->GetThread()->get_id() << ")";
+        if (BasicThread* pThread = dynamic_cast<BasicThread*>(runnable)) {
+          auto stdThread = std::static_pointer_cast<std::thread>(pThread->GetThread());
+          os << "(tid: " << std::setw(5) << std::setfill(' ') << stdThread->get_id() << ")";
+        }
 
         // Type information, in human-readable form
         os << ' ' << autowiring::demangle(typeid(*runnable)) << ' ';

--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -186,8 +186,6 @@ void autowiring::dbg::PrintRunnables(std::ostream& os, CoreContext& ctxt) {
 
         // Type information, in human-readable form
         os << ' ' << autowiring::demangle(typeid(*runnable)) << ' ';
-
-        os << " " << autowiring::demangle(typeid(*runnable));
         if (ContextMember* pMember = dynamic_cast<ContextMember*>(runnable))
           os << " (" << pMember->GetName() << ')';
         os << '\n';

--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <unordered_set>
 #include <sstream>
+#include <thread>
 
 using namespace autowiring;
 using namespace autowiring::dbg;

--- a/src/autowiring/AutowiringDebug.h
+++ b/src/autowiring/AutowiringDebug.h
@@ -30,6 +30,11 @@ namespace autowiring {
     void PrintContextTree(std::ostream& os);
     void PrintContextTree(std::ostream& os, const std::shared_ptr<CoreContext>& ctxt);
 
+    /// <summary>
+    /// Writes out the status of all runnables within a context
+    /// </summary>
+    void PrintRunnables(std::ostream& os, CoreContext& ctxt);
+
     /// <returns>
     /// The current packet under processing
     /// </returns>

--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -175,6 +175,14 @@ bool BasicThread::DoAdditionalWait(std::chrono::nanoseconds timeout) {
   );
 }
 
+std::shared_ptr<std::thread> BasicThread::GetThread(void) const {
+  // Return an aliased shared pointer
+  return {
+    m_state,
+    &m_state->m_thisThread
+  };
+}
+
 bool BasicThread::IsCompleted(void) const {
   return m_state->m_completed;
 }

--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -175,7 +175,7 @@ bool BasicThread::DoAdditionalWait(std::chrono::nanoseconds timeout) {
   );
 }
 
-std::shared_ptr<std::thread> BasicThread::GetThread(void) const {
+std::shared_ptr<void> BasicThread::GetThread(void) const {
   // Return an aliased shared pointer
   return {
     m_state,

--- a/src/autowiring/BasicThread.h
+++ b/src/autowiring/BasicThread.h
@@ -14,6 +14,10 @@ namespace autowiring {
   struct BasicThreadStateBlock;
 }
 
+namespace std {
+  class thread;
+}
+
 /// <summary>
 /// Thread priority classifications from low to high.
 /// </summary>
@@ -209,6 +213,11 @@ protected:
   bool DoAdditionalWait(std::chrono::nanoseconds timeout) override;
 
 public:
+  /// <returns>
+  /// The underlying std::thread
+  /// </returns>
+  std::shared_ptr<std::thread> GetThread(void) const;
+
   /// <returns>
   /// The current thread priority
   /// </returns>

--- a/src/autowiring/BasicThread.h
+++ b/src/autowiring/BasicThread.h
@@ -14,10 +14,6 @@ namespace autowiring {
   struct BasicThreadStateBlock;
 }
 
-namespace std {
-  class thread;
-}
-
 /// <summary>
 /// Thread priority classifications from low to high.
 /// </summary>
@@ -214,9 +210,9 @@ protected:
 
 public:
   /// <returns>
-  /// The underlying std::thread
+  /// A void pointer to the underlying std::thread
   /// </returns>
-  std::shared_ptr<std::thread> GetThread(void) const;
+  std::shared_ptr<void> GetThread(void) const;
 
   /// <returns>
   /// The current thread priority

--- a/src/autowiring/CoreContext.h
+++ b/src/autowiring/CoreContext.h
@@ -392,6 +392,8 @@ public:
   // Accessor methods:
   /// True if and only if this is the global context.
   bool IsGlobalContext(void) const { return !m_pParent; }
+  /// True if and only if this is an anonymous context
+  bool IsAnonymousContext(void) const { return SigilType == auto_id_t<void>{}; }
   /// The number of Autowired members in this context.
   size_t GetMemberCount(void) const { return m_concreteTypes.size(); }
   /// The number of child contexts of this context.

--- a/src/autowiring/test/AutowiringDebugTest.cpp
+++ b/src/autowiring/test/AutowiringDebugTest.cpp
@@ -5,6 +5,7 @@
 #include "TestFixtures/Decoration.hpp"
 #include <algorithm>
 #include <fstream>
+#include <thread>
 
 class AutowiringDebugTest:
   public testing::Test

--- a/src/autowiring/test/AutowiringDebugTest.cpp
+++ b/src/autowiring/test/AutowiringDebugTest.cpp
@@ -187,11 +187,11 @@ TEST_F(AutowiringDebugTest, PrintRunnables) {
 
   ASSERT_EQ(
     "void(Current Context)\n"
-    "|   [ RUNNING ]    (efgh)\n"
+    "|   [ RUNNING ] RunnableMember<0>  (efgh)\n"
     "|-- void\n"
-    "|       [ RUNNING ]    (abcd)\n"
+    "|       [ RUNNING ] RunnableMember<0>  (abcd)\n"
     "*-- void\n"
-    "|       [ RUNNING ]    (efgh)\n",
+    "|       [ RUNNING ] RunnableMember<0>  (efgh)\n",
     str
   );
 }

--- a/src/autowiring/test/AutowiringDebugTest.cpp
+++ b/src/autowiring/test/AutowiringDebugTest.cpp
@@ -152,20 +152,18 @@ TEST_F(AutowiringDebugTest, FilterWithSyntheticID) {
   ASSERT_NE(std::string::npos, off) << "AutoFilterGraph dump failed to correctly handle an uninstantiated output type";
 }
 
-namespace {
-  template<int>
-  class RunnableMember:
-    public ContextMember,
-    public CoreRunnable
-  {
-  public:
-    RunnableMember(const char* name) :
-      ContextMember(name)
-    {}
+template<int>
+class RunnableMember:
+  public ContextMember,
+  public CoreRunnable
+{
+public:
+  RunnableMember(const char* name) :
+    ContextMember(name)
+  {}
 
-    bool OnStart(void) override { return true; }
-  };
-}
+  bool OnStart(void) override { return true; }
+};
 
 TEST_F(AutowiringDebugTest, PrintRunnables) {
   AutoCurrentContext ctxt;


### PR DESCRIPTION
Another slight adjustment to hung runnable outputs.  Contexts should print all of their runnable members, whether they are running or not, and use a status flag to indicate what is still running and under what context.  Also print the thread ID of runnables that are threads, wherever possible.

Furthermore, the context map was not actually readable when printed in windows due to Unicode translation problems on the command line.  Replace the unicode box drawing code with simple ASCII in order to ensure compatibility for now, and update unit tests as needed.

Also add a unit test for all new behaviors.