### PR TITLE
Fix msvc14 64-bit release mode linker error

### DIFF
--- a/src/autowiring/auto_id.cpp
+++ b/src/autowiring/auto_id.cpp
@@ -17,6 +17,9 @@ const auto_id_block auto_id_t<void>::s_block{
   nullptr
 };
 
+const auto_id_t_init<void, true> auto_id_t_init<void, true>::init;
+const auto_id_t_init<void, false> auto_id_t_init<void, false>::init;
+
 int autowiring::CreateIndex(void) {
   return s_index++;
 }

--- a/src/autowiring/auto_id.cpp
+++ b/src/autowiring/auto_id.cpp
@@ -17,8 +17,8 @@ const auto_id_block auto_id_t<void>::s_block{
   nullptr
 };
 
-const auto_id_t_init<void, true> auto_id_t_init<void, true>::init;
-const auto_id_t_init<void, false> auto_id_t_init<void, false>::init;
+const auto_id_t_init<void, true> auto_id_t_init<void, true>::init{};
+const auto_id_t_init<void, false> auto_id_t_init<void, false>::init{};
 
 int autowiring::CreateIndex(void) {
   return s_index++;


### PR DESCRIPTION
We declare but never explicitly define the void `init` blocks.  Somehow this still works on every other build configuration, but not VC2015 release mode.  Fix this.