### PR TITLE
Avoid undefined behavior of defined()

### DIFF
--- a/src/autowiring/C++11/cpp11.h
+++ b/src/autowiring/C++11/cpp11.h
@@ -4,7 +4,11 @@
 // The reason this header exists is due to the asymmetric availability of C++11 on our
 // various compiler targets.
 
-#define IS_CLANG defined(__clang_major__)
+#ifdef __clang_major__
+  #define IS_CLANG 1
+#else
+  #define IS_CLANG 0
+#endif
 #define CLANG_CHECK(maj, min) (__clang_major__ == maj && __clang_minor__ >= min || __clang_major__ > maj)
 #define GCC_CHECK(maj, min) (__GNUC__ == maj && __GNUC_MINOR__  >= min || __GNUC__ > maj)
 


### PR DESCRIPTION
When upgrading to clang for Android, we get this on virtually every source file:
```
In file included from /home/tombuilder/external-libraries/src/autowiring/src/autowiring/test/stdafx.h:7:
/home/tombuilder/external-libraries/src/autowiring/src/./autowiring/C++11/cpp11.h:11:5: warning: macro expansion producing
      'defined' has undefined behavior [-Wexpansion-to-defined]
#if IS_CLANG && !CLANG_CHECK(3, 6)
```

We should probably go ahead and fix this as clang is correct to point out that it's not part of the C preprocessor standard: https://gcc.gnu.org/onlinedocs/cpp/Defined.html