### PR TITLE
Fix parallel class

### DIFF
--- a/src/autowiring/DispatchQueue.h
+++ b/src/autowiring/DispatchQueue.h
@@ -154,7 +154,7 @@ public:
   /// In a synchronized context, all attached lambdas are guaranteed to be called when this function returns.
   /// No guarantees are made in an unsynchronized context.
   ///
-  /// Any delayed dispatchers that are ready at the time of the call will be invoked.  All oter delayed
+  /// Any delayed dispatchers that are ready at the time of the call will be invoked.  All other delayed
   /// dispatchers will be aborted.
   ///
   /// If a dispatcher throws any exception other than dispatch_aborted_exception, the remaining dispatchers

--- a/src/autowiring/Parallel.cpp
+++ b/src/autowiring/Parallel.cpp
@@ -30,7 +30,7 @@ parallel::parallel(CoreContext& ctxt, size_t concurrency):
   while (concurrency--)
     std::thread(
       [block] {
-        while(block->owned)
+        for(;;)
           try { block->dq.WaitForEvent(); }
           catch(dispatch_aborted_exception&) {
             // Expected behavior, things tearing down, end here
@@ -42,11 +42,6 @@ parallel::parallel(CoreContext& ctxt, size_t concurrency):
   // Configure our signal after everything else is done
   onStopReg = ctxt.onShutdown += [this, block] {
     std::lock_guard<std::mutex> lk(block->m_lock);
-    if (!block->owned)
-      // Status block already destroyed, we're in a teardown race
-      // Short-circuit here, no reason to double-call stop
-      return;
-
     stop_unsafe();
   };
 }
@@ -68,7 +63,6 @@ void parallel::stop_unsafe(void) {
   if (!m_block)
     return;
 
-  m_block->owned = false;
   m_ctxt->onShutdown -= onStopReg;
   m_ctxt.reset();
   m_block->dq.Rundown();

--- a/src/autowiring/Parallel.cpp
+++ b/src/autowiring/Parallel.cpp
@@ -56,7 +56,10 @@ parallel::~parallel(void) {
 }
 
 void parallel::stop(void) {
-  std::lock_guard<std::mutex> lk(m_block->m_lock);
+  auto block = m_block;
+  if (!block)
+    return;
+  std::lock_guard<std::mutex> lk(block->m_lock);
   stop_unsafe();
 }
 
@@ -68,5 +71,6 @@ void parallel::stop_unsafe(void) {
   m_block->owned = false;
   m_ctxt->onShutdown -= onStopReg;
   m_ctxt.reset();
+  m_block->dq.Rundown();
   m_block.reset();
 }

--- a/src/autowiring/Parallel.h
+++ b/src/autowiring/Parallel.h
@@ -262,9 +262,6 @@ protected:
     std::condition_variable m_queueUpdated;
     std::unordered_map<auto_id, std::deque<AnySharedPointer>> m_queue;
 
-    // Holds true as long as the owner exists; false once the owner has been destroyed
-    bool owned = true;
-
     // Dispatch queue containing input items:
     DispatchQueue dq;
 


### PR DESCRIPTION
Threads were leaking due to `DispatchQueue::WaitForEvent` waiting forever for each thread. The fix was to `Rundown` the dispatch queue, causing `WaitForEvent` to abort both existing and future calls.