### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ via the [find_package](http://www.cmake.org/cmake/help/v3.0/command/find_package
 
 Building on ARM-Linux requires the use of a toolchain file.  This file is included with Autowiring.  To configure, use the following invocation:
 
-    cmake . -DCMAKE_TOOLCHAIN_FILE=toolchain-arm32.cmake -DCMAKE_PREFIX_PATH:PATH=/your/lib/path
+    cmake . -DCMAKE_TOOLCHAIN_FILE=standard/toolchain-arm32.cmake -DCMAKE_PREFIX_PATH:PATH=/your/lib/path
 
 For 64-bit ARMv8 (AArch64), use toolchain-arm64.cmake
 
@@ -70,7 +70,7 @@ For 64-bit ARMv8 (AArch64), use toolchain-arm64.cmake
 
 Similar requirements to Arm-linux, you must specify a toolchain file.  You must also specify the path to your Android toolchain directory.  Make sure you update `/opt/android-standalone-toolchain` to point to your actual Android standalone toolchain directory. To build for 64 bit android systems, export the environment variable `export ARMv8=true`. If you aren't cross-compiling, then simply run cmake with no options.
 
-    cmake . -DCMAKE_TOOLCHAIN_FILE=toolchain-android.cmake -DLLVM_ANDROID_TOOLCHAIN_DIR=/opt/android-standalone-toolchain
+    cmake . -DCMAKE_TOOLCHAIN_FILE=standard/toolchain-android.cmake -DLLVM_ANDROID_TOOLCHAIN_DIR=/opt/android-standalone-toolchain
 
 # Test
 


### PR DESCRIPTION
Toolchain files are now located under the `standard` directory, update `README.md` to reflect this.