### PR TITLE
Fix static assert in get_marshaller

### DIFF
--- a/src/autowiring/config_descriptor.h
+++ b/src/autowiring/config_descriptor.h
@@ -26,7 +26,7 @@ namespace autowiring {
   };
 
   template<typename T>
-  static const marshaller<T>& get_marshaller(void) {
+  static const marshaller_base& get_marshaller(void) {
     // To fix this, specialize autowiring::marshal for your type
     static_assert(
       !std::is_base_of<invalid_marshal_base, autowiring::marshaller<T>>::value,


### PR DESCRIPTION
This static assert is never actually going to get hit, because the expression `marshaller_base& x = get_marshaller()` is evaluated before the template itself is instantiated.  This means that the compiler will complain about a conversion being impossible and never actually try to instantiate the template.  We have to make the return type strictly compatible and _then_ we can do the check inside the static_assert.