### PR TITLE
Add invoke feature to signal

### DIFF
--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -99,6 +99,7 @@ set(Autowiring_SRCS
   demangle.h
   deref_error.h
   deref_error.cpp
+  dereferencer.h
   Deserialize.h
   dispatch_aborted_exception.h
   dispatch_aborted_exception.cpp

--- a/src/autowiring/callable.h
+++ b/src/autowiring/callable.h
@@ -1,6 +1,8 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include "index_tuple.h"
 #include <memory>
+#include <tuple>
 
 namespace autowiring {
   // Callable wrapper type, always invoked in a synchronized context
@@ -10,8 +12,32 @@ namespace autowiring {
     callable_base* m_pFlink = nullptr;
   };
 
-  template<typename Fn>
+  template<typename Fn, typename... Args>
   struct callable :
+    callable_base
+  {
+    callable(Fn&& fn, Args&&... args) :
+      fn(std::move(fn)),
+      args(std::forward<Args>(args)...)
+    {}
+
+    Fn fn;
+    std::tuple<typename std::decay<Args>::type...> args;
+
+    template<int... N>
+    void call(index_tuple<N...>) {
+      fn(
+        std::move(std::get<N>(args))...
+      );
+    }
+
+    void operator()() override {
+      call(typename make_index_tuple<sizeof...(Args)>::type{});
+    }
+  };
+
+  template<typename Fn>
+  struct callable<Fn> :
     callable_base
   {
     callable(Fn&& fn) : fn(std::move(fn)) {}

--- a/src/autowiring/dereferencer.h
+++ b/src/autowiring/dereferencer.h
@@ -1,0 +1,58 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+
+namespace autowiring {
+  namespace detail {
+    // Holds true if type T can be copied safely
+    template<typename T>
+    struct can_copy {
+      static const bool value =
+        !std::is_abstract<T>::value &&
+        std::is_copy_constructible<T>::value;
+    };
+
+    // Utility type for handling dereferencing of an input value
+    template<typename T, typename = void>
+    struct dereferencer
+    {
+      static_assert(std::is_copy_constructible<T>::value, "T must be copy constructable");
+      static_assert(!std::is_abstract<T>::value, "T cannot be abstract");
+
+      dereferencer(dereferencer&& rhs) : val(std::move(rhs.val)) {}
+      dereferencer(T&& val) : val(std::move(val)) {}
+      T val;
+      const T& operator*(void) const { return val; }
+    };
+
+    template<typename T>
+    struct dereferencer<T&&, void>
+    {
+      dereferencer(dereferencer&& rhs) : val(std::move(rhs.val)) {}
+      dereferencer(T&& val) : val(std::move(val)) {}
+      T val;
+      const T& operator*(void) const { return val; }
+    };
+
+    /// <summary>
+    /// Copyable reference argument
+    /// </summary>
+    template<typename T>
+    struct dereferencer<T&, typename std::enable_if<!can_copy<T>::value>::type> {
+      dereferencer(const dereferencer& rhs) : val(rhs.val) {}
+      dereferencer(const T& val) : val(val) {}
+      const T& val;
+      const T& operator*(void) const { return val; }
+    };
+
+    /// <summary>
+    /// Non-copyable reference argument
+    /// </summary>
+    template<typename T>
+    struct dereferencer<T&, typename std::enable_if<can_copy<T>::value>::type> {
+      dereferencer(dereferencer&& rhs) : val(std::move(rhs.val)) {}
+      dereferencer(const T& val) : val(val) {}
+      T val;
+      const T& operator*(void) const { return val; }
+    };
+  }
+}

--- a/src/autowiring/index_tuple.h
+++ b/src/autowiring/index_tuple.h
@@ -1,5 +1,6 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
+#include <type_traits>
 
 namespace autowiring {
 

--- a/src/autowiring/registration.h
+++ b/src/autowiring/registration.h
@@ -31,6 +31,10 @@ namespace autowiring {
       rhs.pobj = nullptr;
     }
 
+    void clear(void) {
+      *owner -= *this;
+    }
+
     operator bool(void) const { return pobj != nullptr; }
   };
 }

--- a/src/autowiring/registration.h
+++ b/src/autowiring/registration.h
@@ -32,7 +32,8 @@ namespace autowiring {
     }
 
     void clear(void) {
-      *owner -= *this;
+      if(pobj)
+        *owner -= *this;
     }
 
     operator bool(void) const { return pobj != nullptr; }

--- a/src/autowiring/signal.h
+++ b/src/autowiring/signal.h
@@ -593,12 +593,10 @@ namespace autowiring {
     template<typename Fn>
     void invoke(Fn&& fn) {
       // For a discussion of what's happening here, see the operator() overload
-      if (!try_enter()) {
-        handoff(
+      if (!try_enter())
+        return handoff(
           new callable<Fn>{ std::forward<Fn&&>(fn) }
         );
-        return;
-      }
 
       // We've entered the asserting state succesfully.  Invoke the function and then leave the state.
       fn();

--- a/src/autowiring/signal.h
+++ b/src/autowiring/signal.h
@@ -501,6 +501,44 @@ namespace autowiring {
     }
 
     /// <summary>
+    /// Locks the signal's asserting state
+    /// </summary>
+    /// <remarks>
+    /// Be warned:  The underlying system is implemented using a spin lock.  No part of signal invokes
+    /// the lock method, instead using try_lock and wait-free algorithms underneath.
+    ///
+    /// Furthermore, this signal does not actually prevent the signal from becoming asserted; rather,
+    /// it only prevents other threads from invoking handlers registered on this signal.
+    ///
+    /// As with any spin lock, users are urged to minimize the amount of time the signal is locked.
+    ///
+    /// This method will deadlock if it is invoked and the caller already owns the lock.
+    ///
+    /// This method will deadlock if it is invoked from within a signal handler.
+    /// </remarks>
+    void lock(void) {
+      while(!try_enter());
+    }
+
+    /// <summary>
+    /// Prospective equivalent of lock.
+    /// </summary>
+    bool try_lock(void) {
+      return try_enter();
+    }
+
+    /// <summary>
+    /// Unlocks the signal's asserting state
+    /// </summary>
+    /// <remarks>
+    /// This routine leaves the asserting state, but also executes any deferred dispatchers that may
+    /// have been registered.
+    /// </remarks>
+    void unlock(void) AUTO_NOEXCEPT {
+      leave();
+    }
+
+    /// <summary>
     /// Attaches the specified handler to this signal
     /// </summary>
     /// <remarks>

--- a/src/autowiring/signal.h
+++ b/src/autowiring/signal.h
@@ -539,19 +539,19 @@ namespace autowiring {
     ///
     /// fn must not throw unhandled exceptions.
     /// </remarks>
-    template<typename Fn, typename... Args>
-    void invoke(Fn&& fn, Args&&... args) {
+    template<typename Fn, typename... FnArgs>
+    void invoke(Fn&& fn, FnArgs&&... args) {
       // For a discussion of what's happening here, see the operator() overload
       if (!try_enter())
         return handoff(
-          new callable<Fn, Args...>{
+          new callable<Fn, FnArgs...>{
             std::forward<Fn>(fn),
-            std::forward<Args>(args)...
+            std::forward<FnArgs>(args)...
           }
         );
 
       // We've entered the asserting state succesfully.  Invoke the function and then leave the state.
-      fn(std::forward<Args>(args)...);
+      fn(std::forward<FnArgs>(args)...);
       leave();
     }
 

--- a/src/autowiring/signal.h
+++ b/src/autowiring/signal.h
@@ -528,6 +528,8 @@ namespace autowiring {
     /// <summary>
     /// Invokes the specified function in the call order of this signal
     /// </summary>
+    /// <param name="fn">The function to be invoked</param>
+    /// <param name="args">The arguments to be forwarded to the function</param>
     /// <remarks>
     /// The signal's call-order is a single total order, with respect to just this signal, in which
     /// calls are made.  No call is made on this signal while another call is still underway.
@@ -537,16 +539,19 @@ namespace autowiring {
     ///
     /// fn must not throw unhandled exceptions.
     /// </remarks>
-    template<typename Fn>
-    void invoke(Fn&& fn) {
+    template<typename Fn, typename... Args>
+    void invoke(Fn&& fn, Args&&... args) {
       // For a discussion of what's happening here, see the operator() overload
       if (!try_enter())
         return handoff(
-          new callable<Fn>{ std::forward<Fn&&>(fn) }
+          new callable<Fn, Args...>{
+            std::forward<Fn>(fn),
+            std::forward<Args>(args)...
+          }
         );
 
       // We've entered the asserting state succesfully.  Invoke the function and then leave the state.
-      fn();
+      fn(std::forward<Args>(args)...);
       leave();
     }
 

--- a/src/autowiring/signal.h
+++ b/src/autowiring/signal.h
@@ -5,6 +5,7 @@
 #include "autowiring_error.h"
 #include "callable.h"
 #include "Decompose.h"
+#include "dereferencer.h"
 #include "index_tuple.h"
 #include "noop.h"
 #include "registration.h"
@@ -21,60 +22,6 @@
 namespace autowiring {
   template<typename T>
   struct signal;
-
-  namespace detail {
-    // Holds true if type T can be copied safely
-    template<typename T>
-    struct can_copy {
-      static const bool value =
-        !std::is_abstract<T>::value &&
-        std::is_copy_constructible<T>::value;
-    };
-
-    // Utility type for handling dereferencing of an input value
-    template<typename T, typename = void>
-    struct dereferencer
-    {
-      static_assert(std::is_copy_constructible<T>::value, "T must be copy constructable");
-      static_assert(!std::is_abstract<T>::value, "T cannot be abstract");
-
-      dereferencer(dereferencer&& rhs) : val(std::move(rhs.val)) {}
-      dereferencer(T&& val) : val(std::move(val)) {}
-      T val;
-      const T& operator*(void) const { return val; }
-    };
-
-    template<typename T>
-    struct dereferencer<T&&, void>
-    {
-      dereferencer(dereferencer&& rhs) : val(std::move(rhs.val)) {}
-      dereferencer(T&& val) : val(std::move(val)) {}
-      T val;
-      const T& operator*(void) const { return val; }
-    };
-
-    /// <summary>
-    /// Copyable reference argument
-    /// </summary>
-    template<typename T>
-    struct dereferencer<T&, typename std::enable_if<!can_copy<T>::value>::type> {
-      dereferencer(const dereferencer& rhs) : val(rhs.val) {}
-      dereferencer(const T& val) : val(val) {}
-      const T& val;
-      const T& operator*(void) const { return val; }
-    };
-
-    /// <summary>
-    /// Non-copyable reference argument
-    /// </summary>
-    template<typename T>
-    struct dereferencer<T&, typename std::enable_if<can_copy<T>::value>::type> {
-      dereferencer(dereferencer&& rhs) : val(std::move(rhs.val)) {}
-      dereferencer(const T& val) : val(val) {}
-      T val;
-      const T& operator*(void) const { return val; }
-    };
-  }
 
   // Current state of the signal, used as a type of lock.
   enum class SignalState {

--- a/src/autowiring/test/AutoSignalTest.cpp
+++ b/src/autowiring/test/AutoSignalTest.cpp
@@ -787,3 +787,18 @@ TEST_F(AutoSignalTest, CannotEnterInHandler) {
 
   ASSERT_FALSE(relocked) << "Was incorrectly able to lock a signal from within its handler";
 }
+
+TEST_F(AutoSignalTest, MoveInInvoke) {
+  autowiring::signal<void()> x;
+
+  std::unique_ptr<int> vRecovered;
+  x.invoke(
+    [&] (std::unique_ptr<int> v) {
+      vRecovered = std::move(v);
+    },
+    std::unique_ptr<int>(new int(404))
+  );
+
+  ASSERT_NE(nullptr, vRecovered);
+  ASSERT_EQ(404, *vRecovered) << "Recovered unique pointer was not the expected value";
+}


### PR DESCRIPTION
Invoke gives users a way to run an arbitrary function in the call order of a signal.  This can be useful when a small amount of setup work is necessary for a single listener, and that setup work must happen in the call order of the event being registered.

It can also be useful in running a lambda after all other signals have been registered.

One complex use case:

```C++
std::string value;
autowiring::signal<void()> onChanged;
onChanged.invoke([&] {
  // Register the handler in the signal's synchronization context.
  onChanged += [&] {
    // This gets invoked after all signal handlers for the current signal are done
    onChanged.invoke([this] {
      std::cout << "All done!" << std::endl;
    });
  };

  // Now we can also take a snapshot of the value the signal might be referencing.
  std::cout << "Value is " << value << std::endl;
});

// This might possibly be how a user would update the value without needing a mutex to do so
std::string newValue;
onChanged.invoke([&, newValue] {
  value = newValue;
});
```