### PR TITLE
Fix CoreJob race condition

### DIFF
--- a/src/autowiring/CoreJob.cpp
+++ b/src/autowiring/CoreJob.cpp
@@ -99,7 +99,7 @@ bool CoreJob::OnStart(void) {
 
   m_running = true;
 
-  std::unique_lock<std::mutex> lk;
+  std::unique_lock<std::mutex> lk(m_dispatchLock);
   if(m_pHead)
     // Simulate a pending event, because we need to set up our async:
     OnPended(std::move(lk));

--- a/src/autowiring/CoreJob.cpp
+++ b/src/autowiring/CoreJob.cpp
@@ -52,8 +52,10 @@ void CoreJob::OnPended(std::unique_lock<std::mutex>&& lk){
     // Need to ask the thread pool to handle our events again:
     m_curEventInTeardown = false;
 
-    if (m_curEvent)
-      delete static_cast<std::future<void>*>(m_curEvent);
+    std::future<void>* future = static_cast<std::future<void>*>(std::atomic_exchange<void*>(&m_curEvent, nullptr));
+    if (future) {
+      delete future;
+    }
 
     m_curEvent = new std::future<void>(
       std::async(
@@ -122,21 +124,20 @@ void CoreJob::OnStop(bool graceful) {
 }
 
 void CoreJob::DoAdditionalWait(void) {
-  if (m_curEvent) {
-    std::future<void>* ptr = static_cast<std::future<void>*>(m_curEvent);
-    ptr->wait();
-    delete ptr;
-    m_curEvent = nullptr;
+  std::future<void>* future = static_cast<std::future<void>*>(std::atomic_exchange<void*>(&m_curEvent, nullptr));
+
+  if (future) {
+    future->wait();
+    delete future;
   }
 }
 
 bool CoreJob::DoAdditionalWait(std::chrono::nanoseconds timeout) {
-  if (!m_curEvent)
+  std::future<void>* future = static_cast<std::future<void>*>(std::atomic_exchange<void*>(&m_curEvent, nullptr));
+  if (!future)
     return true;
 
-  std::future<void>* ptr = static_cast<std::future<void>*>(m_curEvent);
-  auto status = ptr->wait_for(NanosecondsForFutureWait(timeout));
-  delete ptr;
-  m_curEvent = nullptr;
+  const auto status = future->wait_for(NanosecondsForFutureWait(timeout));
+  delete future;
   return status == std::future_status::ready;
 }

--- a/src/autowiring/CoreJob.h
+++ b/src/autowiring/CoreJob.h
@@ -18,7 +18,7 @@ private:
   bool m_running = false;
 
   // The current outstanding async in the thread pool, if one exists:
-  void* m_curEvent = nullptr;
+  std::atomic<void*> m_curEvent{ nullptr };
 
   // Flag, indicating whether curEvent is in a teardown pathway.  This
   // flag is highly stateful.


### PR DESCRIPTION
It was possible for current event handler to be deleted twice, and also for it to inadvertently be started multiple times, causing a few user functions to be run in different threads.

One of the main issues was that, although `CoreJob`'s `OnPended` function expected a lock, two different locks were being passed from different threads to the function, nullifying exclusivity. Also, the `wait` functions could be called from different threads, potentially causing a double free.

A test (`CoreJobTest.PendFromMultipleThreads`) has been added, but it doesn't fail every time without this fix. To see the failure case, the test should be repeated multiple times (using `--gtest_repeat`, specifying the number of runs, and `--gtest_throw_on_failure`, to stop on failure).