### PR TITLE
Add file_size to std::namespace in the filesystem shim header

### DIFF
--- a/src/autowiring/C++11/filesystem.h
+++ b/src/autowiring/C++11/filesystem.h
@@ -64,6 +64,7 @@ namespace std {
     using awfsnamespace::remove;
     using awfsnamespace::remove_all;
     using awfsnamespace::rename;
+    using awfsnamespace::file_size;
 
 #ifdef _MSC_VER
 #if _MSC_VER >= 1900


### PR DESCRIPTION
file_size was previously not covered by the shim and is required by platform.