### PR TITLE
Update to latest json11 with patches

### DIFF
--- a/contrib/json11/json11.hpp
+++ b/contrib/json11/json11.hpp
@@ -54,19 +54,25 @@
 #include <vector>
 #include <map>
 #include <memory>
+#include <initializer_list>
 
 #ifdef _MSC_VER
-  // noexcept was added to MSVC in Visual Studio 2014
-  #if _MSC_VER > 1800
-    #define JSON11_NOEXCEPT noexcept
-  #else
-    #define JSON11_NOEXCEPT throw()
-  #endif
-#else
-  #define JSON11_NOEXCEPT noexcept
+    #if _MSC_VER <= 1800 // VS 2013
+        #ifndef noexcept
+            #define noexcept throw()
+        #endif
+
+        #ifndef snprintf
+            #define snprintf _snprintf_s
+        #endif
+    #endif
 #endif
 
 namespace json11 {
+
+enum JsonParse {
+    STANDARD, COMMENTS
+};
 
 class JsonValue;
 
@@ -82,11 +88,11 @@ public:
     typedef std::map<std::string, Json> object;
 
     // Constructors for the various types of JSON value.
-    Json() JSON11_NOEXCEPT;         // NUL
-    Json(std::nullptr_t);           // NUL
+    Json() noexcept;                // NUL
+    Json(std::nullptr_t) noexcept;  // NUL
     Json(double value);             // NUMBER
     Json(int value);                // NUMBER
-    Json(bool value) JSON11_NOEXCEPT; // BOOL
+    Json(bool value);               // BOOL
     Json(const std::string &value); // STRING
     Json(std::string &&value);      // STRING
     Json(const char * value);       // STRING
@@ -100,32 +106,17 @@ public:
     Json(const T & t) : Json(t.to_json()) {}
 
     // Implicit constructor: map-like objects (std::map, std::unordered_map, etc)
-    template <class M>
-    Json(
-        const typename std::enable_if<
-            std::is_constructible<std::string, decltype(std::declval<M>().begin()->first)>::value &&
-            std::is_constructible<std::string, decltype(std::declval<M>().begin()->second)>::value,
-            M
-        >::type& m
-    ) :
-        Json(object(m.begin(), m.end()))
-    {}
+    template <class M, typename std::enable_if<
+        std::is_constructible<std::string, decltype(std::declval<M>().begin()->first)>::value
+        && std::is_constructible<Json, decltype(std::declval<M>().begin()->second)>::value,
+            int>::type = 0>
+    Json(const M & m) : Json(object(m.begin(), m.end())) {}
 
     // Implicit constructor: vector-like objects (std::list, std::vector, std::set, etc)
-    template <class V>
-    Json(
-        const typename std::enable_if<
-            std::is_constructible<Json, decltype(std::declval<V>().begin()->first)>::value,
-            V
-        >::type& v
-    ) :
-        Json(array(v.begin(), v.end()))
-    {}
-
-    template<class V>
-    Json(V* begin, V* end):
-      Json(array(begin, end))
-    {}
+    template <class V, typename std::enable_if<
+        std::is_constructible<Json, decltype(*std::declval<V>().begin())>::value,
+            int>::type = 0>
+    Json(const V & v) : Json(array(v.begin(), v.end())) {}
 
     // This prevents Json(some_pointer) from accidentally producing a bool. Use
     // Json(bool(some_pointer)) if that behavior is desired.
@@ -170,17 +161,33 @@ public:
     }
 
     // Parse. If parse fails, return Json() and assign an error message to err.
-    static Json parse(const std::string & in, std::string & err);
-    static Json parse(const char * in, std::string & err) {
+    static Json parse(const std::string & in,
+                      std::string & err,
+                      JsonParse strategy = JsonParse::STANDARD);
+    static Json parse(const char * in,
+                      std::string & err,
+                      JsonParse strategy = JsonParse::STANDARD) {
         if (in) {
-            return parse(std::string(in), err);
+            return parse(std::string(in), err, strategy);
         } else {
             err = "null input";
             return nullptr;
         }
     }
     // Parse multiple objects, concatenated or separated by whitespace
-    static std::vector<Json> parse_multi(const std::string & in, std::string & err);
+    static std::vector<Json> parse_multi(
+        const std::string & in,
+        std::string::size_type & parser_stop_pos,
+        std::string & err,
+        JsonParse strategy = JsonParse::STANDARD);
+
+    static inline std::vector<Json> parse_multi(
+        const std::string & in,
+        std::string & err,
+        JsonParse strategy = JsonParse::STANDARD) {
+        std::string::size_type parser_stop_pos;
+        return parse_multi(in, parser_stop_pos, err, strategy);
+    }
 
     bool operator== (const Json &rhs) const;
     bool operator<  (const Json &rhs) const;
@@ -188,6 +195,14 @@ public:
     bool operator<= (const Json &rhs) const { return !(rhs < *this); }
     bool operator>  (const Json &rhs) const { return  (rhs < *this); }
     bool operator>= (const Json &rhs) const { return !(*this < rhs); }
+
+    /* has_shape(types, err)
+     *
+     * Return true if this is a JSON object and, for each item in types, has a field of
+     * the given type. If not, return false and set err to a descriptive message.
+     */
+    typedef std::initializer_list<std::pair<std::string, Type>> shape;
+    bool has_shape(const shape & types, std::string & err) const;
 
 private:
     std::shared_ptr<JsonValue> m_ptr;

--- a/contrib/json11/test.cpp
+++ b/contrib/json11/test.cpp
@@ -1,18 +1,55 @@
+/*
+ * Define JSON11_TEST_CUSTOM_CONFIG to 1 if you want to build this tester into
+ * your own unit-test framework rather than a stand-alone program.  By setting
+ * The values of the variables included below, you can insert your own custom
+ * code into this file as it builds, in order to make it into a test case for
+ * your favorite framework.
+ */
+#if !JSON11_TEST_CUSTOM_CONFIG
+#define JSON11_TEST_CPP_PREFIX_CODE
+#define JSON11_TEST_CPP_SUFFIX_CODE
+#define JSON11_TEST_STANDALONE_MAIN 1
+#define JSON11_TEST_CASE(name) static void name()
+#define JSON11_TEST_ASSERT(b) assert(b)
+#ifdef NDEBUG
+#undef NDEBUG//at now assert will work even in Release build
+#endif
+#endif // JSON11_TEST_CUSTOM_CONFIG
+
+/*
+ * Enable or disable code which demonstrates the behavior change in Xcode 7 / Clang 3.7,
+ * introduced by DR1467 and described here: https://github.com/dropbox/json11/issues/86
+ * Defaults to off since it doesn't appear the standards committee is likely to act
+ * on this, so it needs to be considered normal behavior.
+ */
+#ifndef JSON11_ENABLE_DR1467_CANARY
+#define JSON11_ENABLE_DR1467_CANARY 0
+#endif
+
+/*
+ * Beginning of standard source file, which makes use of the customizations above.
+ */
+#include <cassert>
 #include <string>
 #include <cstdio>
+#include <cstring>
 #include <iostream>
 #include <sstream>
 #include "json11.hpp"
-#include <cassert>
 #include <list>
 #include <set>
 #include <unordered_map>
+#include <algorithm>
+#include <type_traits>
+
+// Insert user-defined prefix code (includes, function declarations, etc)
+// to set up a custom test suite
+JSON11_TEST_CPP_PREFIX_CODE
 
 using namespace json11;
 using std::string;
 
 // Check that Json has the properties we want.
-#include <type_traits>
 #define CHECK_TRAIT(x) static_assert(std::x::value, #x)
 CHECK_TRAIT(is_nothrow_constructible<Json>);
 CHECK_TRAIT(is_nothrow_default_constructible<Json>);
@@ -22,9 +59,202 @@ CHECK_TRAIT(is_copy_assignable<Json>);
 CHECK_TRAIT(is_nothrow_move_assignable<Json>);
 CHECK_TRAIT(is_nothrow_destructible<Json>);
 
-void parse_from_stdin() {
+JSON11_TEST_CASE(json11_test) {
+    const string simple_test =
+        R"({"k1":"v1", "k2":42, "k3":["a",123,true,false,null]})";
+
+    string err;
+    const auto json = Json::parse(simple_test, err);
+
+    std::cout << "k1: " << json["k1"].string_value() << "\n";
+    std::cout << "k3: " << json["k3"].dump() << "\n";
+
+    for (auto &k : json["k3"].array_items()) {
+        std::cout << "    - " << k.dump() << "\n";
+    }
+
+    string comment_test = R"({
+      // comment /* with nested comment */
+      "a": 1,
+      // comment
+      // continued
+      "b": "text",
+      /* multi
+         line
+         comment
+        // line-comment-inside-multiline-comment
+      */
+      // and single-line comment
+      // and single-line comment /* multiline inside single line */
+      "c": [1, 2, 3]
+      // and single-line comment at end of object
+    })";
+
+    string err_comment;
+    auto json_comment = Json::parse(
+      comment_test, err_comment, JsonParse::COMMENTS);
+    JSON11_TEST_ASSERT(!json_comment.is_null());
+    JSON11_TEST_ASSERT(err_comment.empty());
+
+    comment_test = "{\"a\": 1}//trailing line comment";
+    json_comment = Json::parse(
+      comment_test, err_comment, JsonParse::COMMENTS);
+    JSON11_TEST_ASSERT(!json_comment.is_null());
+    JSON11_TEST_ASSERT(err_comment.empty());
+
+    comment_test = "{\"a\": 1}/*trailing multi-line comment*/";
+    json_comment = Json::parse(
+      comment_test, err_comment, JsonParse::COMMENTS);
+    JSON11_TEST_ASSERT(!json_comment.is_null());
+    JSON11_TEST_ASSERT(err_comment.empty());
+
+    string failing_comment_test = "{\n/* unterminated comment\n\"a\": 1,\n}";
+    string err_failing_comment;
+    auto json_failing_comment = Json::parse(
+      failing_comment_test, err_failing_comment, JsonParse::COMMENTS);
+    JSON11_TEST_ASSERT(json_failing_comment.is_null());
+    JSON11_TEST_ASSERT(!err_failing_comment.empty());
+
+    failing_comment_test = "{\n/* unterminated trailing comment }";
+    json_failing_comment = Json::parse(
+      failing_comment_test, err_failing_comment, JsonParse::COMMENTS);
+    JSON11_TEST_ASSERT(json_failing_comment.is_null());
+    JSON11_TEST_ASSERT(!err_failing_comment.empty());
+
+    failing_comment_test = "{\n/ / bad comment }";
+    json_failing_comment = Json::parse(
+      failing_comment_test, err_failing_comment, JsonParse::COMMENTS);
+    JSON11_TEST_ASSERT(json_failing_comment.is_null());
+    JSON11_TEST_ASSERT(!err_failing_comment.empty());
+
+    failing_comment_test = "{// bad comment }";
+    json_failing_comment = Json::parse(
+      failing_comment_test, err_failing_comment, JsonParse::COMMENTS);
+    JSON11_TEST_ASSERT(json_failing_comment.is_null());
+    JSON11_TEST_ASSERT(!err_failing_comment.empty());
+
+    failing_comment_test = "{\n\"a\": 1\n}/";
+    json_failing_comment = Json::parse(
+      failing_comment_test, err_failing_comment, JsonParse::COMMENTS);
+    JSON11_TEST_ASSERT(json_failing_comment.is_null());
+    JSON11_TEST_ASSERT(!err_failing_comment.empty());
+
+    failing_comment_test = "{/* bad\ncomment *}";
+    json_failing_comment = Json::parse(
+      failing_comment_test, err_failing_comment, JsonParse::COMMENTS);
+    JSON11_TEST_ASSERT(json_failing_comment.is_null());
+    JSON11_TEST_ASSERT(!err_failing_comment.empty());
+
+    std::list<int> l1 { 1, 2, 3 };
+    std::vector<int> l2 { 1, 2, 3 };
+    std::set<int> l3 { 1, 2, 3 };
+    JSON11_TEST_ASSERT(Json(l1) == Json(l2));
+    JSON11_TEST_ASSERT(Json(l2) == Json(l3));
+
+    std::map<string, string> m1 { { "k1", "v1" }, { "k2", "v2" } };
+    std::unordered_map<string, string> m2 { { "k1", "v1" }, { "k2", "v2" } };
+    JSON11_TEST_ASSERT(Json(m1) == Json(m2));
+
+    // Json literals
+    const Json obj = Json::object({
+        { "k1", "v1" },
+        { "k2", 42.0 },
+        { "k3", Json::array({ "a", 123.0, true, false, nullptr }) },
+    });
+
+    std::cout << "obj: " << obj.dump() << "\n";
+    JSON11_TEST_ASSERT(obj.dump() == "{\"k1\": \"v1\", \"k2\": 42, \"k3\": [\"a\", 123, true, false, null]}");
+
+    JSON11_TEST_ASSERT(Json("a").number_value() == 0);
+    JSON11_TEST_ASSERT(Json("a").string_value() == "a");
+    JSON11_TEST_ASSERT(Json().number_value() == 0);
+
+    JSON11_TEST_ASSERT(obj == json);
+    JSON11_TEST_ASSERT(Json(42) == Json(42.0));
+    JSON11_TEST_ASSERT(Json(42) != Json(42.1));
+
+    const string unicode_escape_test =
+        R"([ "blah\ud83d\udca9blah\ud83dblah\udca9blah\u0000blah\u1234" ])";
+
+    const char utf8[] = "blah" "\xf0\x9f\x92\xa9" "blah" "\xed\xa0\xbd" "blah"
+                        "\xed\xb2\xa9" "blah" "\0" "blah" "\xe1\x88\xb4";
+
+    Json uni = Json::parse(unicode_escape_test, err);
+    JSON11_TEST_ASSERT(uni[0].string_value().size() == (sizeof utf8) - 1);
+    JSON11_TEST_ASSERT(std::memcmp(uni[0].string_value().data(), utf8, sizeof utf8) == 0);
+
+    // Demonstrates the behavior change in Xcode 7 / Clang 3.7, introduced by DR1467
+    // and described here: https://llvm.org/bugs/show_bug.cgi?id=23812
+    if (JSON11_ENABLE_DR1467_CANARY) {
+        Json nested_array = Json::array { Json::array { 1, 2, 3 } };
+        JSON11_TEST_ASSERT(nested_array.is_array());
+        JSON11_TEST_ASSERT(nested_array.array_items().size() == 1);
+        JSON11_TEST_ASSERT(nested_array.array_items()[0].is_array());
+        JSON11_TEST_ASSERT(nested_array.array_items()[0].array_items().size() == 3);
+    }
+
+    {
+        const std::string good_json = R"( {"k1" : "v1"})";
+        const std::string bad_json1 = good_json + " {";
+        const std::string bad_json2 = good_json + R"({"k2":"v2", "k3":[)";
+        struct TestMultiParse {
+            std::string input;
+            std::string::size_type expect_parser_stop_pos;
+            size_t expect_not_empty_elms_count;
+            Json expect_parse_res;
+        } tests[] = {
+            {" {", 0, 0, {}},
+            {good_json, good_json.size(), 1, Json(std::map<string, string>{ { "k1", "v1" } })},
+            {bad_json1, good_json.size() + 1, 1, Json(std::map<string, string>{ { "k1", "v1" } })},
+            {bad_json2, good_json.size(), 1, Json(std::map<string, string>{ { "k1", "v1" } })},
+            {"{}", 2, 1, Json::object{}},
+        };
+        for (const auto &tst : tests) {
+            std::string::size_type parser_stop_pos;
+            std::string err;
+            auto res = Json::parse_multi(tst.input, parser_stop_pos, err);
+            JSON11_TEST_ASSERT(parser_stop_pos == tst.expect_parser_stop_pos);
+            JSON11_TEST_ASSERT(
+                (size_t)std::count_if(res.begin(), res.end(),
+                                      [](const Json& j) { return !j.is_null(); })
+                == tst.expect_not_empty_elms_count);
+            if (!res.empty()) {
+                JSON11_TEST_ASSERT(tst.expect_parse_res == res[0]);
+            }
+        }
+    }
+
+    Json my_json = Json::object {
+        { "key1", "value1" },
+        { "key2", false },
+        { "key3", Json::array { 1, 2, 3 } },
+    };
+    std::string json_obj_str = my_json.dump();
+    std::cout << "json_obj_str: " << json_obj_str << "\n";
+    JSON11_TEST_ASSERT(json_obj_str == "{\"key1\": \"value1\", \"key2\": false, \"key3\": [1, 2, 3]}");
+
+    class Point {
+    public:
+        int x;
+        int y;
+        Point (int x, int y) : x(x), y(y) {}
+        Json to_json() const { return Json::array { x, y }; }
+    };
+
+    std::vector<Point> points = { { 1, 2 }, { 10, 20 }, { 100, 200 } };
+    std::string points_json = Json(points).dump();
+    std::cout << "points_json: " << points_json << "\n";
+    JSON11_TEST_ASSERT(points_json == "[[1, 2], [10, 20], [100, 200]]");
+}
+
+#if JSON11_TEST_STANDALONE_MAIN
+
+static void parse_from_stdin() {
     string buf;
-    while (!std::cin.eof()) buf += std::cin.get();
+    string line;
+    while (std::getline(std::cin, line)) {
+        buf += line + "\n";
+    }
 
     string err;
     auto json = Json::parse(buf, err);
@@ -41,73 +271,11 @@ int main(int argc, char **argv) {
         return 0;
     }
 
-    const string simple_test =
-        R"({"k1":"v1", "k2":42, "k3":["a",123,true,false,null]})";
-
-    string err;
-    auto json = Json::parse(simple_test, err);
-
-    std::cout << "k1: " << json["k1"].string_value() << "\n";
-    std::cout << "k3: " << json["k3"].dump() << "\n";
-
-    for (auto &k : json["k3"].array_items()) {
-        std::cout << "    - " << k.dump() << "\n";
-    }
-
-    std::list<int> l1 { 1, 2, 3 };
-    std::vector<int> l2 { 1, 2, 3 };
-    std::set<int> l3 { 1, 2, 3 };
-    assert(Json(l1) == Json(l2));
-    assert(Json(l2) == Json(l3));
-
-    std::map<string, string> m1 { { "k1", "v1" }, { "k2", "v2" } };
-    std::unordered_map<string, string> m2 { { "k1", "v1" }, { "k2", "v2" } };
-    assert(Json(m1) == Json(m2));
-
-    // Json literals
-    Json obj = Json::object({
-        { "k1", "v1" },
-        { "k2", 42.0 },
-        { "k3", Json::array({ "a", 123.0, true, false, nullptr }) },
-    });
-
-    std::cout << "obj: " << obj.dump() << "\n";
-
-    assert(Json("a").number_value() == 0);
-    assert(Json("a").string_value() == "a");
-    assert(Json().number_value() == 0);
-
-    assert(obj == json);
-    assert(Json(42) == Json(42.0));
-    assert(Json(42) != Json(42.1));
-
-    const string unicode_escape_test =
-        R"([ "blah\ud83d\udca9blah\ud83dblah\udca9blah\u0000blah\u1234" ])";
-
-    const char utf8[] = "blah" "\xf0\x9f\x92\xa9" "blah" "\xed\xa0\xbd" "blah"
-                        "\xed\xb2\xa9" "blah" "\0" "blah" "\xe1\x88\xb4";
-
-    Json uni = Json::parse(unicode_escape_test, err);
-    assert(uni[0].string_value().size() == (sizeof utf8) - 1);
-    assert(memcmp(uni[0].string_value().data(), utf8, sizeof utf8) == 0);
-
-    Json my_json = Json::object {
-        { "key1", "value1" },
-        { "key2", false },
-        { "key3", Json::array { 1, 2, 3 } },
-    };
-    std::string json_str = my_json.dump();
-    printf("%s\n", json_str.c_str());
-
-    class Point {
-    public:
-        int x;
-        int y;
-        Point (int x, int y) : x(x), y(y) {}
-        Json to_json() const { return Json::array { x, y }; }
-    };
-
-    std::vector<Point> points = { { 1, 2 }, { 10, 20 }, { 100, 200 } };
-    std::string points_json = Json(points).dump();
-    printf("%s\n", points_json.c_str());
+    json11_test();
 }
+
+#endif // JSON11_TEST_STANDALONE_MAIN
+
+// Insert user-defined suffix code (function definitions, etc)
+// to set up a custom test suite
+JSON11_TEST_CPP_SUFFIX_CODE


### PR DESCRIPTION
To resolve issues with Clang and the version of the json11 library included in the contrib directory, update to https://github.com/dropbox/json11/commit/ec4e45219af1d7cde3d58b49ed762376fccf1ace, plus a Windows-specific patch that was applied to the previous version.