### PR TITLE
Fix null dereference in PrintRunnables

### DIFF
--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -188,8 +188,12 @@ void autowiring::dbg::PrintRunnables(std::ostream& os, CoreContext& ctxt) {
 
         // Type information, in human-readable form
         os << ' ' << autowiring::demangle(typeid(*runnable)) << ' ';
-        if (ContextMember* pMember = dynamic_cast<ContextMember*>(runnable))
-          os << " (" << pMember->GetName() << ')';
+        if (ContextMember* pMember = dynamic_cast<ContextMember*>(runnable)) {
+          if (const char* name = pMember->GetName())
+            os << " (" << name << ')';
+          else
+            os << " (null)";
+        }
         os << '\n';
       }
     }

--- a/src/autowiring/test/AutowiringDebugTest.cpp
+++ b/src/autowiring/test/AutowiringDebugTest.cpp
@@ -195,3 +195,30 @@ TEST_F(AutowiringDebugTest, PrintRunnables) {
     str
   );
 }
+
+namespace {
+class HasNoName :
+  public CoreThread
+{
+public:
+  HasNoName(void) :
+    CoreThread(nullptr)
+  {}
+};
+}
+
+TEST_F(AutowiringDebugTest, NullContextMemberName) {
+  AutoCurrentContext ctxt;
+  AutoRequired<HasNoName>{};
+
+  ctxt->Initiate();
+
+  std::stringstream str;
+  autowiring::dbg::PrintRunnables(str, *AutoCurrentContext{});
+
+  static const char expected[] = "void(Current Context)\n";
+  ASSERT_STREQ(
+    expected,
+    str.str().substr(0, sizeof(expected) - 1).c_str()
+  );
+}


### PR DESCRIPTION
This routine prints context member names directly.  If the name happens to be nullptr, this causes an exception.  Add a test and fix this mistake.