### PR TITLE
Add directory_iterator to filesystem shim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,8 +157,8 @@ install(FILES
   COMPONENT autowiring
 )
 
-# Autoboost headers required everywhere but on Windows, which doesn't rely on filesystem
-if(NOT MSVC)
+# Autoboost headers required everywhere but on MSVC 2015+, which doesn't rely on filesystem
+if(NOT MSVC OR MSVC_VERSION LESS 1900)
   install(
     DIRECTORY ${PROJECT_SOURCE_DIR}/contrib/autoboost/autoboost
     DESTINATION include

--- a/src/autowiring/C++11/filesystem.h
+++ b/src/autowiring/C++11/filesystem.h
@@ -17,6 +17,7 @@ namespace std {
     using awfsnamespace::canonical;
     using awfsnamespace::create_directory;
     using awfsnamespace::current_path;
+    using awfsnamespace::directory_iterator;
     using awfsnamespace::exists;
     using awfsnamespace::is_directory;
     using awfsnamespace::is_empty;

--- a/src/autowiring/C++11/filesystem.h
+++ b/src/autowiring/C++11/filesystem.h
@@ -25,5 +25,6 @@ namespace std {
     using awfsnamespace::remove_all;
     using awfsnamespace::rename;
     using awfsnamespace::file_size;
+    using awfsnamespace::unique_path;
   }
 }


### PR DESCRIPTION
This is used by `LeapResource` and other downstream entities and is a generally useful concept.