### PR TITLE
Bump to v1.0.5

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -32,7 +32,7 @@ PROJECT_NAME           = Autowiring
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = "1.0.4"
+PROJECT_NUMBER         = "1.0.5"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer

--- a/publicDoxyfile.conf
+++ b/publicDoxyfile.conf
@@ -38,7 +38,7 @@ PROJECT_NAME           = Autowiring
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.0.4
+PROJECT_NUMBER         = 1.0.5
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/version.cmake
+++ b/version.cmake
@@ -1,1 +1,1 @@
-set(autowiring_VERSION 1.0.4)
+set(autowiring_VERSION 1.0.5)


### PR DESCRIPTION
<s>Ideally this will be a minor release for bugfixes like #1023.</s>

While not breaking compatibility, #1027 is a significant bugfix.

 And we can update some dependent repositories while leaving LeapHTTP, LeapResource, and others which don't use `.Cancel()` to continue referencing autowiring-1.0.4.

edit: This is me @jdonald who accidentally filed the ticket under one of my other Github accounts.