### PR TITLE
Test bad config field

### DIFF
--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -84,6 +84,13 @@ TEST_F(AutoConfigTest, ConfigFieldAssign) {
   ASSERT_TRUE(x.is_dirty()) << "Config values are assumed to be initially dirty";
 }
 
+TEST_F(AutoConfigTest, ConfigFieldSetBad) {
+  MyConfigurableClass c;
+
+  std::string expected{ "There is no config" };
+  ASSERT_ANY_THROW(autowiring::ConfigSet("z", c, expected.c_str())) << "Tried to set an invalid config key and did not fail.";
+}
+
 TEST_F(AutoConfigTest, String) {
   MyConfigurableClass c;
 


### PR DESCRIPTION
Test the behavior of AutoConfig if setting an undefined field is attempted.