### PR TITLE
Invert AutoFilter altitudes

### DIFF
--- a/src/autowiring/AutoFilterDescriptor.h
+++ b/src/autowiring/AutoFilterDescriptor.h
@@ -246,8 +246,8 @@ public:
   /// </summary>
   bool operator<(const AutoFilterDescriptor& rhs) const {
     return
-      std::tie(m_altitude, m_pCall, m_autoFilter) <
-      std::tie(rhs.m_altitude, rhs.m_pCall, rhs.m_autoFilter);
+      std::tie(rhs.m_altitude, rhs.m_pCall, rhs.m_autoFilter) <
+      std::tie(m_altitude, m_pCall, m_autoFilter);
   }
 
   // Operator overloads:

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -120,14 +120,14 @@ void AutoPacket::AddSatCounterUnsafe(SatCounter& satCounter) {
           throw autowiring_error(ss.str());
         }
 
-        if (it->altitude < satCounter.GetAltitude())
+        if (it->altitude > satCounter.GetAltitude())
           break;
         it++;
       }
       entry.m_modifiers.emplace(it, pCur->is_shared, satCounter.GetAltitude(), &satCounter);
     } else {
       if (pCur->is_input) {
-          entry.m_subscribers.emplace(
+        entry.m_subscribers.emplace(
           pCur->is_shared,
           pCur->is_multi ?
           DecorationDisposition::Subscriber::Type::Multi :
@@ -211,7 +211,8 @@ void AutoPacket::RemoveSatCounterUnsafe(const SatCounter& satCounter) {
           entry.m_modifiers.end(),
           [&satCounter](const DecorationDisposition::Modifier& modifier){
             return modifier.satCounter && *modifier.satCounter == satCounter;
-          }),
+          }
+        ),
         entry.m_modifiers.end()
       );
     } else {

--- a/src/autowiring/DecorationDisposition.h
+++ b/src/autowiring/DecorationDisposition.h
@@ -135,7 +135,7 @@ struct DecorationDisposition
     SatCounter* const satCounter;
 
     bool operator<(const Subscriber& rhs) const {
-      return std::tie(altitude, satCounter) > std::tie(rhs.altitude, rhs.satCounter);
+      return std::tie(altitude, satCounter) < std::tie(rhs.altitude, rhs.satCounter);
     }
   };
 

--- a/src/autowiring/altitude.h
+++ b/src/autowiring/altitude.h
@@ -25,16 +25,16 @@ namespace autowiring {
 enum class altitude {
   // Highest altitude level.  Reserved for temporary debug logic and other nonpermanent code that
   // must run before all other filter levels
-  Highest = 0x9000,
+  Highest =                 0x10000,
 
   // Instrumentation level, for use with instrumentation code.  Instrumentation code often needs to
   // observe the inputs to its AutoFilter before any other code has an opportunity to observe it,
   // because this code needs information about exactly when a decoration was first available.
-  Instrumentation = 0x8000,
+  Instrumentation =         0x20000,
 
   // Default altitude for Deferred autofilters.  Deferred autofilters are guaranteed to return very
   // quickly, even though they may do a lot of work, because they do not tie up the main thread.
-  Dispatch = 0x7000,
+  Dispatch =                0x30000,
 
   // Asynchronous filters are designed to be run with a higher priority than standard filters,
   // but are still expected to complete very quickly.  Because their speedy behavior is implemented
@@ -43,29 +43,33 @@ enum class altitude {
   //
   // It is expected that AutoFilters which are marked as Asynchronous will do the majority of their
   // work in an std::async or other similar call.
-  Asynchronous = 0x6000,
+  Asynchronous =            0x40000,
 
   // The realtime altitude is a higher-than-normal altitude which may have some tight timing requirements
   // but does not run in a separate thread.  Realtime filters run after deferred filters have been
   // scheduled to run.
-  Realtime = 0x5000,
+  Realtime =                0x50000,
 
   // Default altitude range.  Unless otherwise specified, or the filter is marked Deferred, filters
   // will normally execute at this priority level.
-  Standard = 0x4000,
+  Standard =                0x60000,
 
   // Altitude indicator for filters with no hard timing requirements.  This is a convenient place to put
   // filters that may have extensive CPU usage requirements, or which are not strongly impacted by timing.
   // Analytics and diagnostics are typically suitable for execution at the passive level.
-  Passive = 0x3000,
+  Passive =                 0x70000,
 
   // Lowest altitude level.  Reserved for temporary debug logic and other nonpermanent code that
   // must run after all other filter levels.
-  Lowest = 0x2000
+  Lowest =                  0x10000000
 };
 
 inline altitude operator+(altitude alt, int v) {
   return (altitude) ((int) alt + v);
+}
+
+inline altitude operator-(altitude alt, int v) {
+  return (altitude)((int)alt - v);
 }
 
 /// <summary>

--- a/src/autowiring/test/AutoFilterAltitudeTest.cpp
+++ b/src/autowiring/test/AutoFilterAltitudeTest.cpp
@@ -69,15 +69,15 @@ TEST_F(AutoFilterAltitudeTest, LambdaAltitudesOnFactory) {
 
   // Generate a packet and trip the assignments:
   auto packet = factory->NewPacket();
-  ASSERT_EQ(9, ctr[0]);
-  ASSERT_EQ(8, ctr[1]);
-  ASSERT_EQ(7, ctr[2]);
-  ASSERT_EQ(6, ctr[3]);
+  ASSERT_EQ(1, ctr[0]);
+  ASSERT_EQ(2, ctr[1]);
+  ASSERT_EQ(3, ctr[2]);
+  ASSERT_EQ(4, ctr[3]);
   ASSERT_EQ(5, ctr[4]);
-  ASSERT_EQ(4, ctr[5]);
-  ASSERT_EQ(3, ctr[6]);
-  ASSERT_EQ(2, ctr[7]);
-  ASSERT_EQ(1, ctr[8]);
+  ASSERT_EQ(6, ctr[5]);
+  ASSERT_EQ(7, ctr[6]);
+  ASSERT_EQ(8, ctr[7]);
+  ASSERT_EQ(9, ctr[8]);
 }
 
 TEST_F(AutoFilterAltitudeTest, AltitudeOnPacket) {


### PR DESCRIPTION
The original concept of an AutoFilter altitude causes the filter with the highest altitude value to be invoked first.  Unfortunately, this means that an enumeration defining the altitudes for use in a filter network must be declared in the reverse order of invocation, which is confusing.

Flip the altitude test around, and make lower filters run before higher filters.