### PR TITLE
Add support for duration values in configuration

### DIFF
--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -252,6 +252,28 @@ namespace autowiring {
     }
   };
 
+  template<typename Rep, typename Period>
+  struct builtin_marshaller<std::chrono::duration<Rep, Period>, void>:
+    builtin_marshaller<Rep, void>
+  {
+    typedef typename std::chrono::duration<Rep, Period> type;
+
+    std::string marshal(const void* ptr) const override {
+      Rep value = static_cast<const type*>(ptr)->count();
+      return builtin_marshaller<Rep, void>::marshal(&value);
+    }
+
+    void unmarshal(void* ptr, const char* szValue) const override {
+      Rep value;
+      builtin_marshaller<Rep, void>::unmarshal(&value, szValue);
+      *static_cast<type*>(ptr) = type { value };
+    }
+
+    void copy(void* lhs, const void* rhs) const override {
+      *static_cast<type*>(lhs) = *static_cast<const type*>(rhs);
+    }
+  };
+
   /// <summary>
   /// Default marshaller, a point of specialization for external users
   /// </summary>

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -342,3 +342,23 @@ TEST_F(AutoConfigTest, TeardownUnreference) {
   }
   ASSERT_TRUE(cwbf_weak.expired()) << "Object leaked after context destruction";
 }
+
+namespace {
+  struct HasDurationField {
+    std::chrono::seconds d;
+
+    static config_descriptor GetConfigDescriptor(void) {
+      return{
+        { "duration", &HasDurationField::d }
+      };
+    }
+  };
+}
+
+TEST_F(AutoConfigTest, DurationSerialization) {
+  AutoRequired<HasDurationField> hdf;
+  AutoCurrentContext ctxt;
+  ctxt->Config.Set("duration", "192");
+
+  ASSERT_EQ(std::chrono::seconds{ 192 }, hdf->d);
+}


### PR DESCRIPTION
It would be nice to be able to serialize a duration directly.  Use the count on the duration field proper rather than trying to convert to a universal type; the string representation may have to face the user, and if the developer represents duration with `std::chrono::seconds`, the user should be specifying that duration in seconds as well.