### PR TITLE
Autoconfig/set from member

### DIFF
--- a/src/autowiring/ConfigManager.cpp
+++ b/src/autowiring/ConfigManager.cpp
@@ -19,11 +19,16 @@ void ConfigManager::Register(void* pObj, const config_descriptor& desc) {
 
   {
     std::lock_guard<autowiring::spin_lock> lk(m_lock);
+
+    // This goes through all of the fields in the user-specified descriptor.  These fields describe offsets
+    // in pObj, and each one could require us to either populate offsets in pObj with values that we are
+    // keeping in m_config, or it could require us to update m_config based on metadata described by these
+    // fields.
     for (const auto& field : desc.fields) {
       const config_field& field_desc = field.second;
 
-      // We need to attach this field to the corresponding configuration entry,
-      // we perform the attachment by name
+      // We need to attach this field to the corresponding configuration entry, we perform the attachment by
+      // name.  After we have our entry we can fill it or use it to fill other objects as needed.
       Entry& entry = m_config[field_desc.name];
       entry.attached.emplace_back(
         field_desc,
@@ -32,9 +37,19 @@ void ConfigManager::Register(void* pObj, const config_descriptor& desc) {
 
       Entry::Attachment& attachment = entry.attached.back();
       if (entry.value)
-        // This configuration entry specifies a default value, we will take that value and store
-        // it in the manager to be advertised during query
+        // We have a value already.  Force the attachment's field to take on the value we
+        // are storing locally.
         attachment.configField->marshaller->unmarshal(attachment.pField, entry.value->c_str());
+      else if (field_desc.default_value) {
+        // Descriptor provides a default value, and we do not have a value ourselves in our own
+        // local config store.  In this case, we take the default value, and unconditionally overwrite
+        // the value currently present on the object.
+        entry.value = attachment.configField->marshaller->marshal(attachment.configField->default_value.ptr());
+        field_desc.marshaller->copy(attachment.pField, attachment.configField->default_value.ptr());
+      }
+      ///else
+        // In this case, no value stored locally, no default value either.  We can't really do much
+        // except to default this entry.
 
       // Deferred signalling on all watcher collections.  This part causes When handlers to be invoked.
       const std::vector<const metadata_base*>& all_metadata = attachment.bound_metadata->get_list();

--- a/src/autowiring/ConfigManager.cpp
+++ b/src/autowiring/ConfigManager.cpp
@@ -40,16 +40,13 @@ void ConfigManager::Register(void* pObj, const config_descriptor& desc) {
         // We have a value already.  Force the attachment's field to take on the value we
         // are storing locally.
         attachment.configField->marshaller->unmarshal(attachment.pField, entry.value->c_str());
-      else if (field_desc.default_value) {
-        // Descriptor provides a default value, and we do not have a value ourselves in our own
+      else {
+        // Descriptor must provide a default value, and we do not have a value ourselves in our own
         // local config store.  In this case, we take the default value, and unconditionally overwrite
         // the value currently present on the object.
         entry.value = attachment.configField->marshaller->marshal(attachment.configField->default_value.ptr());
         field_desc.marshaller->copy(attachment.pField, attachment.configField->default_value.ptr());
       }
-      ///else
-        // In this case, no value stored locally, no default value either.  We can't really do much
-        // except to default this entry.
 
       // Deferred signalling on all watcher collections.  This part causes When handlers to be invoked.
       const std::vector<const metadata_base*>& all_metadata = attachment.bound_metadata->get_list();

--- a/src/autowiring/ConfigManager.h
+++ b/src/autowiring/ConfigManager.h
@@ -150,7 +150,7 @@ namespace autowiring {
     /// Invokes the specified callback when a piece of metadata is attached to any object
     /// </summary>
     /// <returns>A shared pointer containing the added watcher</returns>
-    /// <remarks>
+    /// <remarks><![CDATA[
     /// Two callable signatures are allowed.  The first is the full context variant, which
     /// provides the configuration filed.  Here, M is the metadata type:
     ///
@@ -159,7 +159,7 @@ namespace autowiring {
     /// The second is the compact variant, for which only the raw metadata is provided:
     ///
     /// [] (const M& slider)
-    /// </remarks>
+    /// ]]></remarks>
     template<typename Fn>
     std::shared_ptr<WhenWatcher> WhenFn(Fn&& fn) {
       auto retVal = std::make_shared<internal::WhenWatcherT<Fn, decltype(&Fn::operator())>>(std::forward<Fn>(fn));

--- a/src/autowiring/config.h
+++ b/src/autowiring/config.h
@@ -75,6 +75,15 @@ namespace autowiring {
     bool operator==(const T& rhs) const { return get() == rhs; }
     bool operator!=(const T& rhs) const { return get() != rhs; }
 
+    /// <summary>
+    /// Forces an update to the value stored in this field
+    /// </summary>
+    /// <remarks>
+    ///
+    /// </remarks>
+    void force_assign(T rhs) { *this = std::move(rhs); }
+
+  private:
     config& operator=(const config& value) {
       // Local copy to hold the spin lock a minimum amount of time
       return *this = value.get();
@@ -92,6 +101,9 @@ namespace autowiring {
       dirty = true;
       return *this;
     }
+
+    template<typename T>
+    friend struct marshaller;
   };
 
   template<typename T>

--- a/src/autowiring/config.h
+++ b/src/autowiring/config.h
@@ -102,7 +102,7 @@ namespace autowiring {
       return *this;
     }
 
-    template<typename T>
+    template<typename U>
     friend struct marshaller;
   };
 

--- a/src/autowiring/config.h
+++ b/src/autowiring/config.h
@@ -115,5 +115,9 @@ namespace autowiring {
       interior.unmarshal(&value, szValue);
       *static_cast<type*>(ptr) = std::move(value);
     }
+
+    void copy(void* lhs, const void* rhs) const override {
+      *static_cast<config<T>*>(lhs) = *static_cast<const config<T>*>(rhs);
+    }
   };
 }

--- a/src/autowiring/config_descriptor.h
+++ b/src/autowiring/config_descriptor.h
@@ -195,6 +195,9 @@ namespace autowiring {
     return { std::forward<T>(t) };
   }
 
+  /// <summary>
+  /// Represents a single field in a context member that may be configured
+  /// </summary>
   struct config_field {
     config_field(void) = default;
     config_field(const config_field& rhs) { *this = rhs; }
@@ -231,10 +234,14 @@ namespace autowiring {
     // Offset from the base of the object to the member to be serialized
     size_t offset = 0;
 
-    // Default value for this type, must not be empty:
+    // Default value for this type.  Must not be empty, but there are no guarantees
+    // about the type of the underlying object.  In particular, the object will be
+    // initialized, but it may be value-initialized; for integer types this means
+    // it may contain random data.
     AnySharedPointer default_value;
 
-    // Pointer to the required marshaller singleton:
+    // Pointer to the required marshaller singleton.  This allows us to move to and
+    // from string representations of this field.
     const marshaller_base* marshaller = nullptr;
 
     // All of the metadata attached to this field

--- a/src/autowiring/config_descriptor.h
+++ b/src/autowiring/config_descriptor.h
@@ -231,7 +231,7 @@ namespace autowiring {
     // Offset from the base of the object to the member to be serialized
     size_t offset = 0;
 
-    // Default value for this type, if one exists:
+    // Default value for this type, must not be empty:
     AnySharedPointer default_value;
 
     // Pointer to the required marshaller singleton:

--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -15,6 +15,8 @@ namespace autowiring {
   template<typename T>
   struct marshaller;
 
+  class ConfigManager;
+
   /// <summary>
   /// The interface all marshallers must support
   /// </summary>
@@ -43,6 +45,20 @@ namespace autowiring {
     /// Implementations of this method make use of the assignment operator to perform the copy.
     /// </remarks>
     virtual void copy(void* lhs, const void* rhs) const = 0;
+
+    /// <summary>
+    /// Notification passed by the ConfigManager when a field has been attached
+    /// </summary>
+    /// <remarks>
+    /// When a configurable object is added to a context, each field in the object is processed one
+    /// at a time and then bound to the context's ConfigManager.  After being bound, each field's
+    /// marshaller is given the opportunity to consider the newly created field together with the
+    /// ConfigManager.
+    ///
+    /// One use case for this is allowing config fields to back-propagate changes on themselves to
+    /// the owning ConfigManager.
+    /// </remarks>
+    virtual void attach(ConfigManager& manager, void* pField) const {};
   };
 
   /// <summary>

--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -30,6 +30,19 @@ namespace autowiring {
     /// <param name="szValue">The string value to be converted</param>
     /// <param name="ptr">A pointer to the memory region where the output will be stored</param>
     virtual void unmarshal(void* ptr, const char* szValue) const = 0;
+
+    /// <summary>
+    /// Copies the value on the right-hand side to the left-hand side without translation.
+    /// </summary>
+    /// <param name="lhs">The destination for the assignment</param>
+    /// <param name="rhs">The source of the copy</param>
+    /// <remarks>
+    /// As with all other methods on this interface, this operation assumes that both objects
+    /// are fully initialized and are pointers to the correct type.
+    ///
+    /// Implementations of this method make use of the assignment operator to perform the copy.
+    /// </remarks>
+    virtual void copy(void* lhs, const void* rhs) const = 0;
   };
 
   /// <summary>
@@ -57,6 +70,10 @@ namespace autowiring {
         *static_cast<bool*>(ptr) = false;
       else
         throw std::invalid_argument("Boolean unmarshaller expects true or false keyword");
+    }
+
+    void copy(void* lhs, const void* rhs) const override {
+      *static_cast<bool*>(lhs) = *static_cast<const bool*>(rhs);
     }
   };
 
@@ -107,6 +124,10 @@ namespace autowiring {
       }
       if(negative)
         value *= -1;
+    }
+
+    void copy(void* lhs, const void* rhs) const override {
+      *static_cast<T*>(lhs) = *static_cast<const T*>(rhs);
     }
   };
 
@@ -210,6 +231,10 @@ namespace autowiring {
       if (negative)
         value *= -1.0f;
     }
+
+    void copy(void* lhs, const void* rhs) const override {
+      *static_cast<T*>(lhs) = *static_cast<const T*>(rhs);
+    }
   };
 
   /// <summary>
@@ -244,6 +269,10 @@ namespace autowiring {
       interior.unmarshal(&value, szValue);
       *static_cast<type*>(ptr) = std::move(value);
     }
+
+    void copy(void* lhs, const void* rhs) const override {
+      *static_cast<std::atomic<T>*>(lhs) = static_cast<const std::atomic<T>*>(rhs)->load();
+    }
   };
 
   template<>
@@ -258,6 +287,10 @@ namespace autowiring {
 
     void unmarshal(void* ptr, const char* szValue) const override {
       *static_cast<std::string*>(ptr) = szValue;
+    }
+
+    void copy(void* lhs, const void* rhs) const override {
+      *static_cast<std::string*>(lhs) = *static_cast<const std::string*>(rhs);
     }
   };
 }

--- a/src/autowiring/observable.h
+++ b/src/autowiring/observable.h
@@ -29,6 +29,9 @@ public:
     onChanged(std::move(rhs.onChanged)),
     onBeforeChanged(std::move(rhs.onBeforeChanged))
   {}
+  observable(const observable& rhs) :
+    val(rhs.val)
+  {}
 
   autowiring::signal<void()> onChanged;
   autowiring::signal<void(const T& oldValue, const T& newValue)> onBeforeChanged;
@@ -58,6 +61,11 @@ public:
     return *this;
   }
 
+  observable& operator=(const observable& rhs)
+  {
+    return *this = rhs.get();
+  }
+
   observable& operator=(T&& rhs) {
     onBeforeChanged(val, rhs);
     val = std::move(rhs);
@@ -68,10 +76,10 @@ public:
 
 
 template<typename T>
-struct marshaller<autowiring::observable<T>> :
+struct marshaller<observable<T>> :
   marshaller_base
 {
-  typedef autowiring::observable<T> type;
+  typedef observable<T> type;
 
   // Marshaller for the interior type
   marshaller<T> interior;
@@ -84,6 +92,10 @@ struct marshaller<autowiring::observable<T>> :
     T value;
     interior.unmarshal(&value, szValue);
     *static_cast<type*>(ptr) = std::move(value);
+  }
+
+  void copy(void* lhs, const void* rhs) const override {
+    *static_cast<observable<T>*>(lhs) = *static_cast<const observable<T>*>(rhs);
   }
 };
 

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -96,8 +96,11 @@ TEST_F(AutoConfigTest, ConfigFieldAssign) {
 }
 
 TEST_F(AutoConfigTest, ConfigDefault) {
+  // Default value will be whatever bUnsigned is assigned to in the inline initializer.  This is
+  // because MyConfigurableClass is not actually in a context, which means Autowiring will not
+  // attempt to configure it.
   MyConfigurableClass c;
-  ASSERT_EQ(4444, c.bUnsigned); //The default value provided in the descriptor will override the initialized value.
+  ASSERT_EQ(92999, c.bUnsigned);
 }
 
 TEST_F(AutoConfigTest, String) {

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -222,10 +222,10 @@ TEST_F(AutoConfigTest, ContextGetSimple) {
   AutoRequired<MyConfigurableClass> mcc;
 
   mcc->b = 10442;
-  EXPECT_EQ("929", ctxt->Config.Get("b")) << "Non-Observable value had an unexpected value.";
+  ASSERT_EQ("929", ctxt->Config.Get("b")) << "Non-Observable value had an unexpected value.";
 
   ctxt->Config.Set("b", "10443");
-  EXPECT_EQ(10443, mcc->b) << "Non-Observable value set in the context not modified in the backing value.";
+  ASSERT_EQ(10443, mcc->b) << "Non-Observable value set in the context not modified in the backing value.";
 }
 
 TEST_F(AutoConfigTest, ContextGetObservable) {
@@ -234,10 +234,10 @@ TEST_F(AutoConfigTest, ContextGetObservable) {
 
   mcc->obs = 10442;
   const std::string& val = ctxt->Config.Get("obs");
-  EXPECT_EQ("10442", val) << "Observable value set directly not updated in the context.";
+  ASSERT_EQ("10442", val) << "Observable value set directly not updated in the context.";
 
   ctxt->Config.Set("b", "10443");
-  EXPECT_EQ(10443, mcc->b) << "Non-Observable value set in the context not modified in the backing value.";
+  ASSERT_EQ(10443, mcc->b) << "Non-Observable value set in the context not modified in the backing value.";
 }
 
 TEST_F(AutoConfigTest, ContextMultiReference) {
@@ -247,13 +247,13 @@ TEST_F(AutoConfigTest, ContextMultiReference) {
 
   const auto expectStr1 = "Hello Multiverse";
   mcc->a = expectStr1;
-  EXPECT_STREQ(expectStr1, dc->a->c_str());
-  EXPECT_STREQ(expectStr1, ctxt->Config.Get("a").c_str());
+  ASSERT_STREQ(expectStr1, dc->a->c_str());
+  ASSERT_STREQ(expectStr1, ctxt->Config.Get("a").c_str());
 
   const auto expectStr2 = "Hello Universe 616";
   ctxt->Config.Set("a", expectStr2);
-  EXPECT_STREQ(expectStr2, mcc->a->c_str());
-  EXPECT_STREQ(expectStr2, dc->a->c_str());
+  ASSERT_STREQ(expectStr2, mcc->a->c_str());
+  ASSERT_STREQ(expectStr2, dc->a->c_str());
 }
 
 namespace {

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -233,7 +233,8 @@ TEST_F(AutoConfigTest, ContextGetObservable) {
   AutoRequired<MyConfigurableClass> mcc;
 
   mcc->obs = 10442;
-  EXPECT_EQ("10442", ctxt->Config.Get("obs")) << "Observable value set directly not updated in the context.";
+  const std::string& val = ctxt->Config.Get("obs");
+  EXPECT_EQ("10442", val) << "Observable value set directly not updated in the context.";
 
   ctxt->Config.Set("b", "10443");
   EXPECT_EQ(10443, mcc->b) << "Non-Observable value set in the context not modified in the backing value.";

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -228,18 +228,6 @@ TEST_F(AutoConfigTest, ContextGetSimple) {
   ASSERT_EQ(10443, mcc->b) << "Non-Observable value set in the context not modified in the backing value.";
 }
 
-TEST_F(AutoConfigTest, ContextGetObservable) {
-  AutoCurrentContext ctxt;
-  AutoRequired<MyConfigurableClass> mcc;
-
-  mcc->obs = 10442;
-  const std::string& val = ctxt->Config.Get("obs");
-  ASSERT_EQ("10442", val) << "Observable value set directly not updated in the context.";
-
-  ctxt->Config.Set("b", "10443");
-  ASSERT_EQ(10443, mcc->b) << "Non-Observable value set in the context not modified in the backing value.";
-}
-
 TEST_F(AutoConfigTest, ContextMultiReference) {
   AutoCurrentContext ctxt;
   AutoRequired<MyConfigurableClass> mcc;

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -246,12 +246,19 @@ TEST_F(AutoConfigTest, ContextMultiReference) {
   AutoRequired<DuplicateClass> dc;
 
   const auto expectStr1 = "Hello Multiverse";
-  mcc->a = expectStr1;
-  ASSERT_STREQ(expectStr1, dc->a->c_str());
-  ASSERT_STREQ(expectStr1, ctxt->Config.Get("a").c_str());
+  mcc->a.force_assign(expectStr1);
+  ASSERT_STREQ("Hello world", dc->a->c_str());
+  ASSERT_STREQ("Hello world!", ctxt->Config.Get("a").c_str());
+
+  ASSERT_TRUE(mcc->a.clear_dirty());
+  ASSERT_TRUE(dc->a.clear_dirty());
 
   const auto expectStr2 = "Hello Universe 616";
   ctxt->Config.Set("a", expectStr2);
+  ASSERT_TRUE(mcc->a.is_dirty());
+  ASSERT_TRUE(dc->a.is_dirty());
+  mcc->a.clear_dirty();
+  dc->a.clear_dirty();
   ASSERT_STREQ(expectStr2, mcc->a->c_str());
   ASSERT_STREQ(expectStr2, dc->a->c_str());
 }


### PR DESCRIPTION
Auto config does not behave as expected when setting values directly from a field that is injected into a context.
