### PR TITLE
Fix VS2015 compiler error

### DIFF
--- a/src/autotesting/AutowiringEnclosure.h
+++ b/src/autotesting/AutowiringEnclosure.h
@@ -86,6 +86,7 @@ public:
   {}
 
   const bool allowGlobalReferences;
+
   // The context that is current for the test being run right now
   std::shared_ptr<CoreContext> m_ctxt;
 

--- a/src/autowiring/CreationRules.h
+++ b/src/autowiring/CreationRules.h
@@ -105,7 +105,7 @@ struct crh<construction_strategy::standard, T, Args...> {
   // If T doesn't inherit Object, then we need to compose a unifying type which does
   typedef typename SelectTypeUnifier<T>::type TActual;
 
-  static_assert(!has_static_new<T, Args...>::value, "Can't inject member with arguments if it has a static New");
+  static_assert(!has_static_new<T, typename std::remove_reference<Args>::type...>::value, "Can't inject member with arguments if it has a static New");
 
   static TActual* New(const CoreContext&, Args&&... args) {
     // Allocate slot first before registration

--- a/src/autowiring/CreationRules.h
+++ b/src/autowiring/CreationRules.h
@@ -27,7 +27,7 @@ template<class T, class... Args>
 struct select_strategy {
   static const construction_strategy value =
     // If a factory new is defined, then use it
-    has_static_new<T, Args...>::value ?
+    has_static_new<T, typename std::remove_reference<Args>::type...>::value ?
     construction_strategy::factory_new :
 
     // Otherwise we give up and just try to compose the type directly

--- a/src/autowiring/config_descriptor.h
+++ b/src/autowiring/config_descriptor.h
@@ -43,11 +43,6 @@ namespace autowiring {
     return sc_marshaller;
   }
 
-  template<typename T>
-  struct matched_arg {
-    static T& value(void);
-  };
-
   template<typename T, typename... Args>
   struct has_bind
   {
@@ -55,7 +50,7 @@ namespace autowiring {
     static std::true_type select(
       decltype(
         static_cast<U*>(nullptr)->bind(
-          matched_arg<Args>::value()...
+          *(Args*)nullptr...
         )
       )*
     );

--- a/src/autowiring/config_descriptor.h
+++ b/src/autowiring/config_descriptor.h
@@ -91,18 +91,18 @@ namespace autowiring {
     M m_value;
 
     template<typename T>
-    typename std::enable_if<has_bind<M, T>::value>::type bind(const config_field&, T& field) {
+    typename std::enable_if<has_bind<M, typename std::remove_reference<T>::type>::value>::type bind(const config_field&, T& field) {
       m_value.bind(field);
     }
     template<typename T>
-    typename std::enable_if<has_bind<M, const config_field&, T>::value>::type bind(const config_field& fieldDesc, T& field) {
+    typename std::enable_if<has_bind<M, const config_field, typename std::remove_reference<T>>::value>::type bind(const config_field& fieldDesc, T& field) {
       m_value.bind(fieldDesc, field);
     }
 
     template<typename T>
     typename std::enable_if<
       !has_bind<M, T>::value &&
-      !has_bind<M, const config_field&, T>::value
+      !has_bind<M, const config_field, T>::value
     >::type bind(const config_field&, T&) {}
 
     auto_id id(void) const override { return auto_id_t<M>{}; }

--- a/src/autowiring/has_static_new.h
+++ b/src/autowiring/has_static_new.h
@@ -32,7 +32,7 @@ template<typename T, typename... Args>
 struct has_static_new
 {
   template<class U>
-  static std::true_type select(decltype(U::New(std::forward<Args>(*(typename std::remove_reference<Args>::type*)nullptr)...))*);
+  static std::true_type select(decltype(U::New(*(Args*)nullptr...))*);
 
   template<class U>
   static std::false_type select(...);

--- a/src/autowiring/has_static_new.h
+++ b/src/autowiring/has_static_new.h
@@ -40,4 +40,16 @@ struct has_static_new
   static const bool value = has_well_formed_static_new<T, decltype(select<T>(nullptr)), Args...>::value;
 };
 
+template<typename T>
+struct has_static_new<T>
+{
+	template<class U>
+	static std::true_type select(decltype(U::New())*);
+
+	template<class U>
+	static std::false_type select(...);
+
+	static const bool value = has_well_formed_static_new<T, decltype(select<T>(nullptr))>::value;
+};
+
 }

--- a/src/autowiring/has_static_new.h
+++ b/src/autowiring/has_static_new.h
@@ -32,7 +32,7 @@ template<typename T, typename... Args>
 struct has_static_new
 {
   template<class U>
-  static std::true_type select(decltype(U::New(*(Args*)nullptr...))*);
+  static std::true_type select(decltype(U::New((Args&&)*(Args*)nullptr...))*);
 
   template<class U>
   static std::false_type select(...);

--- a/src/autowiring/has_static_new.h
+++ b/src/autowiring/has_static_new.h
@@ -43,13 +43,13 @@ struct has_static_new
 template<typename T>
 struct has_static_new<T>
 {
-	template<class U>
-	static std::true_type select(decltype(U::New())*);
+  template<class U>
+  static std::true_type select(decltype(U::New())*);
 
-	template<class U>
-	static std::false_type select(...);
+  template<class U>
+  static std::false_type select(...);
 
-	static const bool value = has_well_formed_static_new<T, decltype(select<T>(nullptr))>::value;
+  static const bool value = has_well_formed_static_new<T, decltype(select<T>(nullptr))>::value;
 };
 
 }

--- a/src/autowiring/test/AutowiringTest.cpp
+++ b/src/autowiring/test/AutowiringTest.cpp
@@ -160,6 +160,16 @@ public:
   virtual int getValue(void) = 0;
 };
 
+static_assert(
+  autowiring::has_static_new<StaticNewInt>::value,
+  "Default static new not detected on StaticNewInt"
+);
+
+static_assert(
+  autowiring::has_static_new<StaticNewInt, std::unique_ptr<int>>::value,
+  "Static new with arguments not detected on StaticNewInt"
+);
+
 class StaticNewIntImpl:
   public StaticNewInt
 {


### PR DESCRIPTION
This is because MSVC sometimes has trouble expanding empty parameter packs into certain template substitution contexts.  Generally speaking a template specialization--such as this one--is a sure way to avoid the issue because it prevents an empty parameter pack from existing in the first place.