### PR TITLE
Fix more nagging bugs

### DIFF
--- a/src/autowiring/BasicThreadStateBlock.cpp
+++ b/src/autowiring/BasicThreadStateBlock.cpp
@@ -1,10 +1,12 @@
 // Copyright (C) 2012-2017 Leap Motion, Inc. All rights reserved.
 #include "stdafx.h"
 #include "BasicThreadStateBlock.h"
+#include "BasicThread.h"
 
 using namespace autowiring;
 
-BasicThreadStateBlock::BasicThreadStateBlock(void)
+BasicThreadStateBlock::BasicThreadStateBlock(void) :
+  m_priority{ ThreadPriority::Default }
 {}
 
 BasicThreadStateBlock::~BasicThreadStateBlock(void)

--- a/src/autowiring/BasicThreadStateBlock.h
+++ b/src/autowiring/BasicThreadStateBlock.h
@@ -4,6 +4,8 @@
 #include MUTEX_HEADER
 #include THREAD_HEADER
 
+enum class ThreadPriority;
+
 namespace autowiring {
 
 struct BasicThreadStateBlock:
@@ -12,12 +14,17 @@ struct BasicThreadStateBlock:
   BasicThreadStateBlock(void);
   ~BasicThreadStateBlock(void);
 
+  // Lock used to protect the actual thread
+  std::mutex m_threadLock;
+
   // General purpose thread lock and update condition for the lock
   std::mutex m_lock;
   std::condition_variable m_stateCondition;
 
   // The current thread, if running
   std::thread m_thisThread;
+
+  ThreadPriority m_priority;
 
   // Completion condition, true when this thread is no longer running and has run at least once
   bool m_completed = false;

--- a/src/autowiring/CoreContextStateBlock.cpp
+++ b/src/autowiring/CoreContextStateBlock.cpp
@@ -34,6 +34,7 @@ RunCounter::~RunCounter(void) {
     outstanding = std::move(stateBlock->m_outstanding);
     stateBlock->m_outstanding.reset();
   }
+  outstanding.reset();
 
   // Wake everyone up
   stateBlock->m_stateChanged.notify_all();

--- a/src/autowiring/CoreThread.h
+++ b/src/autowiring/CoreThread.h
@@ -38,9 +38,11 @@ public:
 
 protected:
   /// <summary>
-  /// While stopping, make sure we do it exclusively
+  /// While stopping, make sure we do it cleanly
   /// </summary>
   std::mutex m_stoppingLock;
+  std::condition_variable m_stoppingCond;
+  bool m_onStopCompleted = false;
 
   /// <summary>
   /// Overridden here so we can rundown the dispatch queue

--- a/src/autowiring/CoreThreadLinux.cpp
+++ b/src/autowiring/CoreThreadLinux.cpp
@@ -28,7 +28,7 @@ void BasicThread::GetThreadTimes(std::chrono::milliseconds& kernelTime, std::chr
   userTime = std::chrono::duration_cast<milliseconds>(seconds(usage.ru_utime.tv_sec) + microseconds(usage.ru_utime.tv_usec));
 }
 
-void BasicThread::SetThreadPriority(ThreadPriority threadPriority) {
+void BasicThread::SetThreadPriority(const std::thread::native_handle_type& handle, ThreadPriority threadPriority) {
   struct sched_param param = { 0 };
   int policy = SCHED_OTHER;
   int percent = 0;
@@ -66,8 +66,7 @@ void BasicThread::SetThreadPriority(ThreadPriority threadPriority) {
     throw std::invalid_argument("Attempted to assign an unrecognized thread priority");
   }
   min_priority = sched_get_priority_min(policy);
-  pthread_getschedparam(m_state->m_thisThread.native_handle(), &policy, &param);
+  pthread_getschedparam(handle, &policy, &param);
   param.sched_priority = min_priority + (percent * (sched_get_priority_max(policy) - min_priority) + 50) / 100;
-  pthread_setschedparam(m_state->m_thisThread.native_handle(), policy, &param);
-  m_priority = threadPriority;
+  pthread_setschedparam(handle, policy, &param);
 }

--- a/src/autowiring/CoreThreadMac.cpp
+++ b/src/autowiring/CoreThreadMac.cpp
@@ -52,7 +52,7 @@ void BasicThread::GetThreadTimes(std::chrono::milliseconds& kernelTime, std::chr
   userTime = std::chrono::duration_cast<milliseconds>(nanoseconds(info.pth_user_time));
 }
 
-void BasicThread::SetThreadPriority(ThreadPriority threadPriority) {
+void BasicThread::SetThreadPriority(const std::thread::native_handle_type& handle, ThreadPriority threadPriority) {
   struct sched_param param = { 0 };
   int policy = SCHED_OTHER;
   int percent = 0;
@@ -84,8 +84,7 @@ void BasicThread::SetThreadPriority(ThreadPriority threadPriority) {
   default:
     throw std::invalid_argument("Attempted to assign an unrecognized thread priority");
   }
-  pthread_getschedparam(m_state->m_thisThread.native_handle(), &policy, &param);
+  pthread_getschedparam(handle, &policy, &param);
   param.sched_priority = PTHREAD_MIN_PRIORITY + (percent*(PTHREAD_MAX_PRIORITY - PTHREAD_MIN_PRIORITY) + 50) / 100;
-  pthread_setschedparam(m_state->m_thisThread.native_handle(), policy, &param);
-  m_priority = threadPriority;
+  pthread_setschedparam(handle, policy, &param);
 }

--- a/src/autowiring/CoreThreadWin.cpp
+++ b/src/autowiring/CoreThreadWin.cpp
@@ -60,7 +60,7 @@ bool SetCapturePriority(void) {
   return true;
 }
 
-void BasicThread::SetThreadPriority(ThreadPriority threadPriority) {
+void BasicThread::SetThreadPriority(const std::thread::native_handle_type& handle, ThreadPriority threadPriority) {
   int nPriority;
   switch(threadPriority) {
   case ThreadPriority::Idle:
@@ -98,10 +98,9 @@ void BasicThread::SetThreadPriority(ThreadPriority threadPriority) {
   }
 
   ::SetThreadPriority(
-    m_state->m_thisThread.native_handle(),
+    handle,
     nPriority
   );
-  m_priority = threadPriority;
 }
 
 std::chrono::steady_clock::time_point BasicThread::GetCreationTime(void) {

--- a/src/autowiring/test/CoreThreadTest.cpp
+++ b/src/autowiring/test/CoreThreadTest.cpp
@@ -655,8 +655,14 @@ TEST_F(CoreThreadTest, CanElevateAnyPriority) {
   AutoRequired<CoreThread> ct;
   ctxt->Initiate();
 
+  const auto origPriority = ct->GetThreadPriority();
   for (int i = (int)ThreadPriority::Default; i < (int)ThreadPriority::Multimedia; i++) {
-    BasicThread::ElevatePriority ep{ *ct, (ThreadPriority)i };
-    ASSERT_EQ((ThreadPriority)i, ct->GetThreadPriority());
+    {
+      BasicThread::ElevatePriority ep{ *ct, (ThreadPriority)i };
+      ASSERT_EQ((ThreadPriority)i, ct->GetThreadPriority());
+    }
+    // Ensure that the priority is restored to its previous value:
+    ASSERT_EQ(origPriority, ct->GetThreadPriority());
   }
+  ctxt->SignalShutdown(true);
 }


### PR DESCRIPTION
This PR addresses a few remaining known issues observed in the tests when run repeatedly.

In particular, there were some timing issues with setting the thread priority that could cause the expected thread priority to be lost if set at just the wrong time.

Another issue, that was introduced in #1033, was causing calls to `CoreContext::SignalShutdown` to potentially wait for a `CoreThread` to shutdown, even if the wait flag was not set. The solution was to only wait to `Rundown` (called from the `CoreThread`'s thread) only _after_ the `CoreThread::OnStop` function is called if we are in the midst of a shutdown.

Finally, some tests were modified to clean up after themselves. Many times there were no waiting on the contexts, causing them to interfere with the next test.