### PR TITLE
Add some convenience operators to observable

### DIFF
--- a/src/autowiring/observable.h
+++ b/src/autowiring/observable.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "marshaller.h"
 #include "signal.h"

--- a/src/autowiring/observable.h
+++ b/src/autowiring/observable.h
@@ -72,17 +72,6 @@ public:
     onChanged();
     return *this;
   }
-
-  bool operator==(const T& rhs) { return val == rhs; }
-  bool operator!=(const T& rhs) { return val != rhs; }
-  bool operator<(const T& rhs) { return val < rhs; }
-  bool operator<=(const T& rhs) { return val <= rhs; }
-  bool operator>(const T& rhs) { return val > rhs; }
-  bool operator>=(const T& rhs) { return val >= rhs; }
-  auto operator*(const T& rhs) -> decltype(val * rhs) { return val * rhs; }
-  auto operator/(const T& rhs) -> decltype(val * rhs) { return val / rhs; }
-  auto operator+(const T& rhs) -> decltype(val * rhs) { return val + rhs; }
-  auto operator-(const T& rhs) -> decltype(val * rhs) { return val - rhs; }
 };
 
 template<typename T>

--- a/src/autowiring/observable.h
+++ b/src/autowiring/observable.h
@@ -116,7 +116,7 @@ template<typename T>
 struct hash<autowiring::observable<T>> {
   hash(void) = default;
 
-  const hash<T> interior;
+  hash<T> interior;
 
   auto operator()(const autowiring::observable<T>& value) const -> decltype(interior(value.get())) {
     return interior(value.get());

--- a/src/autowiring/observable.h
+++ b/src/autowiring/observable.h
@@ -72,8 +72,18 @@ public:
     onChanged();
     return *this;
   }
-};
 
+  bool operator==(const T& rhs) { return val == rhs; }
+  bool operator!=(const T& rhs) { return val != rhs; }
+  bool operator<(const T& rhs) { return val < rhs; }
+  bool operator<=(const T& rhs) { return val <= rhs; }
+  bool operator>(const T& rhs) { return val > rhs; }
+  bool operator>=(const T& rhs) { return val >= rhs; }
+  auto operator*(const T& rhs) -> decltype(val * rhs) { return val * rhs; }
+  auto operator/(const T& rhs) -> decltype(val * rhs) { return val / rhs; }
+  auto operator+(const T& rhs) -> decltype(val * rhs) { return val + rhs; }
+  auto operator-(const T& rhs) -> decltype(val * rhs) { return val - rhs; }
+};
 
 template<typename T>
 struct marshaller<observable<T>> :
@@ -99,4 +109,17 @@ struct marshaller<observable<T>> :
   }
 };
 
+}
+
+namespace std {
+template<typename T>
+struct hash<autowiring::observable<T>> {
+  hash(void) = default;
+
+  const hash<T> interior;
+
+  auto operator()(const autowiring::observable<T>& value) const -> decltype(interior(value.get())) {
+    return interior(value.get());
+  }
+};
 }

--- a/src/autowiring/test/ObservableTest.cpp
+++ b/src/autowiring/test/ObservableTest.cpp
@@ -1,6 +1,8 @@
 // Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/observable.h>
+#include <set>
+#include <unordered_set>
 
 class ObservableTest:
   public testing::Test
@@ -35,4 +37,22 @@ TEST_F(ObservableTest, BeforeAndAfter) {
   ASSERT_TRUE(hit) << "Change notification not raised";
   ASSERT_EQ(8, obBefore) << "\"Before\" value in onBeforeChanged was not correct";
   ASSERT_EQ(9, obAfter) << "\"AfFter\" value in onBeforeChanged was not correct";
+}
+
+TEST_F(ObservableTest, SetOfObservable) {
+  std::unordered_set<autowiring::observable<int>> a;
+  a.insert(9);
+  a.insert(10);
+  a.insert(11);
+  ASSERT_EQ(1, a.count(9));
+  ASSERT_EQ(1, a.count(12));
+  ASSERT_EQ(1, a.count(44));
+
+  std::set<autowiring::observable<int>> b;
+  b.insert(9);
+  b.insert(12);
+  b.insert(44);
+  ASSERT_EQ(1, b.count(9));
+  ASSERT_EQ(1, b.count(12));
+  ASSERT_EQ(1, b.count(44));
 }

--- a/src/autowiring/test/ObservableTest.cpp
+++ b/src/autowiring/test/ObservableTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2015 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/observable.h>
 #include <set>

--- a/src/autowiring/test/ObservableTest.cpp
+++ b/src/autowiring/test/ObservableTest.cpp
@@ -41,12 +41,12 @@ TEST_F(ObservableTest, BeforeAndAfter) {
 
 TEST_F(ObservableTest, SetOfObservable) {
   std::unordered_set<autowiring::observable<int>> a;
-  a.insert(9);
-  a.insert(10);
-  a.insert(11);
-  ASSERT_EQ(1, a.count(9));
-  ASSERT_EQ(1, a.count(12));
-  ASSERT_EQ(1, a.count(44));
+  a.insert(4449);
+  a.insert(44410);
+  a.insert(44411);
+  ASSERT_EQ(1, a.count(4449));
+  ASSERT_EQ(1, a.count(44410));
+  ASSERT_EQ(1, a.count(44411));
 
   std::set<autowiring::observable<int>> b;
   b.insert(9);

--- a/src/autowiring/test/ObservableTest.cpp
+++ b/src/autowiring/test/ObservableTest.cpp
@@ -58,8 +58,8 @@ TEST_F(ObservableTest, SetOfObservable) {
 }
 
 TEST_F(ObservableTest, MathOperators) {
-  autowiring::observable<int> one(1);
-  autowiring::observable<int> two(2);
+  const autowiring::observable<int> one(1);
+  const autowiring::observable<int> two(2);
 
   // plus, minus, multiply, divide
   ASSERT_EQ(3, one + 2);

--- a/src/autowiring/test/ObservableTest.cpp
+++ b/src/autowiring/test/ObservableTest.cpp
@@ -56,3 +56,22 @@ TEST_F(ObservableTest, SetOfObservable) {
   ASSERT_EQ(1, b.count(12));
   ASSERT_EQ(1, b.count(44));
 }
+
+TEST_F(ObservableTest, MathOperators) {
+  autowiring::observable<int> one(1);
+  autowiring::observable<int> two(2);
+
+  // plus, minus, multiply, divide
+  ASSERT_EQ(3, one + 2);
+  ASSERT_EQ(1, two - 1);
+  ASSERT_EQ(2.0, one * 2.0);
+  ASSERT_EQ(two, two / one);
+
+  // all comparison operators
+  ASSERT_TRUE(one == 1);
+  ASSERT_TRUE(one != 2);
+  ASSERT_TRUE(one < 2);
+  ASSERT_TRUE(one >= 1);
+  ASSERT_FALSE(one > two);
+  ASSERT_FALSE(two <= one);
+}


### PR DESCRIPTION
These seem like they would be used frequently enough for an observable type, especially the comparison operators which are critical to the

@jdonald update: It seems we need only the hash function.