### PR TITLE
Fix incorrect WaitForStateUpdate behavior

### DIFF
--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -145,8 +145,13 @@ bool BasicThread::OnStart(void) {
 
 void BasicThread::OnStop(bool graceful) {
   // If we were never started, we need to set our completed flag to true
-  if (!m_wasStarted)
+  if (!m_wasStarted) {
+    std::lock_guard<std::mutex> lk(m_state->m_lock);
     m_state->m_completed = true;
+  }
+
+  // State condition must be notified, in the event that anything is blocking
+  m_state->m_stateCondition.notify_all();
 
   // Always invoke stop handler:
   OnStop();

--- a/src/autowiring/test/BasicThreadTest.cpp
+++ b/src/autowiring/test/BasicThreadTest.cpp
@@ -75,3 +75,23 @@ TEST_F(BasicThreadTest, IsMainThread) {
   );
   ASSERT_FALSE(secondaryIsMain.get()) << "Secondary thread incorrectly identified as the main thread";
 }
+
+namespace {
+class WaitsForStateUpdate :
+  public BasicThread
+{
+public:
+  void Run(void) override {
+    WaitForStateUpdate([] { return false; });
+  }
+};
+}
+
+TEST_F(BasicThreadTest, WaitForStateUpdateExits) {
+  AutoRequired<WaitsForStateUpdate> wfsu;
+  AutoCurrentContext ctxt;
+  ctxt->Initiate();
+
+  ctxt->SignalShutdown();
+  ASSERT_TRUE(ctxt->Wait(std::chrono::seconds{ 10 }));
+}


### PR DESCRIPTION
This routine must throw an exception if the thread is terminated during a wait.  Ensure that `BasicThread::OnStop` signals the state mutex when it's called to cause any waiters to wake up.