### PR TITLE
Fix marshaling of unsigned ints and 0

### DIFF
--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -7,6 +7,7 @@
 #include <stdexcept>
 #include <string>
 #include <string.h>
+#include <cstdlib>
 #include TYPE_TRAITS_HEADER
 
 namespace autowiring {
@@ -112,7 +113,12 @@ namespace autowiring {
     void unmarshal(void* ptr, const char* szValue) const override {
       type& value = *static_cast<type*>(ptr);
       char* end = nullptr;
-      value = strtol(szValue, &end, 10);
+      const auto llvalue = std::strtoll(szValue, &end, 10);
+
+      if (llvalue > std::numeric_limits<type>::max() || llvalue < std::numeric_limits<type>::min())
+        throw std::range_error("Overflow error, value is outside the range representable by this type.");
+
+      value = static_cast<type>(llvalue);
     }
 
     void copy(void* lhs, const void* rhs) const override {

--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -5,9 +5,11 @@
 #include <cmath>
 #include <limits>
 #include <stdexcept>
+
+#undef _GLIBCXX_HAVE_BROKEN_VSWPRINTF //Enable to_string in GCC 4.8.
 #include <string>
 #include <string.h>
-#include <cstdlib>
+#include <stdlib.h>
 #include TYPE_TRAITS_HEADER
 
 namespace autowiring {
@@ -113,7 +115,7 @@ namespace autowiring {
     void unmarshal(void* ptr, const char* szValue) const override {
       type& value = *static_cast<type*>(ptr);
       char* end = nullptr;
-      const auto llvalue = std::strtoll(szValue, &end, 10);
+      const auto llvalue = strtoll(szValue, &end, 10);
 
       if (llvalue > std::numeric_limits<type>::max() || llvalue < std::numeric_limits<type>::min())
         throw std::range_error("Overflow error, value is outside the range representable by this type.");

--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -6,7 +6,6 @@
 #include <limits>
 #include <stdexcept>
 
-#undef _GLIBCXX_HAVE_BROKEN_VSWPRINTF //Enable to_string in GCC 4.8.
 #include <string>
 #include <string.h>
 #include <stdlib.h>
@@ -108,8 +107,27 @@ namespace autowiring {
     typedef typename std::remove_volatile<T>::type type;
 
     std::string marshal(const void* ptr) const override {
-      const type val = *static_cast<const type*>(ptr);
-      return std::to_string(val);
+      std::string retVal;
+      type val = *static_cast<const type*>(ptr);
+      if (val == 0)
+        return "0";
+
+      bool pos = 0 < val;
+      if (!pos)
+        val *= ~0;
+      for (; val; val /= 10) {
+        retVal.push_back(static_cast<char>(val % 10 + '0'));
+      }
+      if (!pos)
+        retVal.push_back('-');
+
+      for (
+        auto first = retVal.begin(), last = retVal.end();
+        (first != last) && (first != --last);
+        ++first
+        )
+        std::swap(*first, *last);
+      return retVal;
     }
 
     void unmarshal(void* ptr, const char* szValue) const override {

--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -107,6 +107,9 @@ namespace autowiring {
     std::string marshal(const void* ptr) const override {
       std::string retVal;
       type val = *static_cast<const type*>(ptr);
+      if (val == 0)
+        return "0";
+
       bool pos = 0 < val;
       if (!pos)
         val *= ~0;

--- a/src/autowiring/test/MarshallerTest.cpp
+++ b/src/autowiring/test/MarshallerTest.cpp
@@ -24,5 +24,28 @@ TEST_F(MarshallerTest, NegativeValues) {
   int y = 0xCDCDCDCD;
   std::string valY = b.marshal(&y);
   ASSERT_STREQ("-842150451", valY.c_str());
+
+  int z = 0;
+  std::string valZ = b.marshal(&z);
+  ASSERT_STREQ("0", valZ.c_str());
 }
 
+TEST_F(MarshallerTest, UnsignedValues) {
+  autowiring::marshaller<unsigned int> b;
+
+  int x = 0;
+  std::string valX = b.marshal(&x);
+  ASSERT_STREQ("0", valX.c_str());
+}
+
+TEST_F(MarshallerTest, RoundTripTest) {
+  autowiring::marshaller<unsigned int> b;
+
+  unsigned int x = 20;
+  std::string valX = b.marshal(&x);
+
+  unsigned int outX = 0;
+  b.unmarshal(&outX, valX.c_str());
+
+  ASSERT_EQ(outX, x);
+}


### PR DESCRIPTION
Previous behavior was both incorrect and needlessly complicated - Floats are the only ones that don't have a good cross platform string conversion in the standard.