### PR TITLE
Add pointer syntax for prospective output

### DIFF
--- a/src/autowiring/AutoFilterArgument.h
+++ b/src/autowiring/AutoFilterArgument.h
@@ -1,9 +1,10 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include "auto_arg.h"
 #include <typeinfo>
 
 namespace autowiring {
+template<class T>
+class auto_arg;
 
 /// <summary>
 /// AutoFilter argument disposition

--- a/src/autowiring/AutoPacket.h
+++ b/src/autowiring/AutoPacket.h
@@ -2,7 +2,6 @@
 #pragma once
 #include "AnySharedPointer.h"
 #include "at_exit.h"
-#include "auto_arg.h"
 #include "auto_id.h"
 #include "auto_tuple.h"
 #include "AutoFilterArgument.h"
@@ -35,6 +34,9 @@ namespace autowiring {
 
   template<class T>
   class auto_arg;
+
+  template<class T>
+  struct arg_is_out;
 }
 
 /// <summary>

--- a/src/autowiring/auto_arg.h
+++ b/src/autowiring/auto_arg.h
@@ -147,8 +147,7 @@ public:
     return packet.template GetRvalue<T>();
   }
 
-  template<class C>
-  static void Commit(C& packet, T& val) {
+  static void Commit(AutoPacket& packet, T& val) {
     // Do nothing. Modify val in place, no need to commit
   }
 };
@@ -207,14 +206,12 @@ public:
   static const bool is_multi = false;
   static const int tshift = 0;
 
-  template<class C>
-  static std::shared_ptr<T>&& arg(C& packet) {
+  static std::shared_ptr<T>&& arg(AutoPacket& packet) {
     (void) auto_id_t_init<T, false>::init;
     return packet.template GetRvalueShared<T>();
   }
 
-  template<class C>
-  static void Commit(C& packet, std::shared_ptr<T> val) {
+  static void Commit(AutoPacket& packet, std::shared_ptr<T> val) {
     if (!val)
       packet.template RemoveDecoration<T>();
   }
@@ -255,8 +252,7 @@ public:
     return detail::auto_arg_ctor_helper<T>::arg(packet);
   }
 
-  template<class C>
-  static void Commit(C& packet, type val) {
+  static void Commit(AutoPacket& packet, type val) {
     packet.template Decorate<T>(val);
   }
 };
@@ -319,8 +315,7 @@ public:
     return detail::auto_arg_ctor_helper<T>::arg(packet);
   }
 
-  template<class C>
-  static void Commit(C& packet, type val) {
+  static void Commit(AutoPacket& packet, type val) {
     packet.template Decorate<T>(val);
   }
 };
@@ -387,8 +382,7 @@ public:
     return{ packet.template HasSubscribers<T>() };
   }
 
-  template<class C>
-  static void Commit(C& packet, downstream_status val) {
+  static void Commit(AutoPacket& packet, downstream_status val) {
     if(val.has_downstream)
       packet.template Decorate<T>(val.arg);
   }

--- a/src/autowiring/auto_arg.h
+++ b/src/autowiring/auto_arg.h
@@ -205,7 +205,7 @@ public:
   static std::shared_ptr<T> arg(AutoPacket& packet) {
     (void)auto_id_t_init<T>::init;
 
-    if (!packet.HasSubscribers<T>())
+    if (!packet.template HasSubscribers<T>())
       return nullptr;
     return detail::auto_arg_ctor_helper<T>::arg(packet);
   }
@@ -385,14 +385,14 @@ public:
   template<class C>
   static std::shared_ptr<T> arg(C&) {
     (void)auto_id_t_init<T, false>::init;
-    if (!packet.HasSubscribers<T>())
+    if (!packet.template HasSubscribers<T>())
       return nullptr;
     return std::shared_ptr<T>();
   }
 
   static downstream_status arg(AutoPacket& packet) {
     (void)auto_id_t_init<T>::init;
-    return{ packet.HasSubscribers<T>() };
+    return{ packet.template HasSubscribers<T>() };
   }
 
   template<class C>

--- a/src/autowiring/test/AutoFilterPointerOutTest.cpp
+++ b/src/autowiring/test/AutoFilterPointerOutTest.cpp
@@ -1,0 +1,103 @@
+// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+#include "stdafx.h"
+#include "TestFixtures/Decoration.hpp"
+
+class AutoFilterPointerOut:
+  public testing::Test
+{
+public:
+  AutoFilterPointerOut(void) {
+    AutoCurrentContext()->Initiate();
+  }
+};
+
+TEST_F(AutoFilterPointerOut, SingleDecorationNotConsumed) {
+  AutoRequired<AutoPacketFactory> factory;
+
+  bool called = false;
+  bool hasValue = false;
+  *factory += [&] (Decoration<0>* pOut) {
+    called = true;
+    hasValue = !!pOut;
+  };
+
+  auto packet = factory->NewPacket();
+  ASSERT_TRUE(called);
+  ASSERT_FALSE(hasValue) << "Decoration<0> was not correctly identified as having no subscribers";
+}
+
+TEST_F(AutoFilterPointerOut, SingleSubscriber) {
+  AutoRequired<AutoPacketFactory> factory;
+
+  bool called = false;
+  bool hasValue = false;
+  *factory += [&](Decoration<0>* pOut) {
+    called = true;
+    hasValue = !!pOut;
+    if(pOut)
+      *pOut = { 1766 };
+  };
+
+  Decoration<0> value;
+  bool downstreamCalled = false;
+  *factory += [&](Decoration<0> downstream) {
+    downstreamCalled = true;
+    value = downstream;
+  };
+
+  auto packet = factory->NewPacket();
+  ASSERT_TRUE(called);
+  ASSERT_TRUE(hasValue) << "Decoration<0> was not correctly identified as having one subscribers";
+  ASSERT_TRUE(downstreamCalled) << "Downstream filter not called as expected";
+  ASSERT_EQ(1766, value.i);
+}
+
+TEST_F(AutoFilterPointerOut, ConstPointerInput) {
+  AutoRequired<AutoPacketFactory> factory;
+
+  bool called = false;
+  Decoration<0> value{ -1 };
+  *factory += [&](const Decoration<0>* pIn) {
+    called = true;
+    value = *pIn;
+  };
+
+  auto packet = factory->NewPacket();
+  packet->Decorate(Decoration<0>{4124});
+  ASSERT_TRUE(called);
+  ASSERT_EQ(4124, value.i) << "Const input pointer decoration was not called as expected";
+}
+
+TEST_F(AutoFilterPointerOut, PointerToSharedPointerNoSubcriber) {
+  AutoRequired<AutoPacketFactory> factory;
+
+  bool called = false;
+  bool hasPtrValue = false;
+  *factory += [&](std::shared_ptr<Decoration<0>>* ppOut) {
+    hasPtrValue = !!ppOut;
+    called = true;
+  };
+
+  auto packet = factory->NewPacket();
+  ASSERT_TRUE(called) << "Shared pointer decoration filter not called as expected";
+  ASSERT_FALSE(hasPtrValue) << "Pointer to shared pointer should have been null";
+}
+
+TEST_F(AutoFilterPointerOut, PointerToSharedPointer) {
+  AutoRequired<AutoPacketFactory> factory;
+
+  bool called = false;
+  *factory += [&](std::shared_ptr<Decoration<0>>* ppOut) {
+    *ppOut = std::make_shared<Decoration<0>>(92941);
+    called = true;
+  };
+  *factory += [&](Decoration<0>) {};
+
+  auto packet = factory->NewPacket();
+  ASSERT_TRUE(called) << "Shared pointer decoration filter not called as expected";
+  ASSERT_TRUE(packet->Has<Decoration<0>>()) << "Decoration not present on the packet as expected";
+
+  std::shared_ptr<const Decoration<0>> dec;
+  packet->Get(dec);
+  ASSERT_EQ(92941, dec->i);
+}

--- a/src/autowiring/test/CMakeLists.txt
+++ b/src/autowiring/test/CMakeLists.txt
@@ -13,6 +13,7 @@ set(AutowiringTest_SRCS
   AutoFilterDiagnosticsTest.cpp
   AutoFilterFunctionTest.cpp
   AutoFilterMultiDecorateTest.cpp
+  AutoFilterPointerOutTest.cpp
   AutoFilterRvalueTest.cpp
   AutoFilterSatisfiabilityTest.cpp
   AutoFilterSequencing.cpp


### PR DESCRIPTION
Now filters can detect whether there is at least one subscriber downstream to consume a produced decoration.  This is done by accepting the argument as a pointer, and performing a simple null check.  An example filter is as follows:

```C++
void MyType::AutoFilter(MyOutputType* pOutput) {
  if(!pOutput)
    return;

  *pOutput = PerformExpensiveCalculation();
}
```

The pointer will be specified as null if there are no filters downstream.  The filter can choose to return early if the input argument is null, satisfy other output arguments, or to update local members as needed.

If a shared pointer or control over allocation is desired, the pointer-to-shared-pointer syntax may be used instead:

```C++
void MyType::AutoFilter(std::shared_ptr<MyOutputType>* ppOutput) {
  if (!ppOutput)
    return;

  *ppOutput = std::make_shared<MyOutputType>();
  **ppOutput = PerformExpensiveCalculation();
}
```