### PR TITLE
Restore <autowiring/signal.h>

### DIFF
--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -245,7 +245,7 @@ target_include_directories(
   "${PROJECT_SOURCE_DIR}/contrib/autoboost"
   PUBLIC
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>"
-  "$<BUILD_INTERFACE:${PROJECT_BUILD_DIR}/src>"
+  "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src/autowiring>"
   INTERFACE
   "$<INSTALL_INTERFACE:include>"
 )

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -245,7 +245,7 @@ target_include_directories(
   "${PROJECT_SOURCE_DIR}/contrib/autoboost"
   PUBLIC
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>"
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
+  "$<BUILD_INTERFACE:${PROJECT_BUILD_DIR}/src>"
   INTERFACE
   "$<INSTALL_INTERFACE:include>"
 )

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -245,7 +245,7 @@ target_include_directories(
   "${PROJECT_SOURCE_DIR}/contrib/autoboost"
   PUBLIC
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>"
-  "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src/autowiring>"
+  "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/src>"
   INTERFACE
   "$<INSTALL_INTERFACE:include>"
 )

--- a/src/autowiring/CMakeLists.txt
+++ b/src/autowiring/CMakeLists.txt
@@ -148,6 +148,7 @@ set(Autowiring_SRCS
   Parallel.cpp
   registration.h
   SatCounter.h
+  signal.h
   signal_base.h
   SlotInformation.cpp
   SlotInformation.h

--- a/src/autowiring/autowiring.h
+++ b/src/autowiring/autowiring.h
@@ -5,4 +5,4 @@
 #include "auto_in.h"
 #include "auto_out.h"
 #include "auto_prev.h"
-#include "AutowiringVersion.h"
+#include <autowiring/AutowiringVersion.h>

--- a/src/autowiring/signal.h
+++ b/src/autowiring/signal.h
@@ -1,0 +1,2 @@
+// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+#include "auto_signal.h"


### PR DESCRIPTION
While `<signal.h>` can be confusing as it shares its name with a standard UNIX header, it's explicit enough when customers `#include <autowiring/signal.h>`

We have good reason for calling it `<autowiring/signal.h>` as outlined in #851 when this was first added. Furthermore, I don't want to make a breaking change forcing us to autowiring-1.1.

The problem we had to work around in #998 is properly dealt with by not adding all the dangerous include paths.

- [x] Review #1009 first