### PR TITLE
Rearrange m_valud and val to ease alignment

### DIFF
--- a/src/autowiring/optional.h
+++ b/src/autowiring/optional.h
@@ -42,8 +42,8 @@ public:
   }
 
 private:
-  bool m_valid = false;
   uint8_t val[sizeof(T)];
+  bool m_valid = false;
 
   T& _value(void) { return *reinterpret_cast<T*>(val); }
   const T& _value(void) const { return *reinterpret_cast<const T*>(val); }

--- a/src/autowiring/test/OptionalTest.cpp
+++ b/src/autowiring/test/OptionalTest.cpp
@@ -6,6 +6,15 @@ class OptionalTest :
   public testing::Test
 {};
 
+namespace {
+  class AUTO_ALIGNAS(32) MyAlignedClass {};
+}
+
+static_assert(
+  AUTO_ALIGNOF(optional<MyAlignedClass>) == 32,
+  "Automatic alignment did not occur for an aligned type as expected"
+);
+
 TEST_F(OptionalTest, PrimitiveCheck) {
   optional<int> x;
   ASSERT_FALSE(x);
@@ -15,6 +24,7 @@ TEST_F(OptionalTest, PrimitiveCheck) {
   ASSERT_TRUE(x);
   x = {};
   ASSERT_FALSE(x);
+  ASSERT_EQ((void*)&x, (void*)&x.value()) << "Expected value to be at the top of optional";
 }
 
 TEST_F(OptionalTest, DestructionCheck) {

--- a/src/autowiring/test/OptionalTest.cpp
+++ b/src/autowiring/test/OptionalTest.cpp
@@ -13,9 +13,9 @@ TEST_F(OptionalTest, PrimitiveCheck) {
   ASSERT_TRUE(x);
   x = 0;
   ASSERT_TRUE(x);
+  ASSERT_EQ((void*)&x, (void*)&x.value()) << "Expected value to be at the top of optional";
   x = {};
   ASSERT_FALSE(x);
-  ASSERT_EQ((void*)&x, (void*)&x.value()) << "Expected value to be at the top of optional";
 }
 
 TEST_F(OptionalTest, DestructionCheck) {

--- a/src/autowiring/test/OptionalTest.cpp
+++ b/src/autowiring/test/OptionalTest.cpp
@@ -6,15 +6,6 @@ class OptionalTest :
   public testing::Test
 {};
 
-namespace {
-  class AUTO_ALIGNAS(32) MyAlignedClass {};
-}
-
-static_assert(
-  AUTO_ALIGNOF(optional<MyAlignedClass>) == 32,
-  "Automatic alignment did not occur for an aligned type as expected"
-);
-
 TEST_F(OptionalTest, PrimitiveCheck) {
   optional<int> x;
   ASSERT_FALSE(x);


### PR DESCRIPTION
We use `val` to store the actual structure under construction.  Put it first so it's aligned the same way as `optional`.