### PR TITLE
Fix Android 32-bit build

### DIFF
--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -12,7 +12,7 @@
 #include <stdio.h>
 #include TYPE_TRAITS_HEADER
 
-#if __ANDROID__
+#if defined(__ANDROID__) && !defined(_LIBCPP_VERSION)
 #include <sstream>
 #endif
 
@@ -141,13 +141,13 @@ namespace autowiring {
 
     std::string marshal(const void* ptr) const override {
       type val = *static_cast<const type*>(ptr);
-#if __ANDROID__
+#if defined(__ANDROID__) && !defined(_LIBCPP_VERSION)
       std::stringstream ss;
       ss << val;
       return ss.str();
 #else
       return std::to_string(val);
-#endif //__ANDROID__
+#endif
     }
 
     void unmarshal(void* ptr, const char* szValue) const override {

--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -201,7 +201,7 @@ namespace autowiring {
   template<>
   struct float_converter<long double> {
     static long double convertTo(const char* szValue) {
-#if defined(__ANDROID__) && !defined(_LIBCPP_VERSION)
+#if defined(__ANDROID__) && !defined(__aarch64__) && !defined(_LIBCPP_VERSION)
       std::stringstream ss(szValue);
       long double ld;
       ss >> ld;

--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -200,7 +200,16 @@ namespace autowiring {
 
   template<>
   struct float_converter<long double> {
-    static long double convertTo(const char* szValue) { return strtold(szValue, nullptr); }
+    static long double convertTo(const char* szValue) {
+#if defined(__ANDROID__) && !defined(_LIBCPP_VERSION)
+      std::stringstream ss(szValue);
+      long double ld;
+      ss >> ld;
+      return ld;
+#else
+      return strtold(szValue, nullptr);
+#endif
+    }
     static std::string convertFrom(long double value) {
       return var_to_string<long double, 128>(value, "%.33Lg");
     }

--- a/src/autowiring/test/MarshallerTest.cpp
+++ b/src/autowiring/test/MarshallerTest.cpp
@@ -29,20 +29,6 @@ TEST_F(MarshallerTest, FloatTest) {
   ASSERT_STREQ("123000000", valZ.c_str()) << "Failed to marshal a value with an exponent";
 }
 
-TEST_F(MarshallerTest, DISABLED_FloatRoundTrip_FULL) {
-  autowiring::marshaller<float> f;
-
-  const float start = std::numeric_limits<float>::min();
-  const float end = std::numeric_limits<float>::max();
-
-  for (float x = start; x != end; x = std::nextafterf(x, end)) {
-    std::string str = f.marshal(&x);
-    float roundtrip;
-    f.unmarshal(&roundtrip, str.c_str());
-    ASSERT_EQ(x, roundtrip) << "Floating point value did not round trip correctly";
-  }
-}
-
 TEST_F(MarshallerTest, DoubleMarshalTest) {
   autowiring::marshaller<double> d;
 


### PR DESCRIPTION
Here's the fix that @yeswalrus recommended, using stringstream.

I've clarified the preprocessor conditions so we have one less issue when eventually upgrading from gnustl to libc++.

Travis doesn't build Android yet, so I verified both 32-bit and 64-bit builds locally.

- [x] Fix Travis clang build first
- [x] Check MSVC
- [x] Fixes the issue introduced in PR #1003