### PR TITLE
Update copyright year to 2017

### DIFF
--- a/examples/AutoFilterExample.cpp
+++ b/examples/AutoFilterExample.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include <autowiring/autowiring.h>
 #include <iostream>
 #include <string>

--- a/examples/AutoFilterTutorial.0.0.cpp
+++ b/examples/AutoFilterTutorial.0.0.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 /// @page AutoFilterTutorial_0_0 AutoFilter Tutorial 0.0
 /// This tutorial will introduce the reader to the AutoFilter concept and how to implement a rudimentary
 /// AutoFilter network.  It is recommended that the reader become familiar with the concept of a context

--- a/examples/AutoFilterTutorial.1.0.cpp
+++ b/examples/AutoFilterTutorial.1.0.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 /// @page AutoFilterTutorial_1_0 AutoFilter Tutorial 1.0
 /// This tutorial will introduce the reader to the different kinds of `AutoFilter` input parameter semantics.
 ///

--- a/examples/AutoNetExample.cpp
+++ b/examples/AutoNetExample.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include <autowiring/autowiring.h>
 #include <autonet/AutoNetServer.h>
 #include <iostream>

--- a/examples/ContextExample.cpp
+++ b/examples/ContextExample.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include <autowiring/autowiring.h>
 #include <iostream>
 #include <memory>

--- a/examples/ThreadExample.cpp
+++ b/examples/ThreadExample.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include <autowiring/autowiring.h>
 #include <autowiring/CoreThread.h>
 #include <iostream>

--- a/scripts/copyright_check.sh
+++ b/scripts/copyright_check.sh
@@ -5,7 +5,7 @@
 #
 
 ENFORCED_FILES="examples src"
-COPYRIGHT_HEADER="// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved."
+COPYRIGHT_HEADER="// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved."
 
 # Go to root directory
 for f in $(find $ENFORCED_FILES -name *.hpp -o -name *.cpp -o -name *.h);

--- a/src/autonet/AutoNetServer.cpp
+++ b/src/autonet/AutoNetServer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "AutoNetServer.h"
 

--- a/src/autonet/AutoNetServer.h
+++ b/src/autonet/AutoNetServer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <autowiring/CoreThread.h>
 #include <autowiring/Decompose.h>

--- a/src/autonet/AutoNetServerImpl.cpp
+++ b/src/autonet/AutoNetServerImpl.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "AutoNetServerImpl.hpp"
 #include <autowiring/autowiring.h>

--- a/src/autonet/AutoNetServerImpl.hpp
+++ b/src/autonet/AutoNetServerImpl.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AutoNetServer.h"
 #include <json11/json11.hpp>

--- a/src/autonet/AutoNetTransportHttp.cpp
+++ b/src/autonet/AutoNetTransportHttp.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "AutoNetTransportHttp.hpp"
 

--- a/src/autonet/AutoNetTransportHttp.hpp
+++ b/src/autonet/AutoNetTransportHttp.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AutoNetServer.h"
 #include MEMORY_HEADER

--- a/src/autonet/stdafx.cpp
+++ b/src/autonet/stdafx.cpp
@@ -1,2 +1,2 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"

--- a/src/autonet/stdafx.h
+++ b/src/autonet/stdafx.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <math.h>
 #include <assert.h>

--- a/src/autonet/test/AutoNetTest.cpp
+++ b/src/autonet/test/AutoNetTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autotesting/gtest-all-guard.hpp>
 

--- a/src/autonet/test/BreakpointTest.cpp
+++ b/src/autonet/test/BreakpointTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autonet/AutoNetServer.h>
 #include <autonet/AutoNetServerImpl.hpp>

--- a/src/autonet/test/RPCTest.cpp
+++ b/src/autonet/test/RPCTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autonet/AutoNetServer.h>
 #include <autonet/AutoNetServerImpl.hpp>

--- a/src/autonet/test/WebsocketTest.cpp
+++ b/src/autonet/test/WebsocketTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autonet/AutoNetServer.h>
 #include <autowiring/autowiring.h>

--- a/src/autonet/test/stdafx.cpp
+++ b/src/autonet/test/stdafx.cpp
@@ -1,2 +1,2 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"

--- a/src/autonet/test/stdafx.h
+++ b/src/autonet/test/stdafx.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 #include <autowiring/C++11/cpp11.h>

--- a/src/autotesting/AutowiringEnclosure.h
+++ b/src/autotesting/AutowiringEnclosure.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <autowiring/autowiring.h>
 #include <autowiring/AutowiringDebug.h>

--- a/src/autotesting/gtest-all-guard.cpp
+++ b/src/autotesting/gtest-all-guard.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <gtest/gtest-all.cc>
 #include "AutowiringEnclosure.h"

--- a/src/autotesting/gtest-all-guard.hpp
+++ b/src/autotesting/gtest-all-guard.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 /// <summary>

--- a/src/autotesting/stdafx.cpp
+++ b/src/autotesting/stdafx.cpp
@@ -1,2 +1,2 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"

--- a/src/autotesting/stdafx.h
+++ b/src/autotesting/stdafx.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 // Internal build flag for namespace discrimination

--- a/src/autowiring/AnySharedPointer.cpp
+++ b/src/autowiring/AnySharedPointer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "AnySharedPointer.h"
 

--- a/src/autowiring/AnySharedPointer.h
+++ b/src/autowiring/AnySharedPointer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "auto_id.h"
 #include "fast_pointer_cast.h"

--- a/src/autowiring/AutoCurrentPacketPusher.h
+++ b/src/autowiring/AutoCurrentPacketPusher.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AutoPacket.h"
 

--- a/src/autowiring/AutoFilterArgument.h
+++ b/src/autowiring/AutoFilterArgument.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <typeinfo>
 

--- a/src/autowiring/AutoFilterDescriptor.cpp
+++ b/src/autowiring/AutoFilterDescriptor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "AutoFilterDescriptor.h"
 

--- a/src/autowiring/AutoFilterDescriptor.h
+++ b/src/autowiring/AutoFilterDescriptor.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AnySharedPointer.h"
 #include "altitude.h"

--- a/src/autowiring/AutoPacket.cpp
+++ b/src/autowiring/AutoPacket.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "AutoCurrentPacketPusher.h"
 #include "AutoPacket.h"

--- a/src/autowiring/AutoPacket.h
+++ b/src/autowiring/AutoPacket.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AnySharedPointer.h"
 #include "at_exit.h"

--- a/src/autowiring/AutoPacketFactory.cpp
+++ b/src/autowiring/AutoPacketFactory.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "AutoPacketFactory.h"
 #include "AutoPacketInternal.hpp"

--- a/src/autowiring/AutoPacketFactory.h
+++ b/src/autowiring/AutoPacketFactory.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AutoPacket.h"
 #include "AutoFilterDescriptor.h"

--- a/src/autowiring/AutoPacketGraph.cpp
+++ b/src/autowiring/AutoPacketGraph.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "AutoPacketGraph.h"
 #include "CoreContext.h"

--- a/src/autowiring/AutoPacketGraph.h
+++ b/src/autowiring/AutoPacketGraph.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AutoFilterDescriptor.h"
 #include "AutoPacket.h"

--- a/src/autowiring/AutoPacketInternal.cpp
+++ b/src/autowiring/AutoPacketInternal.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "AutoCurrentPacketPusher.h"
 #include "AutoPacketInternal.hpp"

--- a/src/autowiring/AutoPacketInternal.hpp
+++ b/src/autowiring/AutoPacketInternal.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AutoPacket.h"
 

--- a/src/autowiring/AutowirableSlot.cpp
+++ b/src/autowiring/AutowirableSlot.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "AutowirableSlot.h"
 #include "autowiring_error.h"

--- a/src/autowiring/AutowirableSlot.h
+++ b/src/autowiring/AutowirableSlot.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AnySharedPointer.h"
 #include "auto_signal.h"

--- a/src/autowiring/Autowired.cpp
+++ b/src/autowiring/Autowired.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "Autowired.h"
 

--- a/src/autowiring/Autowired.h
+++ b/src/autowiring/Autowired.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "auto_id.h"
 #include "auto_signal.h"

--- a/src/autowiring/AutowiringDebug.cpp
+++ b/src/autowiring/AutowiringDebug.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "AutowiringDebug.h"
 #include "Autowired.h"

--- a/src/autowiring/AutowiringDebug.h
+++ b/src/autowiring/AutowiringDebug.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <string>
 #include <vector>

--- a/src/autowiring/BasicThread.cpp
+++ b/src/autowiring/BasicThread.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "BasicThread.h"
 #include "autowiring_error.h"

--- a/src/autowiring/BasicThread.h
+++ b/src/autowiring/BasicThread.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "ContextMember.h"
 #include "CoreRunnable.h"

--- a/src/autowiring/BasicThreadStateBlock.cpp
+++ b/src/autowiring/BasicThreadStateBlock.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "BasicThreadStateBlock.h"
 

--- a/src/autowiring/BasicThreadStateBlock.h
+++ b/src/autowiring/BasicThreadStateBlock.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include MEMORY_HEADER
 #include MUTEX_HEADER

--- a/src/autowiring/Bolt.h
+++ b/src/autowiring/Bolt.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "is_any.h"
 #include "BoltBase.h"

--- a/src/autowiring/BoltBase.cpp
+++ b/src/autowiring/BoltBase.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "BoltBase.h"
 

--- a/src/autowiring/BoltBase.h
+++ b/src/autowiring/BoltBase.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "auto_id.h"
 

--- a/src/autowiring/C++11/boost_array.h
+++ b/src/autowiring/C++11/boost_array.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 #include <autoboost/array.hpp>

--- a/src/autowiring/C++11/boost_exception_ptr.h
+++ b/src/autowiring/C++11/boost_exception_ptr.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 #include <autoboost/exception_ptr.hpp>

--- a/src/autowiring/C++11/boost_functional.h
+++ b/src/autowiring/C++11/boost_functional.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <autoboost/function.hpp>
 #include <autoboost/detail/is_sorted.hpp>

--- a/src/autowiring/C++11/boost_future.h
+++ b/src/autowiring/C++11/boost_future.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 #define AUTOBOOST_THREAD_PROVIDES_FUTURE

--- a/src/autowiring/C++11/boost_shared_ptr.h
+++ b/src/autowiring/C++11/boost_shared_ptr.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 // We need to use the autoboost version of shared_ptr everywhere

--- a/src/autowiring/C++11/boost_type_traits.h
+++ b/src/autowiring/C++11/boost_type_traits.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 #include <autoboost/type_traits/conditional.hpp>

--- a/src/autowiring/C++11/chrono_with_profiling_clock.h
+++ b/src/autowiring/C++11/chrono_with_profiling_clock.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 #include <chrono>

--- a/src/autowiring/C++11/cpp11.h
+++ b/src/autowiring/C++11/cpp11.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 // The reason this header exists is due to the asymmetric availability of C++11 on our

--- a/src/autowiring/C++11/empty_file.h
+++ b/src/autowiring/C++11/empty_file.h
@@ -1,3 +1,3 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 // Just an empty file, used when we cannot provide a feature.

--- a/src/autowiring/C++11/filesystem.h
+++ b/src/autowiring/C++11/filesystem.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 //C++17 Filesystem standard

--- a/src/autowiring/C++11/make_unique.h
+++ b/src/autowiring/C++11/make_unique.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 #include RVALUE_HEADER

--- a/src/autowiring/C++11/memory.h
+++ b/src/autowiring/C++11/memory.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 #include <memory>

--- a/src/autowiring/C++11/memory_nostl11.h
+++ b/src/autowiring/C++11/memory_nostl11.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 #include "boost_shared_ptr.h"

--- a/src/autowiring/C++11/mutex.h
+++ b/src/autowiring/C++11/mutex.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 #include <mutex>

--- a/src/autowiring/C++11/unique_ptr.h
+++ b/src/autowiring/C++11/unique_ptr.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 #include <autoboost/type_traits/remove_reference.hpp>

--- a/src/autowiring/CallExtractor.cpp
+++ b/src/autowiring/CallExtractor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "CallExtractor.h"
 #include "AutoPacket.h"

--- a/src/autowiring/CallExtractor.h
+++ b/src/autowiring/CallExtractor.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "auto_arg.h"
 #include "auto_in.h"

--- a/src/autowiring/ConfigBolt.cpp
+++ b/src/autowiring/ConfigBolt.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ConfigBolt.h"
 #include "autowiring.h"

--- a/src/autowiring/ConfigBolt.h
+++ b/src/autowiring/ConfigBolt.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "auto_id.h"
 #include "Bolt.h"

--- a/src/autowiring/ConfigManager.cpp
+++ b/src/autowiring/ConfigManager.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ConfigManager.h"
 #include "ConfigRegistry.h"

--- a/src/autowiring/ConfigManager.h
+++ b/src/autowiring/ConfigManager.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "auto_id.h"
 #include "config_descriptor.h"

--- a/src/autowiring/ConfigRegistry.cpp
+++ b/src/autowiring/ConfigRegistry.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ConfigRegistry.h"
 

--- a/src/autowiring/ConfigRegistry.h
+++ b/src/autowiring/ConfigRegistry.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "config_descriptor.h"
 #include <atomic>

--- a/src/autowiring/ContextEnumerator.cpp
+++ b/src/autowiring/ContextEnumerator.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ContextEnumerator.h"
 #include "CoreContext.h"

--- a/src/autowiring/ContextEnumerator.h
+++ b/src/autowiring/ContextEnumerator.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "autowiring_error.h"
 #include MEMORY_HEADER

--- a/src/autowiring/ContextMap.h
+++ b/src/autowiring/ContextMap.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "autowiring_error.h"
 #include "CoreContext.h"

--- a/src/autowiring/ContextMember.cpp
+++ b/src/autowiring/ContextMember.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ContextMember.h"
 #include "CoreContext.h"

--- a/src/autowiring/ContextMember.h
+++ b/src/autowiring/ContextMember.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "CoreObject.h"
 #include "TeardownNotifier.h"

--- a/src/autowiring/CoreContext.cpp
+++ b/src/autowiring/CoreContext.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "CoreContext.h"
 #include "AutoPacketFactory.h"

--- a/src/autowiring/CoreContext.h
+++ b/src/autowiring/CoreContext.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AnySharedPointer.h"
 #include "auto_signal.h"

--- a/src/autowiring/CoreContextStateBlock.cpp
+++ b/src/autowiring/CoreContextStateBlock.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "CoreContextStateBlock.h"
 #include "CoreContext.h"

--- a/src/autowiring/CoreContextStateBlock.h
+++ b/src/autowiring/CoreContextStateBlock.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "CoreObject.h"
 #include <memory>

--- a/src/autowiring/CoreJob.cpp
+++ b/src/autowiring/CoreJob.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "CoreJob.h"
 #include "CoreContext.h"

--- a/src/autowiring/CoreJob.h
+++ b/src/autowiring/CoreJob.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "ContextMember.h"
 #include "CoreRunnable.h"

--- a/src/autowiring/CoreObject.cpp
+++ b/src/autowiring/CoreObject.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "CoreObject.h"
 

--- a/src/autowiring/CoreObject.h
+++ b/src/autowiring/CoreObject.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 /// <summary>

--- a/src/autowiring/CoreObjectDescriptor.h
+++ b/src/autowiring/CoreObjectDescriptor.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AnySharedPointer.h"
 #include "auto_id.h"

--- a/src/autowiring/CoreRunnable.cpp
+++ b/src/autowiring/CoreRunnable.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "CoreRunnable.h"
 

--- a/src/autowiring/CoreRunnable.h
+++ b/src/autowiring/CoreRunnable.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "C++11/cpp11.h"
 #include CHRONO_HEADER

--- a/src/autowiring/CoreThread.cpp
+++ b/src/autowiring/CoreThread.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "CoreThread.h"
 #include "BasicThreadStateBlock.h"

--- a/src/autowiring/CoreThread.h
+++ b/src/autowiring/CoreThread.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "BasicThread.h"
 #include "DispatchQueue.h"

--- a/src/autowiring/CoreThreadLinux.cpp
+++ b/src/autowiring/CoreThreadLinux.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "BasicThread.h"
 #include "BasicThreadStateBlock.h"

--- a/src/autowiring/CoreThreadMac.cpp
+++ b/src/autowiring/CoreThreadMac.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "BasicThread.h"
 #include "BasicThreadStateBlock.h"

--- a/src/autowiring/CoreThreadWin.cpp
+++ b/src/autowiring/CoreThreadWin.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "BasicThread.h"
 #include "BasicThreadStateBlock.h"

--- a/src/autowiring/CreationRules.h
+++ b/src/autowiring/CreationRules.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "has_simple_constructor.h"
 #include "has_static_new.h"

--- a/src/autowiring/CreationRulesUnix.cpp
+++ b/src/autowiring/CreationRulesUnix.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "CreationRules.h"
 #include <cstdlib>

--- a/src/autowiring/CreationRulesWin.cpp
+++ b/src/autowiring/CreationRulesWin.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "CreationRules.h"
 

--- a/src/autowiring/CurrentContextPusher.cpp
+++ b/src/autowiring/CurrentContextPusher.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "CurrentContextPusher.h"
 #include "GlobalCoreContext.h"

--- a/src/autowiring/CurrentContextPusher.h
+++ b/src/autowiring/CurrentContextPusher.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include MEMORY_HEADER
 

--- a/src/autowiring/Decompose.h
+++ b/src/autowiring/Decompose.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "is_any.h"
 #include <typeinfo>

--- a/src/autowiring/DecorationDisposition.h
+++ b/src/autowiring/DecorationDisposition.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "altitude.h"
 #include "AnySharedPointer.h"

--- a/src/autowiring/Deferred.h
+++ b/src/autowiring/Deferred.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 class DispatchQueue;

--- a/src/autowiring/Deserialize.h
+++ b/src/autowiring/Deserialize.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include TYPE_TRAITS_HEADER
 #include <string>

--- a/src/autowiring/DispatchQueue.cpp
+++ b/src/autowiring/DispatchQueue.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "DispatchQueue.h"
 #include "at_exit.h"

--- a/src/autowiring/DispatchQueue.h
+++ b/src/autowiring/DispatchQueue.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "dispatch_aborted_exception.h"
 #include "DispatchThunk.h"

--- a/src/autowiring/DispatchThunk.h
+++ b/src/autowiring/DispatchThunk.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include CHRONO_HEADER
 #include <memory>

--- a/src/autowiring/ExceptionFilter.cpp
+++ b/src/autowiring/ExceptionFilter.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ExceptionFilter.h"
 

--- a/src/autowiring/ExceptionFilter.h
+++ b/src/autowiring/ExceptionFilter.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 class JunctionBoxBase;

--- a/src/autowiring/GlobalCoreContext.cpp
+++ b/src/autowiring/GlobalCoreContext.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "GlobalCoreContext.h"
 #include <cassert>

--- a/src/autowiring/GlobalCoreContext.h
+++ b/src/autowiring/GlobalCoreContext.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "CoreContext.h"
 

--- a/src/autowiring/HeteroBlock.cpp
+++ b/src/autowiring/HeteroBlock.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "HeteroBlock.h"
 #include "CreationRules.h"

--- a/src/autowiring/HeteroBlock.h
+++ b/src/autowiring/HeteroBlock.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "auto_id.h"
 #include <initializer_list>

--- a/src/autowiring/LockFreeList.h
+++ b/src/autowiring/LockFreeList.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 template<class T>

--- a/src/autowiring/LockReducedCollection.h
+++ b/src/autowiring/LockReducedCollection.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "InterlockedExchange.h"
 #include "ObjectPool.h"

--- a/src/autowiring/ManualThreadPool.cpp
+++ b/src/autowiring/ManualThreadPool.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ManualThreadPool.h"
 #include "at_exit.h"

--- a/src/autowiring/ManualThreadPool.h
+++ b/src/autowiring/ManualThreadPool.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "DispatchQueue.h"
 #include "ThreadPool.h"

--- a/src/autowiring/MemoEntry.cpp
+++ b/src/autowiring/MemoEntry.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "MemoEntry.h"
 

--- a/src/autowiring/MemoEntry.h
+++ b/src/autowiring/MemoEntry.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AnySharedPointer.h"
 #include "once.h"

--- a/src/autowiring/MicroBolt.h
+++ b/src/autowiring/MicroBolt.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Bolt.h"
 #include "CoreContext.h"

--- a/src/autowiring/NewAutoFilter.cpp
+++ b/src/autowiring/NewAutoFilter.cpp
@@ -1,3 +1,3 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "NewAutoFilter.h"

--- a/src/autowiring/NullPool.cpp
+++ b/src/autowiring/NullPool.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "NullPool.h"
 

--- a/src/autowiring/NullPool.h
+++ b/src/autowiring/NullPool.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "ThreadPool.h"
 #include "DispatchQueue.h"

--- a/src/autowiring/Object.h
+++ b/src/autowiring/Object.h
@@ -1,3 +1,3 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "CoreObject.h"

--- a/src/autowiring/ObjectPool.h
+++ b/src/autowiring/ObjectPool.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "autowiring_error.h"
 #include "ObjectPoolMonitor.h"

--- a/src/autowiring/ObjectPoolMonitor.cpp
+++ b/src/autowiring/ObjectPoolMonitor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ObjectPoolMonitor.h"
 

--- a/src/autowiring/ObjectPoolMonitor.h
+++ b/src/autowiring/ObjectPoolMonitor.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <functional>
 #include MUTEX_HEADER

--- a/src/autowiring/Parallel.cpp
+++ b/src/autowiring/Parallel.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "Parallel.h"
 #include "autowiring.h"

--- a/src/autowiring/Parallel.h
+++ b/src/autowiring/Parallel.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AnySharedPointer.h"
 #include "auto_id.h"

--- a/src/autowiring/SatCounter.h
+++ b/src/autowiring/SatCounter.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AutoFilterDescriptor.h"
 

--- a/src/autowiring/SlotInformation.cpp
+++ b/src/autowiring/SlotInformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "SlotInformation.h"
 #include "AutowirableSlot.h"

--- a/src/autowiring/SlotInformation.h
+++ b/src/autowiring/SlotInformation.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "auto_id.h"
 #include "TypeUnifier.h"

--- a/src/autowiring/SystemThreadPool.cpp
+++ b/src/autowiring/SystemThreadPool.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "SystemThreadPool.h"
 

--- a/src/autowiring/SystemThreadPool.h
+++ b/src/autowiring/SystemThreadPool.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "ThreadPool.h"
 

--- a/src/autowiring/SystemThreadPoolStl.cpp
+++ b/src/autowiring/SystemThreadPoolStl.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "SystemThreadPoolStl.h"
 #include "at_exit.h"

--- a/src/autowiring/SystemThreadPoolStl.h
+++ b/src/autowiring/SystemThreadPoolStl.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "DispatchQueue.h"
 #include "SystemThreadPool.h"

--- a/src/autowiring/SystemThreadPoolWin.cpp
+++ b/src/autowiring/SystemThreadPoolWin.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "SystemThreadPoolWin.hpp"
 #include "SystemThreadPoolWinLH.hpp"

--- a/src/autowiring/SystemThreadPoolWin.hpp
+++ b/src/autowiring/SystemThreadPoolWin.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "DispatchQueue.h"
 #include "SystemThreadPool.h"

--- a/src/autowiring/SystemThreadPoolWinLH.cpp
+++ b/src/autowiring/SystemThreadPoolWinLH.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "SystemThreadPoolWinLH.hpp"
 #include "DispatchThunk.h"

--- a/src/autowiring/SystemThreadPoolWinLH.hpp
+++ b/src/autowiring/SystemThreadPoolWinLH.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "DispatchQueue.h"
 #include "SystemThreadPoolWin.hpp"

--- a/src/autowiring/SystemThreadPoolWinXP.cpp
+++ b/src/autowiring/SystemThreadPoolWinXP.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "SystemThreadPoolWinXP.hpp"
 #include "DispatchThunk.h"

--- a/src/autowiring/SystemThreadPoolWinXP.hpp
+++ b/src/autowiring/SystemThreadPoolWinXP.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "DispatchQueue.h"
 #include "SystemThreadPoolWin.hpp"

--- a/src/autowiring/TeardownNotifier.cpp
+++ b/src/autowiring/TeardownNotifier.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TeardownNotifier.h"
 

--- a/src/autowiring/TeardownNotifier.h
+++ b/src/autowiring/TeardownNotifier.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "C++11/cpp11.h"
 #include <atomic>

--- a/src/autowiring/ThreadPool.cpp
+++ b/src/autowiring/ThreadPool.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ThreadPool.h"
 #include "DispatchQueue.h"

--- a/src/autowiring/ThreadPool.h
+++ b/src/autowiring/ThreadPool.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "DispatchThunk.h"
 #include <atomic>

--- a/src/autowiring/TypeIdentifier.h
+++ b/src/autowiring/TypeIdentifier.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "CoreObject.h"
 #include <typeinfo>

--- a/src/autowiring/TypeRegistry.cpp
+++ b/src/autowiring/TypeRegistry.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TypeRegistry.h"
 

--- a/src/autowiring/TypeRegistry.h
+++ b/src/autowiring/TypeRegistry.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "autowiring_error.h"
 #include "CreationRules.h"

--- a/src/autowiring/TypeUnifier.h
+++ b/src/autowiring/TypeUnifier.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "CoreObject.h"
 #include RVALUE_HEADER

--- a/src/autowiring/altitude.h
+++ b/src/autowiring/altitude.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 namespace autowiring {

--- a/src/autowiring/at_exit.h
+++ b/src/autowiring/at_exit.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include RVALUE_HEADER
 

--- a/src/autowiring/atomic_list.cpp
+++ b/src/autowiring/atomic_list.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "atomic_list.h"
 #include <mutex>

--- a/src/autowiring/atomic_list.h
+++ b/src/autowiring/atomic_list.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "callable.h"
 #include "spin_lock.h"

--- a/src/autowiring/auto_arg.cpp
+++ b/src/autowiring/auto_arg.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "auto_arg.h"
 #include "CoreContext.h"

--- a/src/autowiring/auto_arg.h
+++ b/src/autowiring/auto_arg.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AutoPacket.h"
 #include "auto_id.h"

--- a/src/autowiring/auto_id.cpp
+++ b/src/autowiring/auto_id.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "auto_id.h"
 

--- a/src/autowiring/auto_id.h
+++ b/src/autowiring/auto_id.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "fast_pointer_cast.h"
 

--- a/src/autowiring/auto_in.h
+++ b/src/autowiring/auto_in.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "auto_arg.h"
 #include MEMORY_HEADER

--- a/src/autowiring/auto_out.h
+++ b/src/autowiring/auto_out.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AutoPacket.h"
 #include "autowiring_error.h"

--- a/src/autowiring/auto_prev.h
+++ b/src/autowiring/auto_prev.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "auto_arg.h"
 

--- a/src/autowiring/auto_signal.h
+++ b/src/autowiring/auto_signal.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "atomic_list.h"
 #include "auto_tuple.h"

--- a/src/autowiring/auto_tuple.h
+++ b/src/autowiring/auto_tuple.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "is_any.h"
 #include "index_tuple.h"

--- a/src/autowiring/autowiring.h
+++ b/src/autowiring/autowiring.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 #include "Autowired.h"

--- a/src/autowiring/autowiring_error.cpp
+++ b/src/autowiring/autowiring_error.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "autowiring_error.h"
 #include "demangle.h"

--- a/src/autowiring/autowiring_error.h
+++ b/src/autowiring/autowiring_error.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <exception>
 #include <string>

--- a/src/autowiring/basic_timer.h
+++ b/src/autowiring/basic_timer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <chrono>
 

--- a/src/autowiring/bounds.h
+++ b/src/autowiring/bounds.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <type_traits>
 

--- a/src/autowiring/callable.h
+++ b/src/autowiring/callable.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "index_tuple.h"
 #include <memory>

--- a/src/autowiring/chrono_types.h
+++ b/src/autowiring/chrono_types.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <autowiring/C++11/cpp11.h>
 #include CHRONO_HEADER

--- a/src/autowiring/config.h
+++ b/src/autowiring/config.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "marshaller.h"
 #include "spin_lock.h"

--- a/src/autowiring/config_descriptor.cpp
+++ b/src/autowiring/config_descriptor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "config_descriptor.h"
 

--- a/src/autowiring/config_descriptor.h
+++ b/src/autowiring/config_descriptor.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "AnySharedPointer.h"
 #include "auto_id.h"

--- a/src/autowiring/config_event.h
+++ b/src/autowiring/config_event.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "config_descriptor.h"
 

--- a/src/autowiring/demangle.cpp
+++ b/src/autowiring/demangle.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "demangle.h"
 #include "AnySharedPointer.h"

--- a/src/autowiring/demangle.h
+++ b/src/autowiring/demangle.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <string>
 #include <typeinfo>

--- a/src/autowiring/deref_error.cpp
+++ b/src/autowiring/deref_error.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "deref_error.h"
 #include "demangle.h"

--- a/src/autowiring/deref_error.h
+++ b/src/autowiring/deref_error.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "autowiring_error.h"
 #include <typeinfo>

--- a/src/autowiring/dereferencer.h
+++ b/src/autowiring/dereferencer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 namespace autowiring {

--- a/src/autowiring/dispatch_aborted_exception.cpp
+++ b/src/autowiring/dispatch_aborted_exception.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "dispatch_aborted_exception.h"
 

--- a/src/autowiring/dispatch_aborted_exception.h
+++ b/src/autowiring/dispatch_aborted_exception.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "autowiring_error.h"
 

--- a/src/autowiring/fast_pointer_cast.h
+++ b/src/autowiring/fast_pointer_cast.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "C++11/cpp11.h"
 #include MEMORY_HEADER

--- a/src/autowiring/has_autofilter.h
+++ b/src/autowiring/has_autofilter.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Decompose.h"
 #include "Deferred.h"

--- a/src/autowiring/has_autoinit.h
+++ b/src/autowiring/has_autoinit.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Decompose.h"
 

--- a/src/autowiring/has_getconfigdescriptor.h
+++ b/src/autowiring/has_getconfigdescriptor.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include TYPE_TRAITS_HEADER
 #include RVALUE_HEADER

--- a/src/autowiring/has_simple_constructor.h
+++ b/src/autowiring/has_simple_constructor.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include TYPE_TRAITS_HEADER
 

--- a/src/autowiring/has_static_new.h
+++ b/src/autowiring/has_static_new.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include TYPE_TRAITS_HEADER
 #include RVALUE_HEADER

--- a/src/autowiring/has_validate.h
+++ b/src/autowiring/has_validate.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 namespace autowiring {

--- a/src/autowiring/hash_tuple.h
+++ b/src/autowiring/hash_tuple.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include STL_TUPLE_HEADER
 #include "index_tuple.h"

--- a/src/autowiring/index_tuple.h
+++ b/src/autowiring/index_tuple.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <type_traits>
 

--- a/src/autowiring/is_any.h
+++ b/src/autowiring/is_any.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "C++11/cpp11.h"
 #include TYPE_TRAITS_HEADER

--- a/src/autowiring/is_shared_ptr.h
+++ b/src/autowiring/is_shared_ptr.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 namespace autowiring {

--- a/src/autowiring/marshaller.h
+++ b/src/autowiring/marshaller.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <atomic>
 #include <initializer_list>

--- a/src/autowiring/member_new_type.h
+++ b/src/autowiring/member_new_type.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "Decompose.h"
 #include STL_TUPLE_HEADER

--- a/src/autowiring/noop.h
+++ b/src/autowiring/noop.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 namespace autowiring {

--- a/src/autowiring/observable.h
+++ b/src/autowiring/observable.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "marshaller.h"
 #include "auto_signal.h"

--- a/src/autowiring/once.cpp
+++ b/src/autowiring/once.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "once.h"
 

--- a/src/autowiring/once.h
+++ b/src/autowiring/once.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "auto_signal.h"
 #include "callable.h"

--- a/src/autowiring/optional.h
+++ b/src/autowiring/optional.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <memory>
 #include <stdexcept>

--- a/src/autowiring/registration.h
+++ b/src/autowiring/registration.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "signal_base.h"
 

--- a/src/autowiring/signal.h
+++ b/src/autowiring/signal.h
@@ -1,2 +1,2 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "auto_signal.h"

--- a/src/autowiring/signal_base.h
+++ b/src/autowiring/signal_base.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 namespace autowiring {

--- a/src/autowiring/spin_lock.h
+++ b/src/autowiring/spin_lock.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <atomic>
 

--- a/src/autowiring/stdafx.cpp
+++ b/src/autowiring/stdafx.cpp
@@ -1,2 +1,2 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"

--- a/src/autowiring/stdafx.h
+++ b/src/autowiring/stdafx.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 // Internal build flag for namespace discrimination

--- a/src/autowiring/sum.h
+++ b/src/autowiring/sum.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 namespace autowiring {

--- a/src/autowiring/test/AnySharedPointerTest.cpp
+++ b/src/autowiring/test/AnySharedPointerTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/Decoration.hpp"
 #include "TestFixtures/SimpleObject.hpp"

--- a/src/autowiring/test/ArgumentTypeTest.cpp
+++ b/src/autowiring/test/ArgumentTypeTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/var_logic.h>
 #include <autowiring/auto_arg.h>

--- a/src/autowiring/test/AtomicListTest.cpp
+++ b/src/autowiring/test/AtomicListTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/at_exit.h>
 #include <autowiring/atomic_list.h>

--- a/src/autowiring/test/AutoConfigTest.cpp
+++ b/src/autowiring/test/AutoConfigTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/config_descriptor.h>
 #include <autowiring/config.h>

--- a/src/autowiring/test/AutoConfig_FromTableTest.cpp
+++ b/src/autowiring/test/AutoConfig_FromTableTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/config_descriptor.h>
 #include <autowiring/config.h>

--- a/src/autowiring/test/AutoConfig_SliderTest.cpp
+++ b/src/autowiring/test/AutoConfig_SliderTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/config_descriptor.h>
 #include <autowiring/config.h>

--- a/src/autowiring/test/AutoConstructTest.cpp
+++ b/src/autowiring/test/AutoConstructTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 
 class AutoConstructTest:

--- a/src/autowiring/test/AutoFilterAltitudeTest.cpp
+++ b/src/autowiring/test/AutoFilterAltitudeTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/Decoration.hpp"
 #include <autowiring/autowiring.h>

--- a/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
+++ b/src/autowiring/test/AutoFilterCollapseRulesTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/Decoration.hpp"
 

--- a/src/autowiring/test/AutoFilterConstructRulesTest.cpp
+++ b/src/autowiring/test/AutoFilterConstructRulesTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 
 /*

--- a/src/autowiring/test/AutoFilterDescriptorTest.cpp
+++ b/src/autowiring/test/AutoFilterDescriptorTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/Decoration.hpp"
 #include <autowiring/AutoFilterDescriptor.h>

--- a/src/autowiring/test/AutoFilterDiagnosticsTest.cpp
+++ b/src/autowiring/test/AutoFilterDiagnosticsTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/autowiring.h>
 #include <autowiring/demangle.h>

--- a/src/autowiring/test/AutoFilterFunctionTest.cpp
+++ b/src/autowiring/test/AutoFilterFunctionTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/Decoration.hpp"
 #include <autowiring/autowiring.h>

--- a/src/autowiring/test/AutoFilterMultiDecorateTest.cpp
+++ b/src/autowiring/test/AutoFilterMultiDecorateTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/CoreThread.h>
 #include "TestFixtures/Decoration.hpp"

--- a/src/autowiring/test/AutoFilterPointerOutTest.cpp
+++ b/src/autowiring/test/AutoFilterPointerOutTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/Decoration.hpp"
 

--- a/src/autowiring/test/AutoFilterRvalueTest.cpp
+++ b/src/autowiring/test/AutoFilterRvalueTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/autowiring.h>
 #include <autowiring/SatCounter.h>

--- a/src/autowiring/test/AutoFilterSatisfiabilityTest.cpp
+++ b/src/autowiring/test/AutoFilterSatisfiabilityTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/autowiring.h>
 #include "TestFixtures/Decoration.hpp"

--- a/src/autowiring/test/AutoFilterSequencing.cpp
+++ b/src/autowiring/test/AutoFilterSequencing.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/Decoration.hpp"
 #include <autowiring/autowiring.h>

--- a/src/autowiring/test/AutoFilterTest.cpp
+++ b/src/autowiring/test/AutoFilterTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/Decoration.hpp"
 #include <autowiring/AutoPacket.h>

--- a/src/autowiring/test/AutoIDTest.cpp
+++ b/src/autowiring/test/AutoIDTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/Decoration.hpp"
 #include <autowiring/autowiring.h>

--- a/src/autowiring/test/AutoOutTest.cpp
+++ b/src/autowiring/test/AutoOutTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "AutoOutTest.h"
 #include "auto_out.h"

--- a/src/autowiring/test/AutoOutTest.hpp
+++ b/src/autowiring/test/AutoOutTest.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "EnclosedContextTestBase.h"
 

--- a/src/autowiring/test/AutoOutputTest.cpp
+++ b/src/autowiring/test/AutoOutputTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "AutoOutputTest.h"
 #include "AutoPacketFactory.h"

--- a/src/autowiring/test/AutoOutputTest.hpp
+++ b/src/autowiring/test/AutoOutputTest.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "EnclosedContextTestBase.h"
 

--- a/src/autowiring/test/AutoPacketFactoryTest.cpp
+++ b/src/autowiring/test/AutoPacketFactoryTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/CoreThread.h>
 #include CHRONO_HEADER

--- a/src/autowiring/test/AutoPacketTest.cpp
+++ b/src/autowiring/test/AutoPacketTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/CoreThread.h>
 #include "TestFixtures/Decoration.hpp"

--- a/src/autowiring/test/AutoSignalTest.cpp
+++ b/src/autowiring/test/AutoSignalTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/autowiring.h>
 #include <thread>

--- a/src/autowiring/test/AutowiringDebugTest.cpp
+++ b/src/autowiring/test/AutowiringDebugTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/autowiring.h>
 #include <autowiring/AutowiringDebug.h>

--- a/src/autowiring/test/AutowiringTest.cpp
+++ b/src/autowiring/test/AutowiringTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/SimpleObject.hpp"
 #include "TestFixtures/SimpleReceiver.hpp"

--- a/src/autowiring/test/AutowiringUtilitiesTest.cpp
+++ b/src/autowiring/test/AutowiringUtilitiesTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/autowiring.h>
 #include <autowiring/BasicThread.h>

--- a/src/autowiring/test/BasicThreadTest.cpp
+++ b/src/autowiring/test/BasicThreadTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/BasicThread.h>
 #include FUTURE_HEADER

--- a/src/autowiring/test/BoltTest.cpp
+++ b/src/autowiring/test/BoltTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/autowiring.h>
 #include <autowiring/Bolt.h>

--- a/src/autowiring/test/CommonUseCasesTest.cpp
+++ b/src/autowiring/test/CommonUseCasesTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "HasForwardOnlyType.hpp"
 

--- a/src/autowiring/test/ContextCleanupTest.cpp
+++ b/src/autowiring/test/ContextCleanupTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/SimpleObject.hpp"
 #include "TestFixtures/SimpleThreaded.hpp"

--- a/src/autowiring/test/ContextCreatorTest.cpp
+++ b/src/autowiring/test/ContextCreatorTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/ContextCreator.h>
 #include <autowiring/CoreContext.h>

--- a/src/autowiring/test/ContextEnumeratorTest.cpp
+++ b/src/autowiring/test/ContextEnumeratorTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/ContextEnumerator.h>
 #include <algorithm>

--- a/src/autowiring/test/ContextMapTest.cpp
+++ b/src/autowiring/test/ContextMapTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/ExitRaceThreaded.hpp"
 #include "TestFixtures/SimpleThreaded.hpp"

--- a/src/autowiring/test/ContextMemberTest.cpp
+++ b/src/autowiring/test/ContextMemberTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/SimpleObject.hpp"
 #include "TestFixtures/SimpleThreaded.hpp"

--- a/src/autowiring/test/CoreContextTest.cpp
+++ b/src/autowiring/test/CoreContextTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/SimpleObject.hpp"
 #include <autowiring/ContextEnumerator.h>

--- a/src/autowiring/test/CoreJobTest.cpp
+++ b/src/autowiring/test/CoreJobTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/CoreJob.h>
 #include THREAD_HEADER

--- a/src/autowiring/test/CoreRunnableTest.cpp
+++ b/src/autowiring/test/CoreRunnableTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/autowiring.h>
 #include <autowiring/CoreRunnable.h>

--- a/src/autowiring/test/CoreThreadTest.cpp
+++ b/src/autowiring/test/CoreThreadTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/SimpleThreaded.hpp"
 #include <autowiring/at_exit.h>

--- a/src/autowiring/test/CreationRulesTest.cpp
+++ b/src/autowiring/test/CreationRulesTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/Decoration.hpp"
 #include <autowiring/CreationRules.h>

--- a/src/autowiring/test/CurrentContextPusherTest.cpp
+++ b/src/autowiring/test/CurrentContextPusherTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/autowiring.h>
 #include <autowiring/CoreContext.h>

--- a/src/autowiring/test/DecoratorTest.cpp
+++ b/src/autowiring/test/DecoratorTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/Decoration.hpp"
 #include <autowiring/AutoPacket.h>

--- a/src/autowiring/test/DemangleTest.cpp
+++ b/src/autowiring/test/DemangleTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/demangle.h>
 

--- a/src/autowiring/test/DispatchQueueTest.cpp
+++ b/src/autowiring/test/DispatchQueueTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/CoreThread.h>
 #include <autowiring/DispatchQueue.h>

--- a/src/autowiring/test/DtorCorrectnessTest.cpp
+++ b/src/autowiring/test/DtorCorrectnessTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/CoreThread.h>
 #include ATOMIC_HEADER

--- a/src/autowiring/test/ExceptionFilterTest.cpp
+++ b/src/autowiring/test/ExceptionFilterTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/ThrowsWhenFired.hpp"
 #include "TestFixtures/ThrowsWhenRun.hpp"

--- a/src/autowiring/test/FactoryTest.cpp
+++ b/src/autowiring/test/FactoryTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/SimpleInterface.hpp"
 #include <iostream>

--- a/src/autowiring/test/FileSystemHeaderTest.cpp
+++ b/src/autowiring/test/FileSystemHeaderTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/C++11/cpp11.h>
 #include <gtest/gtest.h>

--- a/src/autowiring/test/GlobalInitTest.cpp
+++ b/src/autowiring/test/GlobalInitTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "GlobalInitTest.hpp"
 #include "TestFixtures/SimpleObject.hpp"

--- a/src/autowiring/test/GlobalInitTest.hpp
+++ b/src/autowiring/test/GlobalInitTest.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 class GlobalInitTest:

--- a/src/autowiring/test/HasForwardOnlyType.cpp
+++ b/src/autowiring/test/HasForwardOnlyType.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "HasForwardOnlyType.hpp"
 

--- a/src/autowiring/test/HasForwardOnlyType.hpp
+++ b/src/autowiring/test/HasForwardOnlyType.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <autowiring/autowiring.h>
 

--- a/src/autowiring/test/HeteroBlockTest.cpp
+++ b/src/autowiring/test/HeteroBlockTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/Decoration.hpp"
 #include <autowiring/HeteroBlock.h>

--- a/src/autowiring/test/ImmediateDecoratorTest.cpp
+++ b/src/autowiring/test/ImmediateDecoratorTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ImmediateDecoratorTest.h"
 #include "AutoPacketFactory.h"

--- a/src/autowiring/test/ImmediateDecoratorTest.hpp
+++ b/src/autowiring/test/ImmediateDecoratorTest.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "EnclosedContextTestBase.h"
 

--- a/src/autowiring/test/LockFreeListTest.cpp
+++ b/src/autowiring/test/LockFreeListTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "LockFreeListTest.h"
 #include "LockFreeList.h"

--- a/src/autowiring/test/LockFreeListTest.hpp
+++ b/src/autowiring/test/LockFreeListTest.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "EnclosedContextTestBase.h"
 

--- a/src/autowiring/test/LockReducedCollectionTest.cpp
+++ b/src/autowiring/test/LockReducedCollectionTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "LockReducedCollectionTest.h"
 #include "LockReducedCollection.h"

--- a/src/autowiring/test/LockReducedCollectionTest.hpp
+++ b/src/autowiring/test/LockReducedCollectionTest.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "EnclosedContextTestBase.h"
 

--- a/src/autowiring/test/MarshallerTest.cpp
+++ b/src/autowiring/test/MarshallerTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/marshaller.h>
 

--- a/src/autowiring/test/MentionsVariousOtherTypes.cpp
+++ b/src/autowiring/test/MentionsVariousOtherTypes.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "MentionsVariousOtherTypes.hpp"
 #include <autowiring/autowiring.h>

--- a/src/autowiring/test/MentionsVariousOtherTypes.hpp
+++ b/src/autowiring/test/MentionsVariousOtherTypes.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 class MentionsVariousOtherTypes {

--- a/src/autowiring/test/MultiInheritTest.cpp
+++ b/src/autowiring/test/MultiInheritTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/MultiInherit.hpp"
 #include <autowiring/autowiring.h>

--- a/src/autowiring/test/ObjectPoolTest.cpp
+++ b/src/autowiring/test/ObjectPoolTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/SimpleThreaded.hpp"
 #include <autowiring/ObjectPool.h>

--- a/src/autowiring/test/ObservableTest.cpp
+++ b/src/autowiring/test/ObservableTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/observable.h>
 #include <set>

--- a/src/autowiring/test/OnceTest.cpp
+++ b/src/autowiring/test/OnceTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/SimpleObject.hpp"
 #include "TestFixtures/SimpleThreaded.hpp"

--- a/src/autowiring/test/OptionalDecorationTest.cpp
+++ b/src/autowiring/test/OptionalDecorationTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "OptionalDecorationTest.h"
 #include "AutoPacketFactory.h"

--- a/src/autowiring/test/OptionalDecorationTest.hpp
+++ b/src/autowiring/test/OptionalDecorationTest.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "EnclosedContextTestBase.h"
 

--- a/src/autowiring/test/OptionalTest.cpp
+++ b/src/autowiring/test/OptionalTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/optional.h>
 

--- a/src/autowiring/test/OtherSelectingFixture.cpp
+++ b/src/autowiring/test/OtherSelectingFixture.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "OtherSelectingFixture.hpp"
 #include <autowiring/MicroBolt.h>

--- a/src/autowiring/test/OtherSelectingFixture.hpp
+++ b/src/autowiring/test/OtherSelectingFixture.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <autowiring/ContextMember.h>
 #include <autowiring/MicroBolt.h>

--- a/src/autowiring/test/ParallelTest.cpp
+++ b/src/autowiring/test/ParallelTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/Parallel.h>
 #include <algorithm>

--- a/src/autowiring/test/PostConstructTest.cpp
+++ b/src/autowiring/test/PostConstructTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/SimpleObject.hpp"
 #include "HasForwardOnlyType.hpp"

--- a/src/autowiring/test/PostConstructTest.hpp
+++ b/src/autowiring/test/PostConstructTest.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 class PostConstructTest:

--- a/src/autowiring/test/ScopeTest.cpp
+++ b/src/autowiring/test/ScopeTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/SimpleObject.hpp"
 #include <autowiring/autowiring.h>

--- a/src/autowiring/test/SelfSelectingFixture.cpp
+++ b/src/autowiring/test/SelfSelectingFixture.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "SelfSelectingFixture.hpp"
 #include <autowiring/MicroBolt.h>

--- a/src/autowiring/test/SelfSelectingFixture.hpp
+++ b/src/autowiring/test/SelfSelectingFixture.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <autowiring/ContextMember.h>
 #include <autowiring/MicroBolt.h>

--- a/src/autowiring/test/SelfSelectingFixtureTest.cpp
+++ b/src/autowiring/test/SelfSelectingFixtureTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "OtherSelectingFixture.hpp"
 #include "MentionsVariousOtherTypes.hpp"

--- a/src/autowiring/test/SnoopTest.cpp
+++ b/src/autowiring/test/SnoopTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/Decoration.hpp"
 #include "TestFixtures/SimpleObject.hpp"

--- a/src/autowiring/test/SpinLockTest.cpp
+++ b/src/autowiring/test/SpinLockTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/spin_lock.h>
 #include <gtest/gtest.h>

--- a/src/autowiring/test/TeardownNotifierTest.cpp
+++ b/src/autowiring/test/TeardownNotifierTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/autowiring.h>
 

--- a/src/autowiring/test/TestFixtures/Decoration.hpp
+++ b/src/autowiring/test/TestFixtures/Decoration.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <autowiring/CoreThread.h>
 #include <autowiring/auto_out.h>

--- a/src/autowiring/test/TestFixtures/ExitRaceThreaded.hpp
+++ b/src/autowiring/test/TestFixtures/ExitRaceThreaded.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <autowiring/autowiring.h>
 #include <autowiring/CoreThread.h>

--- a/src/autowiring/test/TestFixtures/FiresManyEventsWhenRun.hpp
+++ b/src/autowiring/test/TestFixtures/FiresManyEventsWhenRun.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "SimpleReceiver.hpp"
 #include <autowiring/CoreThread.h>

--- a/src/autowiring/test/TestFixtures/MultiInherit.hpp
+++ b/src/autowiring/test/TestFixtures/MultiInherit.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "SimpleObject.hpp"
 

--- a/src/autowiring/test/TestFixtures/SimpleInterface.hpp
+++ b/src/autowiring/test/TestFixtures/SimpleInterface.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 class SimpleInterface {

--- a/src/autowiring/test/TestFixtures/SimpleObject.hpp
+++ b/src/autowiring/test/TestFixtures/SimpleObject.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <autowiring/ContextMember.h>
 #include <autowiring/TypeUnifier.h>

--- a/src/autowiring/test/TestFixtures/SimpleReceiver.hpp
+++ b/src/autowiring/test/TestFixtures/SimpleReceiver.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <autowiring/CoreThread.h>
 #include <vector>

--- a/src/autowiring/test/TestFixtures/SimpleThreaded.hpp
+++ b/src/autowiring/test/TestFixtures/SimpleThreaded.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 #include <autowiring/CoreThread.h>

--- a/src/autowiring/test/TestFixtures/ThrowingListener.hpp
+++ b/src/autowiring/test/TestFixtures/ThrowingListener.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 class ThrowingListener {

--- a/src/autowiring/test/TestFixtures/ThrowsWhenFired.hpp
+++ b/src/autowiring/test/TestFixtures/ThrowsWhenFired.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "custom_exception.hpp"
 #include "ThrowingListener.hpp"

--- a/src/autowiring/test/TestFixtures/ThrowsWhenRun.hpp
+++ b/src/autowiring/test/TestFixtures/ThrowsWhenRun.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "ThrowingListener.hpp"
 #include <autowiring/CoreThread.h>

--- a/src/autowiring/test/TestFixtures/custom_exception.hpp
+++ b/src/autowiring/test/TestFixtures/custom_exception.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <exception>
 

--- a/src/autowiring/test/ThreadPoolTest.cpp
+++ b/src/autowiring/test/ThreadPoolTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/autowiring.h>
 #include <autowiring/ManualThreadPool.h>

--- a/src/autowiring/test/TupleTest.cpp
+++ b/src/autowiring/test/TupleTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/auto_tuple.h>
 #include <string>

--- a/src/autowiring/test/TypeRegistryTest.cpp
+++ b/src/autowiring/test/TypeRegistryTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/autowiring.h>
 #include <autowiring/GlobalCoreContext.h>

--- a/src/autowiring/test/UuidTest.cpp
+++ b/src/autowiring/test/UuidTest.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include <autowiring/uuid.h>
 

--- a/src/autowiring/test/stdafx.cpp
+++ b/src/autowiring/test/stdafx.cpp
@@ -1,2 +1,2 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"

--- a/src/autowiring/test/stdafx.h
+++ b/src/autowiring/test/stdafx.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 // Internal build flag for namespace discrimination

--- a/src/autowiring/thread_specific_ptr.h
+++ b/src/autowiring/thread_specific_ptr.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "C++11/cpp11.h"
 #include FUNCTIONAL_HEADER

--- a/src/autowiring/thread_specific_ptr_unix.cpp
+++ b/src/autowiring/thread_specific_ptr_unix.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "thread_specific_ptr.h"
 

--- a/src/autowiring/thread_specific_ptr_win.cpp
+++ b/src/autowiring/thread_specific_ptr_win.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "thread_specific_ptr.h"
 

--- a/src/autowiring/uuid.h
+++ b/src/autowiring/uuid.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 // This is a hexadecimal mapping table, represented as a string.  It's based at 0x30, the charcode for '0'

--- a/src/autowiring/var_logic.h
+++ b/src/autowiring/var_logic.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 namespace autowiring {

--- a/src/autowiring/vector_from_tuple.h
+++ b/src/autowiring/vector_from_tuple.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include "index_tuple.h"
 #include <tuple>

--- a/src/benchmark/AutoBench.cpp
+++ b/src/benchmark/AutoBench.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "Benchmark.h"
 #include "ContextSearchBm.h"

--- a/src/benchmark/Benchmark.cpp
+++ b/src/benchmark/Benchmark.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "Benchmark.h"
 #include "PrintableDuration.h"

--- a/src/benchmark/Benchmark.h
+++ b/src/benchmark/Benchmark.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <chrono>
 #include <initializer_list>

--- a/src/benchmark/ContextSearchBm.cpp
+++ b/src/benchmark/ContextSearchBm.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ContextSearchBm.h"
 #include "Benchmark.h"

--- a/src/benchmark/ContextSearchBm.h
+++ b/src/benchmark/ContextSearchBm.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 struct Benchmark;

--- a/src/benchmark/ContextTrackingBm.cpp
+++ b/src/benchmark/ContextTrackingBm.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ContextTrackingBm.h"
 #include "Benchmark.h"

--- a/src/benchmark/ContextTrackingBm.h
+++ b/src/benchmark/ContextTrackingBm.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 struct Benchmark;

--- a/src/benchmark/DispatchQueueBm.cpp
+++ b/src/benchmark/DispatchQueueBm.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "DispatchQueueBm.h"
 #include "Benchmark.h"

--- a/src/benchmark/DispatchQueueBm.h
+++ b/src/benchmark/DispatchQueueBm.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 struct Benchmark;

--- a/src/benchmark/Foo.h
+++ b/src/benchmark/Foo.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 /// <summary>

--- a/src/benchmark/ObjectPoolBm.cpp
+++ b/src/benchmark/ObjectPoolBm.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "ObjectPoolBm.h"
 #include "Benchmark.h"

--- a/src/benchmark/ObjectPoolBm.h
+++ b/src/benchmark/ObjectPoolBm.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 struct Benchmark;

--- a/src/benchmark/PrintableDuration.h
+++ b/src/benchmark/PrintableDuration.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 #include <chrono>
 #include <iostream>

--- a/src/benchmark/PriorityBoost.cpp
+++ b/src/benchmark/PriorityBoost.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "PriorityBoost.h"
 #include "Benchmark.h"

--- a/src/benchmark/PriorityBoost.h
+++ b/src/benchmark/PriorityBoost.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 struct Benchmark;

--- a/src/benchmark/stdafx.cpp
+++ b/src/benchmark/stdafx.cpp
@@ -1,2 +1,2 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"

--- a/src/benchmark/stdafx.h
+++ b/src/benchmark/stdafx.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2016 Leap Motion, Inc. All rights reserved.
+// Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #pragma once
 
 #include <autowiring/C++11/cpp11.h>


### PR DESCRIPTION
If we do a v1.0.5 release, we should probably update the copyright year before 2017 is over.