### PR TITLE
Fix vs2015 type deduction error

### DIFF
--- a/src/autowiring/Autowired.h
+++ b/src/autowiring/Autowired.h
@@ -377,8 +377,8 @@ class AutoConstruct:
 {
 public:
   template<class... Args>
-  AutoConstruct(Args&&... args) :
-    std::shared_ptr<T>(init(std::forward<Args&&>(args)...))
+  AutoConstruct(Args... args) :
+    std::shared_ptr<T>(init(std::forward<Args>(args)...))
   {}
 
   operator bool(void) const { return IsAutowired(); }

--- a/src/autowiring/test/AutoConstructTest.cpp
+++ b/src/autowiring/test/AutoConstructTest.cpp
@@ -103,7 +103,6 @@ TEST_F(AutoConstructTest, FactoryNewPrivateCtor) {
   ASSERT_EQ(1002, mpcc->ival) << "Correct ctor was not invoked on a type with a private ctor";
 }
 
-
 namespace {
   class MyPrivateCtorStringClass :
     public CoreObject


### PR DESCRIPTION
Changes to the way msvc handles template deduction caused a break. I believe this is the correct fix.