### PR TITLE
Workaround approximate use_count in std::shared_ptr

### DIFF
--- a/src/autotesting/AutowiringEnclosure.h
+++ b/src/autotesting/AutowiringEnclosure.h
@@ -62,10 +62,10 @@ namespace autowiring {
     }
 
     template<typename T, typename Duration>
-    inline bool WaitForUseCount(const std::shared_ptr<T>& sptr, long useCount, Duration duration) {
+    inline bool WaitForUseCount(const T& type, long useCount, Duration duration) {
       const auto limit = std::chrono::steady_clock::now() + duration;
       do {
-        if (useCount == sptr.use_count()) return true;
+        if (useCount == type.use_count()) return true;
         std::this_thread::yield();
       } while (std::chrono::steady_clock::now() < limit);
       return false;

--- a/src/autowiring/test/ContextCleanupTest.cpp
+++ b/src/autowiring/test/ContextCleanupTest.cpp
@@ -2,6 +2,7 @@
 #include "stdafx.h"
 #include "TestFixtures/SimpleObject.hpp"
 #include "TestFixtures/SimpleThreaded.hpp"
+#include "autotesting/AutowiringEnclosure.h"
 #include <autowiring/autowiring.h>
 #include <autowiring/CoreContext.h>
 #include THREAD_HEADER
@@ -19,7 +20,7 @@ TEST_F(ContextCleanupTest, ValidateTeardownOrder) {
 
     std::weak_ptr<WeakPtrChecker> self;
   };
-  
+
   // Construct, the destroy
   std::make_shared<WeakPtrChecker>();
 }
@@ -227,6 +228,5 @@ TEST_F(ContextCleanupTest, VerifyThreadShutdownInterleave) {
   ctxt->SignalShutdown(true);
 
   // At this point, the thread must have returned AND released its shared pointer to the enclosing context
-  ASSERT_EQ(initCount, ctxt.use_count()) << "Context thread persisted even after it should have fallen out of scope";
+  ASSERT_TRUE(autowiring::autotesting::WaitForUseCount(ctxt, initCount, std::chrono::seconds(5))) << "Context thread persisted even after it should have fallen out of scope";
 }
-

--- a/src/autowiring/test/ContextMapTest.cpp
+++ b/src/autowiring/test/ContextMapTest.cpp
@@ -2,6 +2,7 @@
 #include "stdafx.h"
 #include "TestFixtures/ExitRaceThreaded.hpp"
 #include "TestFixtures/SimpleThreaded.hpp"
+#include "autotesting/AutowiringEnclosure.h"
 #include <autowiring/autowiring.h>
 #include <autowiring/ContextMap.h>
 #include <string>
@@ -76,11 +77,11 @@ TEST_F(ContextMapTest, VerifyWithThreads) {
     // Terminate whole context, wait for it to respond
     context->SignalShutdown();
     context->Wait();
-    ASSERT_EQ(1UL, context.use_count()) << "Context reference should have been unique after thread expiration";
+    ASSERT_TRUE(autowiring::autotesting::WaitForUseCount(context, 1L, std::chrono::seconds(5))) << "Context reference should have been unique after thread expiration";
   }
 
   // Release our threaded entity:
-  ASSERT_EQ(1UL, threaded.use_count()) << "Thread was holding a self-reference even after context termination has completed";
+  ASSERT_TRUE(autowiring::autotesting::WaitForUseCount(threaded, 1L, std::chrono::seconds(5))) << "Thread was holding a self-reference even after context termination has completed";
   threaded.reset();
   ASSERT_TRUE(weakContext.expired()) << "Context still existed even after the last reference to it should have been gone";
 

--- a/src/autowiring/test/CoreThreadTest.cpp
+++ b/src/autowiring/test/CoreThreadTest.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "TestFixtures/SimpleThreaded.hpp"
+#include "autotesting/AutowiringEnclosure.h"
 #include <autowiring/at_exit.h>
 #include <autowiring/autowiring.h>
 #include <algorithm>
@@ -570,7 +571,7 @@ TEST_F(CoreThreadTest, ContextWaitTimesOutInOnStop) {
   // Let BIOS back out now:
   bios->Continue();
   ASSERT_TRUE(ctxt->Wait(std::chrono::seconds(5))) << "Context did not complete in a timely fashion";
-  ASSERT_EQ(2UL, ctxt.use_count()) << "Entity held a context shared pointer after teardown has taken place";
+  ASSERT_TRUE(autowiring::autotesting::WaitForUseCount(ctxt, 2L, std::chrono::seconds(1))) << "Entity held a context shared pointer after teardown has taken place";
 }
 
 TEST_F(CoreThreadTest, SubContextHoldsParentContext) {

--- a/src/autowiring/test/CoreThreadTest.cpp
+++ b/src/autowiring/test/CoreThreadTest.cpp
@@ -571,7 +571,7 @@ TEST_F(CoreThreadTest, ContextWaitTimesOutInOnStop) {
   // Let BIOS back out now:
   bios->Continue();
   ASSERT_TRUE(ctxt->Wait(std::chrono::seconds(5))) << "Context did not complete in a timely fashion";
-  ASSERT_TRUE(autowiring::autotesting::WaitForUseCount(ctxt, 2L, std::chrono::seconds(1))) << "Entity held a context shared pointer after teardown has taken place";
+  ASSERT_TRUE(autowiring::autotesting::WaitForUseCount(ctxt, 2L, std::chrono::seconds(5))) << "Entity held a context shared pointer after teardown has taken place";
 }
 
 TEST_F(CoreThreadTest, SubContextHoldsParentContext) {


### PR DESCRIPTION
According to the C++ documentation on `std::shared_ptr::use_count()` function, the value returned is approximate in a multithreaded environment. Some tests are expecting an exact count, so adjust tests to allow the count to become _correct_ within a specified amount of time.