### PR TITLE
Fix memory leak in autowiring::signal

### DIFF
--- a/src/autowiring/signal.h
+++ b/src/autowiring/signal.h
@@ -118,6 +118,7 @@ namespace autowiring {
         delete prior;
         prior = cur;
       }
+      delete prior;
     }
 
     signal& operator=(signal&& rhs) {

--- a/src/autowiring/test/AutoSignalTest.cpp
+++ b/src/autowiring/test/AutoSignalTest.cpp
@@ -724,3 +724,12 @@ TEST_F(AutoSignalTest, IsExecuting) {
   };
   ASSERT_FALSE(sig.is_executing()) << "Signal was incorrectly marked as executing even though nothing is happening";
 }
+
+TEST_F(AutoSignalTest, NoLeaks) {
+  auto v = std::make_shared<bool>(false);
+  {
+    autowiring::signal<void()> x;
+    x += [v] {};
+  }
+  ASSERT_TRUE(v.unique()) << "Signal did not destroy all attached lambdas on its destruction";
+}

--- a/src/autowiring/test/OnceTest.cpp
+++ b/src/autowiring/test/OnceTest.cpp
@@ -33,7 +33,7 @@ TEST(OnceTest, CallAfterSet) {
   ASSERT_EQ(1, val2) << "Lambda not executed on assignment as expected";
 }
 
-TEST(OnceTest, NoLeaks) {
+TEST(OnceTest, NoLeaks_Asserted) {
   autowiring::once_signal<void> o;
   auto v = std::make_shared<bool>(false);
   o += [v] {};
@@ -43,6 +43,15 @@ TEST(OnceTest, NoLeaks) {
   ASSERT_TRUE(v.unique()) << "Shared pointer leaked by once flag after execution";
   o += [v] {};
   ASSERT_TRUE(v.unique()) << "Shared pointer leaked by once flag after post-set attachment";
+}
+
+TEST(OnceTest, NoLeaks_NotAsserted) {
+  auto v = std::make_shared<bool>(false);
+  {
+    autowiring::once_signal<void()> x;
+    x += [v] {};
+  }
+  ASSERT_TRUE(v.unique()) << "Signal did not destroy all attached lambdas on its destruction";
 }
 
 TEST(OnceTest, MultiLambdaPending) {


### PR DESCRIPTION
Fix a memory leak caused by the `autowiring::signal` destructor not properly freeing the last listener in the list of listeners.  Also add a test to guarantee we don't miss this again, and add a corresponding test to `autowiring::once_signal` just in case.