### PR TITLE
Fix Xcode deprecation warning for OSMemoryBarrier()

### DIFF
--- a/contrib/autoboost/autoboost/asio/detail/macos_fenced_block.hpp
+++ b/contrib/autoboost/autoboost/asio/detail/macos_fenced_block.hpp
@@ -19,7 +19,7 @@
 
 #if defined(__MACH__) && defined(__APPLE__)
 
-#include <libkern/OSAtomic.h>
+#include <atomic>
 
 #include <autoboost/asio/detail/push_options.hpp>
 
@@ -42,13 +42,13 @@ public:
   // Constructor for a full fenced block.
   explicit macos_fenced_block(full_t)
   {
-    OSMemoryBarrier();
+    std::atomic_thread_fence(std::memory_order_seq_cst);
   }
 
   // Destructor.
   ~macos_fenced_block()
   {
-    OSMemoryBarrier();
+    std::atomic_thread_fence(std::memory_order_seq_cst);
   }
 };
 


### PR DESCRIPTION
Fix this warning in autoboost :
```
autowiring/contrib/autoboost/autoboost/asio/detail/macos_fenced_block.hpp:51:5: warning: 
      'OSMemoryBarrier' is deprecated: first deprecated in macOS 10.12 - Use
      std::atomic_thread_fence() from <atomic> instead
      [-Wdeprecated-declarations]
    OSMemoryBarrier();
```
Doesn't seem to be fixed in the boost repo yet so I couldn't mimic something there.

On github I found in the repo for `cmus`, a music player, they used `std::memory_order_seq_cst`. The documentation seems to indicate `OSMemoryBarrier()` is a sequential consistency barrier too.
