### PR TITLE
Add a way to determine whether a signal has listeners

### DIFF
--- a/src/autowiring/signal.h
+++ b/src/autowiring/signal.h
@@ -594,5 +594,8 @@ namespace autowiring {
     // template format of the earlier function call overload, overload resolution will never
     // select this variant.
     //void operator()(Args... args) const;
+
+    bool has_listeners(void) const { return m_pFirstListener != nullptr; }
+    operator bool() const { return has_listeners(); }
   };
 }

--- a/src/autowiring/test/AutoSignalTest.cpp
+++ b/src/autowiring/test/AutoSignalTest.cpp
@@ -819,3 +819,10 @@ TEST_F(AutoSignalTest, MoveInInvoke) {
   ASSERT_NE(nullptr, vRecovered);
   ASSERT_EQ(404, *vRecovered) << "Recovered unique pointer was not the expected value";
 }
+
+TEST_F(AutoSignalTest, ListenerCheck) {
+  autowiring::signal<void()> s;
+  ASSERT_FALSE(s) << "Signal did not correctly report it had no listeners";
+  s += [] {};
+  ASSERT_TRUE(s) << "Signal stated that it had no listeners when it should have had at least one";
+}

--- a/src/autowiring/test/AutoSignalTest.cpp
+++ b/src/autowiring/test/AutoSignalTest.cpp
@@ -823,6 +823,8 @@ TEST_F(AutoSignalTest, MoveInInvoke) {
 TEST_F(AutoSignalTest, ListenerCheck) {
   autowiring::signal<void()> s;
   ASSERT_FALSE(s) << "Signal did not correctly report it had no listeners";
-  s += [] {};
+  registration_t reg = s += [] {};
   ASSERT_TRUE(s) << "Signal stated that it had no listeners when it should have had at least one";
+  s -= reg;
+  ASSERT_FALSE(s) << "Signal believed it still had listeners even after they were all unregistered";
 }


### PR DESCRIPTION
Some signals are actually quite expensive to assert.  It would be helpful to be able to query a signal to determine whether it has listeners before doing work to try to invoke it.