### PR TITLE
Fix leak in DispatchQueue::Abort

### DIFF
--- a/src/autowiring/DispatchQueue.cpp
+++ b/src/autowiring/DispatchQueue.cpp
@@ -97,38 +97,36 @@ void DispatchQueue::TryDispatchEventUnsafe(std::unique_lock<std::mutex>& lk) {
 }
 
 void DispatchQueue::Abort(void) {
+  // Wake up anyone who is still waiting when we return
+  auto x = MakeAtExit([this] { m_queueUpdated.notify_all(); });
+
+  DispatchThunkBase* pHead;
+  std::priority_queue<autowiring::DispatchThunkDelayed> delayedQueue;
+
+  // Do not permit any more lambdas to be pended to our queue
   {
-    DispatchThunkBase* pHead;
-    std::priority_queue<autowiring::DispatchThunkDelayed> delayedQueue;
-
-    // Do not permit any more lambdas to be pended to our queue
-    {
-      std::lock_guard<std::mutex> lk(m_dispatchLock);
-      onAborted();
-      m_dispatchCap = 0;
-      pHead = m_pHead;
-      m_pHead = nullptr;
-      m_pTail = nullptr;
-      delayedQueue = std::move(m_delayedQueue);
-    }
-
-    // Destroy the whole dispatch queue.  Do so in an unsynchronized context in order to prevent
-    // reentrancy.
-    size_t nTraversed = 0;
-    for (auto cur = pHead; cur;) {
-      auto next = cur->m_pFlink;
-      delete cur;
-      cur = next;
-      nTraversed++;
-    }
-
-    // Decrement the count by the number of entries we actually traversed.  Abort may potentially
-    // be called from a lambda function, so assigning this value directly to zero would be an error.
-    m_count -= nTraversed;
+    std::lock_guard<std::mutex> lk(m_dispatchLock);
+    onAborted();
+    m_dispatchCap = 0;
+    pHead = m_pHead;
+    m_pHead = nullptr;
+    m_pTail = nullptr;
+    delayedQueue = std::move(m_delayedQueue);
   }
 
-  // Wake up anyone who is still waiting:
-  m_queueUpdated.notify_all();
+  // Destroy the whole dispatch queue.  Do so in an unsynchronized context in order to prevent
+  // reentrancy.
+  size_t nTraversed = 0;
+  for (auto cur = pHead; cur;) {
+    auto next = cur->m_pFlink;
+    delete cur;
+    cur = next;
+    nTraversed++;
+  }
+
+  // Decrement the count by the number of entries we actually traversed.  Abort may potentially
+  // be called from a lambda function, so assigning this value directly to zero would be an error.
+  m_count -= nTraversed;
 }
 
 bool DispatchQueue::Cancel(void) {

--- a/src/autowiring/test/DispatchQueueTest.cpp
+++ b/src/autowiring/test/DispatchQueueTest.cpp
@@ -335,3 +335,12 @@ TEST_F(DispatchQueueTest, MixedCancel) {
   ASSERT_FALSE(called1.unique()) << "Cancellation cancelled the wrong lambda";
   ASSERT_TRUE(called2.unique()) << "Cancellation cancelled the wrong lambda";
 }
+
+TEST_F(DispatchQueueTest, DelayedAbort) {
+  DispatchQueue dq;
+
+  auto v = std::make_shared<bool>(true);
+  dq += std::chrono::hours{ 1 }, [v] {};
+  dq.Abort();
+  ASSERT_TRUE(v.unique()) << "A delayed dispatcher was leaked after a call to Abort";
+}


### PR DESCRIPTION
This is not a true leak, but rather technical leak that exists because things are not destroyed at the expected time.  Delayed dispatchers attached to a `DispatchQueue` are not deleted when the `Abort` call completes.  They are eventually destroyed in `~DispatchQueue`, but they should be instead destroyed as soon as it is possible to know that's needed.