### PR TITLE
Fix compatibility issues with non-Xcode 9 systems

### DIFF
--- a/src/autowiring/auto_id.h
+++ b/src/autowiring/auto_id.h
@@ -58,7 +58,7 @@ namespace autowiring {
       )
     {}
 
-#if !defined(_MSC_VER)
+#if defined(__clang__) && __clang_major__ >= 9
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wc++1z-compat-mangling"
 #endif
@@ -79,7 +79,7 @@ namespace autowiring {
       pToObj(pToObj),
       pFromObj(pFromObj)
     {}
-#if !defined(_MSC_VER)
+#if defined(__clang__) && __clang_major__ >= 9
 #pragma clang diagnostic pop
 #endif
 


### PR DESCRIPTION
_Only_ include a particular `#pragma` if using Xcode 9 or newer.