### PR TITLE
Fix gcc issue with constructors taking references to abstract objects

### DIFF
--- a/src/autowiring/has_static_new.h
+++ b/src/autowiring/has_static_new.h
@@ -15,7 +15,7 @@ template <class T, typename... Args>
 class has_static_new
 {
   template<class U, class = typename std::enable_if<
-    std::is_function<decltype(U::New(std::declval<Args>()...))(Args...)>::value &&
+    std::is_function<decltype(U::New(std::declval<Args>()...))(Args&&...)>::value &&
     std::is_convertible<decltype(U::New(std::declval<Args>()...)), T*>::value
   >::type>
   static std::true_type check(void*);

--- a/src/autowiring/test/AutoConstructTest.cpp
+++ b/src/autowiring/test/AutoConstructTest.cpp
@@ -169,3 +169,4 @@ static_assert(
 TEST_F(AutoConstructTest, MultiStaticNewTest) {
   AutoConstruct<MultiStaticNew> multistatic{ 1 };
 }
+


### PR DESCRIPTION
Uncovered when linking with platform on arm-gcc5. 