### PR TITLE
Fix subcontext config propagation

### DIFF
--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -65,6 +65,7 @@ set(Autowiring_SRCS
   config.h
   config_descriptor.h
   config_descriptor.cpp
+  config_event.h
   ConfigBolt.h
   ConfigBolt.cpp
   ConfigManager.h

--- a/src/autowiring/ConfigManager.cpp
+++ b/src/autowiring/ConfigManager.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ConfigManager.h"
+#include "ConfigRegistry.h"
 #include "at_exit.h"
 #include <mutex>
 #include <unordered_set>
@@ -9,47 +10,78 @@ using namespace autowiring;
 
 struct entry {};
 
-ConfigManager::ConfigManager(void) :
-  m_empty("")
-{}
+ConfigManager::ConfigManager(std::shared_ptr<ConfigManager> pParent) :
+  m_pParent(pParent)
+{
+  if (pParent)
+    // No defaulting work needed, we can end here
+    return;
 
-void ConfigManager::Register(void* pObj, const config_descriptor& desc) {
+  // The root configuration manager will prepopulate itself with a total traversal of all elements
+  for (const config_descriptor& descriptor : config_registry{})
+    for (const auto& field_entry : descriptor.fields) {
+      const config_field& field = field_entry.second;
+
+      Entry& entry = m_config[field_entry.first];
+
+      // If there's a default value on this field, try to marshal it, otherwise the field stays blank
+      if (field.default_value)
+        entry.value = field.marshaller->marshal(field.default_value.ptr());
+    }
+}
+
+void ConfigManager::Clear(void) {
+  // Clear any recursive handlers created by binding to a default value
+  for (auto& q : m_config) {
+    Entry& entry = q.second;
+    entry.reg.clear();
+  }
+
+  // Unlink from the parent
+  m_pParent = {};
+}
+
+void ConfigManager::Register(std::shared_ptr<void> pObj, const config_descriptor& desc) {
   // Deferred call registrations:
   std::vector<std::pair<WhenWatcher*, const config_event*>> deferred;
 
-  {
-    std::lock_guard<autowiring::spin_lock> lk(m_lock);
+  // Byte object base, held for convenience
+  uint8_t* pObjBase = static_cast<uint8_t*>(pObj.get());
 
+  {
     // This goes through all of the fields in the user-specified descriptor.  These fields describe offsets
     // in pObj, and each one could require us to either populate offsets in pObj with values that we are
     // keeping in m_config, or it could require us to update m_config based on metadata described by these
     // fields.
     for (const auto& field : desc.fields) {
       const config_field& field_desc = field.second;
+      void* pField = pObjBase + field_desc.offset;
 
       // We need to attach this field to the corresponding configuration entry, we perform the attachment by
       // name.  After we have our entry we can fill it or use it to fill other objects as needed.
-      Entry& entry = m_config[field_desc.name];
-      entry.attached.emplace_back(
-        field_desc,
-        static_cast<uint8_t*>(pObj) + field_desc.offset
-      );
-
-      Entry::Attachment& attachment = entry.attached.back();
-      if (entry.value)
-        // We have a value already.  Force the attachment's field to take on the value we
-        // are storing locally.
-        attachment.configField->marshaller->unmarshal(attachment.pField, entry.value->c_str());
-      else {
-        // Descriptor must provide a default value, and we do not have a value ourselves in our own
-        // local config store.  In this case, we take the default value, and unconditionally overwrite
-        // the value currently present on the object.
-        entry.value = attachment.configField->marshaller->marshal(attachment.configField->default_value.ptr());
-        field_desc.marshaller->copy(attachment.pField, attachment.configField->default_value.ptr());
+      Entry& entry = GetEntryUnsafe(field_desc.name);
+      metadata_pack_base* pBoundMetadata;
+      {
+        entry.attached.emplace_back(field_desc, pField);
+        pBoundMetadata = entry.attached.back().bound_metadata.get();
       }
 
+      // Register a change handler with this object.  Also hold a reference to the object's shared
+      // pointer, we want to prevent the enclosing object's destruction as long as the entry is
+      // invoking.
+      const marshaller_base* marshaller = field_desc.marshaller;
+      entry.onChanged << [pObj, marshaller, pField, &entry] {
+        // register the handler
+        entry.onChanged += [pObj, marshaller, pField, &entry] {
+          marshaller->unmarshal(pField, entry.value.c_str());
+        };
+
+        // Take the default value
+        marshaller->unmarshal(pField, entry.value.c_str());
+      };
+
       // Deferred signalling on all watcher collections.  This part causes When handlers to be invoked.
-      const std::vector<const metadata_base*>& all_metadata = attachment.bound_metadata->get_list();
+      const std::vector<const metadata_base*>& all_metadata = pBoundMetadata->get_list();
       for (const auto& m : all_metadata) {
         auto q = metadata_collection.emplace(
           std::piecewise_construct,
@@ -89,26 +121,99 @@ void ConfigManager::WhenInternal(const std::shared_ptr<WhenWatcher>& watcher) {
     w.OnMetadata(*match);
 }
 
-const std::string& ConfigManager::Get(std::string name) const {
+ConfigManager::Entry& ConfigManager::GetEntryUnsafe(const std::string& name) {
   auto q = m_config.find(name);
-  if (q == m_config.end())
-    return m_empty;
+  if (q != m_config.end())
+    return q->second;
 
-  return *q->second.value;
+  auto& configEntry = m_config[name];
+  if (!m_pParent)
+    // No parent, no recursive registration possible
+    return configEntry;
+
+  // Need to ensure this value is correctly updated on parent value modifications
+  auto& parentEntry = m_pParent->GetEntry(name);
+
+  // Need to register ourselves and take a value in the sequence order of the parent:
+  auto self = shared_from_this();
+  parentEntry.onChanged << [self, &configEntry, &parentEntry] {
+    // Now we can perform a registration while nothing else is going on
+    configEntry.reg = parentEntry.onChanged += [self, &configEntry, &parentEntry] {
+      // Double-check that we are still registered.  Technically we can become
+      // unregistered while a signal is underway, which means that the entity
+      // performing the unregistration has kicked off a new call to setValue
+      if (!configEntry.reg)
+        return;
+
+      // Take a copy to our local total order, notify everyone:
+      configEntry.onChanged.invoke(
+        [&] (std::string&& valueCopy) {
+          configEntry.value = std::move(valueCopy);
+        },
+        std::string{ parentEntry.value }
+      );
+      configEntry.onChanged();
+    };
+
+    // And we want to take a snapshot of the value and store it in ourselves:
+    configEntry.onChanged.invoke(
+      [&] (std::string&& valueCopy) {
+        configEntry.value = std::move(valueCopy);
+      },
+      std::string{ parentEntry.value }
+    );
+  };
+  return configEntry;
+}
+
+ConfigManager::Entry& ConfigManager::GetEntry(const std::string& name) {
+  std::lock_guard<autowiring::spin_lock> lk(m_lock);
+  return GetEntryUnsafe(name);
+}
+
+std::string ConfigManager::Get(const std::string& name) const {
+  const Entry* pEntry;
+  {
+    std::lock_guard<autowiring::spin_lock> lk(m_lock);
+    auto q = m_config.find(name);
+    pEntry = q == m_config.end() ? nullptr : &q->second;
+  }
+
+  if (!pEntry)
+    return m_pParent ? m_pParent->Get(name) : "";
+
+  // Lock the signal to prevent the value from being changed:
+  std::lock_guard<signal<void()>> lk(pEntry->onChanged);
+  return pEntry->value;
 }
 
 void ConfigManager::Set(std::string&& name, std::string&& value) {
-  std::lock_guard<autowiring::spin_lock> lk(m_lock);
-  auto q = m_config.find(name);
-  if (q == m_config.end())
-    q = m_config.emplace(std::move(name), Entry{}).first;
+  Entry* pEntry;
 
-  Entry& entry = q->second;
-  entry.value = std::move(value);
+  {
+    std::lock_guard<autowiring::spin_lock> lk(m_lock);
+    auto q = m_config.find(name);
+    if (q == m_config.end())
+      q = m_config.emplace(std::move(name), Entry{}).first;
 
-  for (Entry::Attachment& attachment : entry.attached)
-    attachment.configField->marshaller->unmarshal(
-      attachment.pField,
-      entry.value->c_str()
-    );
+    pEntry = &q->second;
+
+    // If we are registered on this level, we need to unregister with the parent,
+    // because this level is overriding the parent's value
+    if (pEntry->reg)
+      pEntry->reg.clear();
+  }
+
+  // Sequenced value assignment:
+  pEntry->onChanged.invoke(
+    [pEntry] (std::string&& rhs) {
+      pEntry->value = std::move(rhs);
+    },
+    std::move(value)
+  );
+  pEntry->onChanged();
+}
+
+void ConfigManager::Default(std::string name) {
+
 }

--- a/src/autowiring/ConfigManager.h
+++ b/src/autowiring/ConfigManager.h
@@ -2,6 +2,7 @@
 #pragma once
 #include "auto_id.h"
 #include "config_descriptor.h"
+#include "config_event.h"
 #include "Decompose.h"
 #include "optional.h"
 #include "spin_lock.h"
@@ -11,29 +12,6 @@
 #include <vector>
 
 namespace autowiring {
-  struct config_event {
-    config_event(void) = default;
-    config_event(void* pObj, const config_descriptor* desc, const config_field* field_desc, const metadata_base* metadata) :
-      pObj(pObj),
-      desc(desc),
-      field_desc(field_desc),
-      metadata(metadata)
-    {}
-
-    // A pointer to the enclosing object on which the event is being asserted
-    void* pObj;
-
-    // A pointer to the field itself
-    void* field(void) const {
-      return static_cast<char*>(pObj) + field_desc->offset;
-    }
-
-    // Metadata and descriptor pointers
-    const config_descriptor* desc;
-    const config_field* field_desc;
-    const metadata_base* metadata;
-  };
-
   struct WhenWatcher {
     WhenWatcher(auto_id id) :
       id(id)

--- a/src/autowiring/config_event.h
+++ b/src/autowiring/config_event.h
@@ -9,7 +9,7 @@ struct metadata_base;
 
 struct config_event {
   config_event(void) = default;
-  config_event(void* pObj, const config_descriptor* desc, const config_field* field_desc, const metadata_base* metadata) :
+  config_event(std::shared_ptr<void> pObj, const config_descriptor* desc, const config_field* field_desc, const metadata_base* metadata) :
     pObj(pObj),
     desc(desc),
     field_desc(field_desc),
@@ -17,11 +17,11 @@ struct config_event {
   {}
 
   // A pointer to the enclosing object on which the event is being asserted
-  void* pObj;
+  std::shared_ptr<void> pObj;
 
   // A pointer to the field itself
   void* field(void) const {
-    return static_cast<char*>(pObj) + field_desc->offset;
+    return static_cast<char*>(pObj.get()) + field_desc->offset;
   }
 
   // Metadata and descriptor pointers

--- a/src/autowiring/config_event.h
+++ b/src/autowiring/config_event.h
@@ -1,0 +1,32 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#pragma once
+#include "config_descriptor.h"
+
+namespace autowiring {
+struct config_descriptor;
+struct config_field;
+struct metadata_base;
+
+struct config_event {
+  config_event(void) = default;
+  config_event(void* pObj, const config_descriptor* desc, const config_field* field_desc, const metadata_base* metadata) :
+    pObj(pObj),
+    desc(desc),
+    field_desc(field_desc),
+    metadata(metadata)
+  {}
+
+  // A pointer to the enclosing object on which the event is being asserted
+  void* pObj;
+
+  // A pointer to the field itself
+  void* field(void) const {
+    return static_cast<char*>(pObj) + field_desc->offset;
+  }
+
+  // Metadata and descriptor pointers
+  const config_descriptor* desc;
+  const config_field* field_desc;
+  const metadata_base* metadata;
+};
+}

--- a/src/autowiring/signal.h
+++ b/src/autowiring/signal.h
@@ -556,6 +556,15 @@ namespace autowiring {
     }
 
     /// <summary>
+    /// Identical to invoke with no arguments
+    /// </summary>
+    template<typename Fn>
+    signal& operator<<(Fn&& fn) {
+      invoke<Fn>(std::forward<Fn>(fn));
+      return *this;
+    }
+
+    /// <summary>
     /// Raises the signal and invokes all attached handlers
     /// </summary>
     /// <param name="args">

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -252,6 +252,26 @@ TEST_F(AutoConfigTest, ContextMultiReference) {
   ASSERT_STREQ(expectStr2, dc->a->c_str());
 }
 
+TEST_F(AutoConfigTest, SubContextPropogation) {
+  AutoCurrentContext ctxt;
+  AutoCreateContext subCtxt(ctxt);
+
+  std::shared_ptr<MyConfigurableClass> mcc = subCtxt->Inject<MyConfigurableClass>();
+  ctxt->Config.Set("b", "10442");
+
+  ASSERT_EQ(mcc->b, 10442) << "Setting of the \'b\' config was not propogated to the sub context.";
+}
+
+TEST_F(AutoConfigTest, SubContextDelayedPropogation) {
+  AutoCurrentContext ctxt;
+  AutoCreateContext subCtxt(ctxt);
+
+  ctxt->Config.Set("b", "10442");
+  std::shared_ptr<MyConfigurableClass> mcc = subCtxt->Inject<MyConfigurableClass>();
+
+  ASSERT_EQ(mcc->b, 10442) << "Setting of the \'b\' config was not propogated to the sub context when it was injected after \'b\' was set.";
+}
+
 namespace {
   class slider
   {

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -252,7 +252,7 @@ TEST_F(AutoConfigTest, ContextMultiReference) {
   ASSERT_STREQ(expectStr2, dc->a->c_str());
 }
 
-TEST_F(AutoConfigTest, SubContextPropogation) {
+TEST_F(AutoConfigTest, SubContextPropagation) {
   AutoCurrentContext ctxt;
   AutoCreateContext subCtxt(ctxt);
 
@@ -262,7 +262,7 @@ TEST_F(AutoConfigTest, SubContextPropogation) {
   ASSERT_EQ(mcc->b, 10442) << "Setting of the \'b\' config was not propogated to the sub context.";
 }
 
-TEST_F(AutoConfigTest, SubContextDelayedPropogation) {
+TEST_F(AutoConfigTest, SubContextDelayedPropagation) {
   AutoCurrentContext ctxt;
   AutoCreateContext subCtxt(ctxt);
 

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -327,5 +327,18 @@ TEST_F(AutoConfigTest, CanEnumRegistry) {
         nFound++;
     }
   }
-  ASSERT_EQ(1, nFound) << "Failed to find a descriptor field in the total descriptor enumeration";
+  ASSERT_EQ(1U, nFound) << "Failed to find a descriptor field in the total descriptor enumeration";
+}
+
+TEST_F(AutoConfigTest, TeardownUnreference) {
+  std::weak_ptr<ClassWithBoundsField> cwbf_weak;
+  AutoCurrentContext ctxt;
+  ctxt->Config.Set("crazyjenkins", "29291");
+
+  {
+    AutoCreateContext child;
+    AutoRequired<ClassWithBoundsField> cwbf{ child };
+    cwbf_weak = cwbf;
+  }
+  ASSERT_TRUE(cwbf_weak.expired()) << "Object leaked after context destruction";
 }


### PR DESCRIPTION
The feature allowing value propagation into subcontexts during assignment or instantiation was not actually implemented.  Provide it so that configuration users do not need to use bolts to do this by hand.