### PR TITLE
Eliminate unneeded default initializer

### DIFF
--- a/src/autowiring/config_descriptor.h
+++ b/src/autowiring/config_descriptor.h
@@ -270,7 +270,7 @@ namespace autowiring {
     }
 
   private:
-    std::vector<const metadata_base*> empty{};
+    std::vector<const metadata_base*> empty;
     std::unordered_map<auto_id, std::vector<const metadata_base*>> m_mdMap;
 
     // Initializes our default value


### PR DESCRIPTION
This is causing VS2013 CTP to crash, and it's not necessary, remove it.