### PR TITLE
Remove unused ThreadPool header references

### DIFF
--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -6,10 +6,8 @@
 #include "CoreThread.h"
 #include "demangle.h"
 #include "GlobalCoreContext.h"
-#include "ManualThreadPool.h"
 #include "MicroBolt.h"
 #include "NullPool.h"
-#include "SystemThreadPool.h"
 #include "thread_specific_ptr.h"
 #include <cassert>
 #include <sstream>

--- a/src/autowiring/GlobalCoreContext.cpp
+++ b/src/autowiring/GlobalCoreContext.cpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "GlobalCoreContext.h"
-#include "SystemThreadPool.h"
 #include <cassert>
 
 GlobalCoreContext::GlobalCoreContext(void):


### PR DESCRIPTION
We don't seem to be using ThreadPools by default with CoreThread or BasicThread. Remove these header references to be certain.

- [ ] Review #1009