### PR TITLE
Fix NotifyWhenAutowired not working with some types

### DIFF
--- a/src/autowiring/AutowirableSlot.h
+++ b/src/autowiring/AutowirableSlot.h
@@ -219,6 +219,17 @@ public:
 
     return *retVal;
   }
+
+  //This ensures that the callback will be properly triggered if using a derived type
+  template<class Fn>
+  void NotifyWhenAutowired(Fn&& fn) {
+    // We have to initialize here, in the operator context, because we don't actually know if the
+    // user will be making use of this type.
+    (void)fast_pointer_cast_initializer<T, CoreObject>::sc_init;
+    (void)auto_id_t_init<T>::init;
+
+    DeferrableAutowiring::NotifyWhenAutowired(fn);
+  }
 };
 
 template<typename T>

--- a/src/autowiring/test/PostConstructTest.cpp
+++ b/src/autowiring/test/PostConstructTest.cpp
@@ -142,6 +142,48 @@ TEST_F(PostConstructTest, VerifyTrivialNotifyWhenAutowired) {
   ASSERT_TRUE(called) << "An autowiring notification was not invoked on an already-satisfied field as expected";
 }
 
+TEST_F(PostConstructTest, DelayedNotifyWhenAutowired) {
+  // Autorequire, and add a registration:
+  bool called = false;
+  Autowired<SimpleObject> so;
+  so.NotifyWhenAutowired([&called] { called = true; });
+
+  // Inject a type after:
+  AutoRequired<SimpleObject>();
+  ASSERT_TRUE(called) << "An autowiring notification was not invoked on an already-satisfied field as expected";
+}
+
+struct Interface2 : ContextMember {};
+struct Implementation2 : Interface2 {
+};
+
+TEST_F(PostConstructTest, DeriveNotifyWhenAutowired) {
+
+  // Autorequire, and add a registration:
+  bool called = false;
+  Autowired<Interface2> interface;
+  interface.NotifyWhenAutowired([&called] { called = true; });
+
+  // Inject a type after:
+  AutoRequired<Implementation2>();
+  ASSERT_TRUE(called) << "An autowiring notification was not invoked on an already-satisfied field as expected";
+}
+
+struct Interface3 : ContextMember {};
+struct Implementation3 : Interface3 {
+};
+
+TEST_F(PostConstructTest, InjectNotifyWhenAutowired) {
+  // Autorequire, and add a registration:
+  bool called = false;
+  Autowired<Interface3> interface;
+  interface.NotifyWhenAutowired([&called] { called = true; });
+
+  // Inject a type after:
+  AutoCurrentContext()->Inject<Implementation3>();
+  ASSERT_TRUE(called) << "An autowiring notification was not invoked on an already-satisfied field as expected";
+}
+
 TEST_F(PostConstructTest, MultiNotifyWhenAutowired) {
   // Add multiple notifications on the same space:
   int field = 0;
@@ -155,6 +197,7 @@ TEST_F(PostConstructTest, MultiNotifyWhenAutowired) {
   // Verify that the notification got hit ten times:
   ASSERT_EQ(10, field) << "Autowiring lambdas did not run the expected number of times";
 }
+
 
 TEST_F(PostConstructTest, NotificationTeardownRace) {
   std::shared_ptr<CoreContext> pContext;

--- a/src/autowiring/test/PostConstructTest.cpp
+++ b/src/autowiring/test/PostConstructTest.cpp
@@ -198,6 +198,14 @@ TEST_F(PostConstructTest, MultiNotifyWhenAutowired) {
   ASSERT_EQ(10, field) << "Autowiring lambdas did not run the expected number of times";
 }
 
+/*
+ Compile time failure case:
+class ForwardDeclared;
+TEST_F(PostConstructTest, TestForwardDeclare) {
+  Autowired<ForwardDeclared> decl;
+  decl.NotifyWhenAutowired([]() {std::cout << "thing"; });
+}
+*/
 
 TEST_F(PostConstructTest, NotificationTeardownRace) {
   std::shared_ptr<CoreContext> pContext;


### PR DESCRIPTION
In order to work correctly the type must first be registered using auto_id_t. By adding the registration in the call to NotifyWhenAutowired, this problem is prevented at the expense of disallowing calls to NotifyWhenAutowired on forward declared types