### PR TITLE
Fix has_static_new

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[**]
+indent_style = space
+indent_size = 2
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,6 @@ Autowiring.nuspec
 autowiring.kdev4
 *.opendb
 *.orig
-autowiring.VC.db
+*.VC.db*
 .vscode
 AutowiringVersion.h
-
-*.VC.db*

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ autowiring.kdev4
 autowiring.VC.db
 .vscode
 AutowiringVersion.h
+
+*.VC.db*

--- a/src/autowiring/has_static_new.h
+++ b/src/autowiring/has_static_new.h
@@ -32,7 +32,7 @@ template<typename T, typename... Args>
 struct has_static_new
 {
   template<class U>
-  static std::true_type select(decltype(U::New((Args&&)*(Args*)nullptr...))*);
+  static std::true_type select(decltype(U::New(std::declval<Args>()...)));
 
   template<class U>
   static std::false_type select(...);

--- a/src/autowiring/has_static_new.h
+++ b/src/autowiring/has_static_new.h
@@ -5,51 +5,18 @@
 
 namespace autowiring {
 
-/// <summary>
-/// Utility helper structure for types which have a factory New routine
-/// </summary>
-/// <remarks>
-/// A factory New routine is malformed when the return type is not implicitly castable to type T
-/// </remarks>
-template<class T, class Selector, class... Args>
-struct has_well_formed_static_new {
-  static const bool value = std::is_convertible<
-    decltype(
-      T::New(
-        std::declval<Args>()...
-      )
-    ),
-    T*
-  >::value;
-};
-
-template<class T, class... Args>
-struct has_well_formed_static_new<T, std::false_type, Args...> {
-  static const bool value = false;
-};
-
-template<typename T, typename... Args>
-struct has_static_new
+template <class T, typename... Args>
+class has_static_new
 {
-  template<class U>
-  static std::true_type select(decltype(U::New(std::declval<Args>()...)));
-
-  template<class U>
-  static std::false_type select(...);
-
-  static const bool value = has_well_formed_static_new<T, decltype(select<T>(nullptr)), Args...>::value;
-};
-
-template<typename T>
-struct has_static_new<T>
-{
-  template<class U>
-  static std::true_type select(decltype(U::New())*);
-
-  template<class U>
-  static std::false_type select(...);
-
-  static const bool value = has_well_formed_static_new<T, decltype(select<T>(nullptr))>::value;
+  template<class U, class = typename std::enable_if<
+    std::is_function<decltype(U::New(std::declval<Args>()...))(Args...)>::value &&
+    std::is_convertible<decltype(U::New(std::declval<Args>()...)), T*>::value
+  >::type>
+  static std::true_type check(void*);
+  template <class...>
+  static std::false_type check(...);
+public:
+  static const bool value = decltype(check<T>(nullptr))::value;
 };
 
 }

--- a/src/autowiring/has_static_new.h
+++ b/src/autowiring/has_static_new.h
@@ -5,6 +5,12 @@
 
 namespace autowiring {
 
+/// <summary>
+/// Utility helper structure for types which have a factory New routine
+/// </summary>
+/// <remarks>
+/// A factory New routine is malformed when the return type is not implicitly castable to type T
+/// </remarks>
 template <class T, typename... Args>
 class has_static_new
 {
@@ -13,6 +19,7 @@ class has_static_new
     std::is_convertible<decltype(U::New(std::declval<Args>()...)), T*>::value
   >::type>
   static std::true_type check(void*);
+
   template <class...>
   static std::false_type check(...);
 public:

--- a/src/autowiring/test/AutoConstructTest.cpp
+++ b/src/autowiring/test/AutoConstructTest.cpp
@@ -167,5 +167,5 @@ static_assert(
   );
 
 TEST_F(AutoConstructTest, MultiStaticNewTest) {
-  AutoConstruct<MultiStaticNew> badstatic{ 1 };
+  AutoConstruct<MultiStaticNew> multistatic{ 1 };
 }

--- a/src/autowiring/test/AutoConstructTest.cpp
+++ b/src/autowiring/test/AutoConstructTest.cpp
@@ -102,3 +102,47 @@ TEST_F(AutoConstructTest, FactoryNewPrivateCtor) {
   ASSERT_NE(nullptr, mpcc.get()) << "Null not expected as a return type from a factory new construction";
   ASSERT_EQ(1002, mpcc->ival) << "Correct ctor was not invoked on a type with a private ctor";
 }
+
+
+namespace {
+  class MyPrivateCtorStringClass :
+    public CoreObject
+  {
+    MyPrivateCtorStringClass(void) :
+      istr("default_string")
+    {}
+    MyPrivateCtorStringClass(const char* istr) :
+      istr(istr)
+    {}
+
+  public:
+    const char* istr;
+
+    static MyPrivateCtorStringClass* New(const char* str) {
+      return new MyPrivateCtorStringClass{ str };
+    }
+  };
+}
+
+static_assert(
+  autowiring::has_static_new<MyPrivateCtorStringClass, decltype("")>::value,
+  "Failed to find factory new on a type that carries it"
+  );
+static_assert(
+  autowiring::select_strategy<MyPrivateCtorStringClass, decltype("")>::value == autowiring::construction_strategy::factory_new,
+  "Construction strategy incorrectly inferred"
+  );
+static_assert(
+  !std::is_constructible<MyPrivateCtorStringClass>::value,
+  "Type reported as being constructable when it was not"
+  );
+static_assert(
+  !autowiring::has_simple_constructor<MyPrivateCtorStringClass>::value,
+  "Simple constructor detected when said constructor should have been private"
+  );
+
+TEST_F(AutoConstructTest, FactoryNewPrivateStringCtor) {
+  AutoConstruct<MyPrivateCtorStringClass> mpcc{ "a new string" };
+  ASSERT_NE(nullptr, mpcc.get()) << "Null not expected as a return type from a factory new construction";
+  ASSERT_STREQ("a new string", mpcc->istr) << "Correct ctor was not invoked on a type with a private ctor";
+}

--- a/src/autowiring/test/AutoConstructTest.cpp
+++ b/src/autowiring/test/AutoConstructTest.cpp
@@ -19,6 +19,11 @@ namespace {
   };
 }
 
+static_assert(
+  autowiring::select_strategy<HasDefaultCtorAndOthers, int>::value == autowiring::construction_strategy::standard,
+  "Construction strategy incorrectly inferred"
+  );
+
 TEST_F(AutoConstructTest, AutoConstructNoArgs) {
   AutoConstruct<HasDefaultCtorAndOthers> hdcao;
   ASSERT_EQ(101, hdcao->v) << "Default constructor was not called as expected";
@@ -144,4 +149,23 @@ TEST_F(AutoConstructTest, FactoryNewPrivateStringCtor) {
   AutoConstruct<MyPrivateCtorStringClass> mpcc{ "a new string" };
   ASSERT_NE(nullptr, mpcc.get()) << "Null not expected as a return type from a factory new construction";
   ASSERT_STREQ("a new string", mpcc->istr) << "Correct ctor was not invoked on a type with a private ctor";
+}
+
+class MultiStaticNew : public CoreObject {
+  MultiStaticNew() {}
+public:
+  static char* New() { return nullptr; }
+  static MultiStaticNew* New(int x) { return nullptr; }
+};
+static_assert(
+  !autowiring::has_static_new<MultiStaticNew>::value,
+  "Found a bad static new"
+  );
+static_assert(
+  autowiring::has_static_new<MultiStaticNew, int>::value,
+  "Failed to find a good static new override"
+  );
+
+TEST_F(AutoConstructTest, MultiStaticNewTest) {
+  AutoConstruct<MultiStaticNew> badstatic{ 1 };
 }

--- a/src/autowiring/test/AutoConstructTest.cpp
+++ b/src/autowiring/test/AutoConstructTest.cpp
@@ -103,7 +103,6 @@ TEST_F(AutoConstructTest, FactoryNewPrivateCtor) {
   ASSERT_EQ(1002, mpcc->ival) << "Correct ctor was not invoked on a type with a private ctor";
 }
 
-
 namespace {
   class MyPrivateCtorStringClass :
     public CoreObject


### PR DESCRIPTION
MSVC2015, alone among MSVC versions and for reasons that are beyond me chokes on the function name detection portion of the old has_static_new's SFINAE.
This overhauls it to be far more concise, and compile correctly.
