### PR TITLE
Add a lock for `m_ContextIDs` and `m_ContextPtrs`

### DIFF
--- a/src/autonet/AutoNetServerImpl.cpp
+++ b/src/autonet/AutoNetServerImpl.cpp
@@ -322,6 +322,7 @@ void AutoNetServerImpl::HandleUnsubscribe(websocketpp::connection_hdl hdl) {
 int AutoNetServerImpl::ResolveContextID(CoreContext* ctxt) {
   static int counter = 0;
 
+  std::lock_guard<autowiring::spin_lock> lk(m_lock);
   if(m_ContextIDs.find(ctxt) == m_ContextIDs.end()){
     m_ContextIDs[ctxt] = counter;
     m_ContextPtrs[counter] = ctxt;
@@ -333,6 +334,7 @@ int AutoNetServerImpl::ResolveContextID(CoreContext* ctxt) {
 }
 
 CoreContext* AutoNetServerImpl::ResolveContextID(int id) {
+  std::lock_guard<autowiring::spin_lock> lk(m_lock);
   return m_ContextPtrs.at(id);
 }
 

--- a/src/autonet/AutoNetServerImpl.hpp
+++ b/src/autonet/AutoNetServerImpl.hpp
@@ -135,7 +135,8 @@ protected:
   // Set of all subscribers
   std::set<AutoNetTransportHandler::connection_hdl, std::owner_less<AutoNetTransportHandler::connection_hdl>> m_Subscribers;
 
-  // one-to-one map of contexts to integers
+  // one-to-one map of contexts to integers, and a lock because we use this in an unsynchronized setting
+  autowiring::spin_lock m_lock;
   std::map<CoreContext*, int> m_ContextIDs;
   std::map<int, CoreContext*> m_ContextPtrs;
 


### PR DESCRIPTION
These members are often accessed in an unsynchronized context, synchronize them by adding a spin lock to ensure we do not wind up with memory smashers when using Autonet in highly concurrent settings.