### PR TITLE
Bump version number

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -32,7 +32,7 @@ PROJECT_NAME           = Autowiring
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = "1.0.3"
+PROJECT_NUMBER         = "1.0.4"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer

--- a/publicDoxyfile.conf
+++ b/publicDoxyfile.conf
@@ -38,7 +38,7 @@ PROJECT_NAME           = Autowiring
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.0.3
+PROJECT_NUMBER         = 1.0.4
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/version.cmake
+++ b/version.cmake
@@ -1,1 +1,1 @@
-set(autowiring_VERSION 1.0.3)
+set(autowiring_VERSION 1.0.4)


### PR DESCRIPTION
Autowiring 1.0.3 lost fat binary support, need autowiring 1.0.4 to restore that for leapipc and other libraries.