### PR TITLE
Fix DispatchQueue length on Cancel

### DIFF
--- a/src/autowiring/DispatchQueue.cpp
+++ b/src/autowiring/DispatchQueue.cpp
@@ -163,6 +163,7 @@ bool DispatchQueue::Cancel(void) {
     // Found a ready thunk, run from here:
     thunk.reset(m_pHead);
     m_pHead = thunk->m_pFlink;
+    m_count--;
   }
   else if (!m_delayedQueue.empty()) {
     auto& f = m_delayedQueue.top();

--- a/src/autowiring/test/DispatchQueueTest.cpp
+++ b/src/autowiring/test/DispatchQueueTest.cpp
@@ -291,7 +291,9 @@ TEST_F(DispatchQueueTest, SimpleCancel) {
   DispatchQueue dq;
   auto called = std::make_shared<bool>(false);
   dq += [called] { *called = true; };
+  ASSERT_EQ(1U, dq.GetDispatchQueueLength());
   ASSERT_TRUE(dq.Cancel()) << "Dispatch queue failed to cancel a lambda as expected";
+  ASSERT_EQ(0U, dq.GetDispatchQueueLength());
   ASSERT_FALSE(dq.DispatchEvent()) << "Succeeded in dispatching an event that should not have been dispatched";
   ASSERT_FALSE(*called) << "Dispatch queue executed a lambda that should have been destroyed";
   ASSERT_TRUE(called.unique()) << "Dispatch queue leaked a lambda function";


### PR DESCRIPTION
It appears that the dispatch queue count is not being decremented when cancelling from the normal, non-deferred queue.