### PR TITLE
CMAKE_OSX_ARCHITECTURES must be set with FORCE

### DIFF
--- a/standard/CombinedInstaller.cmake
+++ b/standard/CombinedInstaller.cmake
@@ -34,7 +34,9 @@ include(DefaultValue)
 include(ParseVersion)
 
 function(combined_installer)
-  message("Project name is ${CMAKE_PROJECT_NAME}")
+  if(COMBINED_INSTALLER_DEBUG)
+    message("Project name is ${CMAKE_PROJECT_NAME}")
+  endif()
 
   set(options )
   set(oneValueArgs NAME VENDOR CONTACT VERSION GUID LICENSE README WIXFILE)
@@ -97,7 +99,9 @@ function(combined_installer)
   #
   # For more information on the rationale for this process, see the discussion on semantic versioning
   # found at http://semver.org/
-  message("Upgrade GUID is ${ARG_GUID}")
+  if(COMBINED_INSTALLER_DEBUG)
+    message("Upgrade GUID is ${ARG_GUID}")
+  endif()
   set(CPACK_WIX_UPGRADE_GUID "{${ARG_GUID}}")
 
   # Need a custom wix installation template so that we update the CMake package registry correctly

--- a/standard/StandardProject.cmake
+++ b/standard/StandardProject.cmake
@@ -37,12 +37,12 @@ endmacro()
 function(standard_project_preinit)
   # Pre-initialization steps - these variables must be set before the first call to
   # project()
-  if(APPLE)
+  if(APPLE AND CMAKE_OSX_ARCHITECTURES STREQUAL "")
     if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
-      set(CMAKE_OSX_ARCHITECTURES "arm" CACHE STRING "Mac OS X build architectures")
+      set(CMAKE_OSX_ARCHITECTURES "arm" CACHE STRING "Mac OS X build architectures" FORCE)
     else()
       # Build Fat binaries on OSX by default
-      set(CMAKE_OSX_ARCHITECTURES "x86_64;i386" CACHE STRING "Mac OS X build architectures")
+      set(CMAKE_OSX_ARCHITECTURES "x86_64;i386" CACHE STRING "Mac OS X build architectures" FORCE)
     endif()
   endif()
 

--- a/standard/StandardProject.cmake
+++ b/standard/StandardProject.cmake
@@ -82,7 +82,11 @@ function(standard_project_preinit)
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/lib PARENT_SCOPE)
 
   # Postfix on all debug libraries should be "d"
-  set(CMAKE_DEBUG_POSTFIX d${CMAKE_DEBUG_POSTFIX} PARENT_SCOPE)
+  # PARENT_SCOPE causes the variable to not be set locally, and we
+  # rely on this value in the following loop....
+
+  set(CMAKE_DEBUG_POSTFIX "d${CMAKE_DEBUG_POSTFIX}")
+  set(CMAKE_DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX} PARENT_SCOPE)
 
   # 64-bit installations should suffix with 64 regardless of the CPU type (arm or intel)
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)


### PR DESCRIPTION
`CMAKE_OSX_ARCHITECTURES` is actually assigned on the command line, and if not there, is assigned by CMake to an empty string.  This means that it has a value when the `set` command is encountered, and therefore unless `FORCE` is also specified, the `set` will be ignored.

See leapmotion/standard#3 for more information.