### PR TITLE
Config/stl marshal

### DIFF
--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -155,7 +155,7 @@ namespace autowiring {
   template<typename T>
   struct float_converter;
 
-#ifdef MSVC
+#if defined(_MSC_VER) && _MSC_VER <= 1900 //This is reported resolved in VC++15
 #define AW_SNPRINTF sprintf_s
 #else
 #define AW_SNPRINTF snprintf

--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -7,6 +7,7 @@
 #include <stdexcept>
 
 #include <string>
+#include <sstream>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -137,7 +138,9 @@ namespace autowiring {
 
     std::string marshal(const void* ptr) const override {
       type val = *static_cast<const type*>(ptr);
-      return std::to_string(val);
+      std::stringstream ss;
+      ss << val;
+      return ss.str();
     }
 
     void unmarshal(void* ptr, const char* szValue) const override {

--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -135,27 +135,8 @@ namespace autowiring {
     typedef typename std::remove_volatile<T>::type type;
 
     std::string marshal(const void* ptr) const override {
-      std::string retVal;
       type val = *static_cast<const type*>(ptr);
-      if (val == 0)
-        return "0";
-
-      bool pos = 0 < val;
-      if (!pos)
-        val *= ~0;
-      for (; val; val /= 10) {
-        retVal.push_back(static_cast<char>(val % 10 + '0'));
-      }
-      if (!pos)
-        retVal.push_back('-');
-
-      for (
-        auto first = retVal.begin(), last = retVal.end();
-        (first != last) && (first != --last);
-        ++first
-        )
-        std::swap(*first, *last);
-      return retVal;
+      return std::to_string(val);
     }
 
     void unmarshal(void* ptr, const char* szValue) const override {

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -5,7 +5,7 @@
 #include <autowiring/ConfigRegistry.h>
 #include <autowiring/observable.h>
 #include <cstring>
-#include "stdlib.h"
+#include <cstdlib>
 
 namespace aw = autowiring;
 
@@ -168,7 +168,7 @@ TEST_F(AutoConfigTest, Double) {
 
   c.e = 10929.4423;
   strVal = autowiring::ConfigGet("e", c);
-  double outVal = strtod(strVal.c_str(),nullptr);
+  double outVal = strtod(strVal.c_str(), nullptr);
   ASSERT_EQ(c.e, outVal) << "Double config value failed to round trip";
 
   c.e = 109290000000000;
@@ -177,7 +177,7 @@ TEST_F(AutoConfigTest, Double) {
 
   c.e = -0.0099291;
   strVal = autowiring::ConfigGet("e", c);
-  outVal = strtod(strVal.c_str(),nullptr);
+  outVal = strtod(strVal.c_str(), nullptr);
   ASSERT_EQ(c.e, outVal) << "Double config value failed to round trip with a negative number";
 
   autowiring::ConfigSet("e", c, "77482.4");

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -5,6 +5,7 @@
 #include <autowiring/ConfigRegistry.h>
 #include <autowiring/observable.h>
 #include <cstring>
+#include "stdlib.h"
 
 namespace aw = autowiring;
 
@@ -154,7 +155,8 @@ TEST_F(AutoConfigTest, Float) {
 
   c.d = 10929.4f;
   std::string strVal = autowiring::ConfigGet("d", c);
-  ASSERT_STREQ("10929.4", strVal.c_str());
+  const float fVal = strtof(strVal.c_str(), nullptr);
+  ASSERT_EQ(c.d, fVal) << "Floating point config value didn't successfully round trip";
 
   autowiring::ConfigSet("d", c, "123.4");
   ASSERT_FLOAT_EQ(c.d, 123.4f) << "Float configuration value not assigned";
@@ -166,7 +168,8 @@ TEST_F(AutoConfigTest, Double) {
 
   c.e = 10929.4423;
   strVal = autowiring::ConfigGet("e", c);
-  ASSERT_STREQ("10929.4423", strVal.c_str());
+  double outVal = strtod(strVal.c_str(),nullptr);
+  ASSERT_EQ(c.e, outVal) << "Double config value failed to round trip";
 
   c.e = 109290000000000;
   strVal = autowiring::ConfigGet("e", c);
@@ -174,7 +177,8 @@ TEST_F(AutoConfigTest, Double) {
 
   c.e = -0.0099291;
   strVal = autowiring::ConfigGet("e", c);
-  ASSERT_STREQ("-0.0099291", strVal.c_str());
+  outVal = strtod(strVal.c_str(),nullptr);
+  ASSERT_EQ(c.e, outVal) << "Double config value failed to round trip with a negative number";
 
   autowiring::ConfigSet("e", c, "77482.4");
   ASSERT_DOUBLE_EQ(c.e, 77482.4) << "Double configuration value not assigned";

--- a/src/autowiring/test/MarshallerTest.cpp
+++ b/src/autowiring/test/MarshallerTest.cpp
@@ -51,7 +51,9 @@ TEST_F(MarshallerTest, DoubleMarshalTest) {
 
   double x = -0.00899999999999999;
   std::string val = d.marshal(&x);
-  ASSERT_STREQ("-0.00899999999999999", val.c_str()) << "Failed to marshal a double-precision value";
+  double outX;
+  d.unmarshal(&outX, val.c_str());
+  ASSERT_EQ(x,outX) << "Failed to round trip a large double precision value";
 }
 
 TEST_F(MarshallerTest, NegativeValues) {

--- a/src/autowiring/test/MarshallerTest.cpp
+++ b/src/autowiring/test/MarshallerTest.cpp
@@ -6,12 +6,33 @@ class MarshallerTest:
   public testing::Test
 {};
 
+TEST_F(MarshallerTest, FloatTest) {
+  autowiring::marshaller<float> f;
+
+  float x = 0;
+  std::string valX = f.marshal(&x);
+  ASSERT_STREQ("0", valX.c_str()) << "Failed to properly output 0";
+
+  float outX = 20;
+  f.unmarshal(&outX, valX.c_str());
+  ASSERT_EQ(outX, 0) << "Failed to properly round trip 0";
+
+  float y = 0.0001f;
+  std::string valY = f.marshal(&y);
+  ASSERT_STREQ("0.0001", valY.c_str()) << "Failed to marshal a decimal value";
+
+  float z = 1.23e8f;
+  std::string valZ = f.marshal(&z);
+  ASSERT_STREQ("123000000", valZ.c_str()) << "Failed to marshal a value with an exponent";
+}
+}
+
 TEST_F(MarshallerTest, DoubleMarshalTest) {
-  autowiring::marshaller<double> b;
+  autowiring::marshaller<double> d;
 
   double x = -0.00899999999999999;
-  std::string val = b.marshal(&x);
-  ASSERT_STREQ("-0.00899999999999999", val.c_str());
+  std::string val = d.marshal(&x);
+  ASSERT_STREQ("-0.00899999999999999", val.c_str()) << "Failed to marshal a double-precision value";
 }
 
 TEST_F(MarshallerTest, NegativeValues) {

--- a/src/autowiring/test/MarshallerTest.cpp
+++ b/src/autowiring/test/MarshallerTest.cpp
@@ -20,9 +20,6 @@ TEST_F(MarshallerTest, FloatTest) {
   float y = 0.0001f;
   std::string valY = f.marshal(&y);
 
-  //This value is actually notoriously difficult to create a minimal string
-  //representation for.
-  //ASSERT_STREQ("0.0001", valY.c_str()) << "Failed to marshal a decimal value";
   float outY = 0;
   f.unmarshal(&outY, valY.c_str());
   ASSERT_EQ(y, outY) << "Failed to properly round trip 0.0001f";

--- a/src/autowiring/test/MarshallerTest.cpp
+++ b/src/autowiring/test/MarshallerTest.cpp
@@ -19,12 +19,31 @@ TEST_F(MarshallerTest, FloatTest) {
 
   float y = 0.0001f;
   std::string valY = f.marshal(&y);
-  ASSERT_STREQ("0.0001", valY.c_str()) << "Failed to marshal a decimal value";
+
+  //This value is actually notoriously difficult to create a minimal string
+  //representation for.
+  //ASSERT_STREQ("0.0001", valY.c_str()) << "Failed to marshal a decimal value";
+  float outY = 0;
+  f.unmarshal(&outY, valY.c_str());
+  ASSERT_EQ(y, outY) << "Failed to properly round trip 0.0001f";
 
   float z = 1.23e8f;
   std::string valZ = f.marshal(&z);
   ASSERT_STREQ("123000000", valZ.c_str()) << "Failed to marshal a value with an exponent";
 }
+
+TEST_F(MarshallerTest, DISABLED_FloatRoundTrip_FULL) {
+  autowiring::marshaller<float> f;
+
+  const float start = std::numeric_limits<float>::min();
+  const float end = std::numeric_limits<float>::max();
+
+  for (float x = start; x != end; x = std::nextafterf(x, end)) {
+    std::string str = f.marshal(&x);
+    float roundtrip;
+    f.unmarshal(&roundtrip, str.c_str());
+    ASSERT_EQ(x, roundtrip) << "Floating point value did not round trip correctly";
+  }
 }
 
 TEST_F(MarshallerTest, DoubleMarshalTest) {


### PR DESCRIPTION
Eliminate custom parsing/marshaling code and use the STL where appropriate.
