### PR TITLE
Remove null auto_signal.cpp

### DIFF
--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -24,7 +24,6 @@ set(Autowiring_SRCS
   auto_out.h
   auto_prev.h
   auto_signal.h
-  auto_signal.cpp
   auto_tuple.h
   AutoCurrentPacketPusher.h
   AutoFilterDescriptor.h

--- a/src/autowiring/auto_signal.cpp
+++ b/src/autowiring/auto_signal.cpp
@@ -1,7 +1,0 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
-#include "stdafx.h"
-#include "auto_signal.h"
-#include "SlotInformation.h"
-
-using namespace autowiring;
-


### PR DESCRIPTION
Fixes this clang linker warning:

```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: for architecture: x86_64 file: ../../lib/libAutowiring.a(auto_signal.cpp.o) has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: for architecture: i386 file: ../../lib/libAutowiring.a(auto_signal.cpp.o) has no symbols
```

- [x] Review #1009