### PR TITLE
Fix bug in concurrent output debugging

### DIFF
--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -173,10 +173,12 @@ void autowiring::dbg::PrintRunnables(std::ostream& os, CoreContext& ctxt) {
         printCtxt.PrintAttributeIndentation();
         if (runnable->IsRunning())
           os << "[ RUNNING ]";
+        else if (runnable->ShouldStop())
+          os << "[ STOPPED ]";
         else if (runnable->WasStarted())
           os << "[ STARTED ]";
         else
-          os << "[ STOPPED ]";
+          os << "[ UNKNOWN ]";
 
         // If we can get the tid, print that, otherwise just leave it blank
         if (BasicThread* pThread = dynamic_cast<BasicThread*>(runnable)) {

--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -178,7 +178,7 @@ void autowiring::dbg::PrintRunnables(std::ostream& os, CoreContext& ctxt) {
         else if (runnable->WasStarted())
           os << "[ STARTED ]";
         else
-          os << "[ UNKNOWN ]";
+          os << "[ WAITING ]";
 
         // If we can get the tid, print that, otherwise just leave it blank
         if (BasicThread* pThread = dynamic_cast<BasicThread*>(runnable)) {


### PR DESCRIPTION
* If running right now, we're in the RUNNING state
* If we aren't running and we should stop, we are in the STOPPED state
* If we aren't running, shouldn't stop, but we were started, we're in the STARTING state
* Otherwise we haven't been started yet and are in the WAITING state