### PR TITLE
Fix signed/unsigned mismatch problem

### DIFF
--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -115,6 +115,14 @@ namespace autowiring {
   template<typename T>
   struct integral_converter<T, typename std::enable_if<std::is_unsigned<T>::value>::type> {
     static T convert(const char* p) {
+      // Trim
+      while (isspace(*p))
+        p++;
+
+      // This is the reason we're trimming--no signed numbers in unsigned deserialization
+      if (*p == '-')
+        throw std::range_error("Underflow error, attempted to set a signed value in an unsigned field");
+
       char* end = nullptr;
       return static_cast<T>(strtoull(p, &end, 10));
     }

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -45,7 +45,7 @@ namespace {
   public:
     autowiring::config<std::string> a{ "Hello world!" };
     std::atomic<int> b{ 929 };
-    std::atomic<unsigned int> bUnsigned{ 92999 };
+    std::atomic<uint64_t> bUnsigned{ 92999 };
     volatile bool c = false;
     volatile float d = 1.0f;
     volatile double e = 99.2;


### PR DESCRIPTION
This is caused when we try to serialize 64-bit values.  Add specializations to handle this case and a test to ensure we don't regress here.