### PR TITLE
Make AutowiringEnclosure behavior easier to follow

### DIFF
--- a/src/autotesting/AutowiringEnclosure.h
+++ b/src/autotesting/AutowiringEnclosure.h
@@ -91,7 +91,6 @@ public:
 
   // Base overrides:
   void OnTestStart(const testing::TestInfo& info) override {
-    AutoRequired<AutowiringEnclosureExceptionFilter> filter;
 
     // Set global context current first, then initiate
     AutoGlobalContext global;

--- a/src/autotesting/AutowiringEnclosure.h
+++ b/src/autotesting/AutowiringEnclosure.h
@@ -127,7 +127,7 @@ public:
 
     {
       // Verify we can grab the test case back out and that the pointer is correct:
-      Autowired<AutowiringEnclosureExceptionFilter> ecef;
+      AutowiredFast<AutowiringEnclosureExceptionFilter> ecef{ ctxt };
 
       // Need to make sure we got back our exception filter before continuing:
       ASSERT_TRUE(ecef.IsAutowired()) << "Failed to find the enclosed context exception filter; unit test may have incorrectly reset the enclosing context before returning";
@@ -153,6 +153,5 @@ public:
     // No more references to this context except for the pointer we hold ourselves
     ASSERT_TRUE(ctxt.unique()) << "Detected a dangling context reference after test termination, context may be leaking";
     ctxt = {};
-
   }
 };

--- a/src/autowiring/test/CoreThreadTest.cpp
+++ b/src/autowiring/test/CoreThreadTest.cpp
@@ -551,7 +551,12 @@ public:
 };
 
 TEST_F(CoreThreadTest, ContextWaitTimesOutInOnStop) {
-  AutoCurrentContext ctxt;
+  AutoCurrentContext()->Initiate();
+
+  // Create a child context so we have precise and reliable use count numbers
+  AutoCreateContext ctxt;
+  ctxt->SetCurrent();
+
   AutoRequired<BlocksInOnStop> bios;
   ctxt->Initiate();
 


### PR DESCRIPTION
Refactor AutowiringEnclosure to use member variables on the test listener in order to track state.  This makes it easer to find out what the current context is during debugging and also makes it simpler to find memory leaks.