### PR TITLE
Avoid pthread_setname_np()

### DIFF
--- a/src/autowiring/CoreThreadLinux.cpp
+++ b/src/autowiring/CoreThreadLinux.cpp
@@ -12,7 +12,9 @@ using std::chrono::milliseconds;
 using std::chrono::microseconds;
 
 void BasicThread::SetCurrentThreadName(void) const {
+#ifndef __RK1108__
   pthread_setname_np(pthread_self(), m_name);
+#endif
 }
 
 std::chrono::steady_clock::time_point BasicThread::GetCreationTime(void) {


### PR DESCRIPTION
We still support the thread names on x86_64 Linux and Android, but it isn't available on RV1108.