### PR TITLE
Remove references to std::tr1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ if(NOT MSVC OR MSVC_VERSION LESS 1900)
   )
 endif()
 
+add_definitions(-DGTEST_HAS_TR1_TUPLE=0)
+
 # Recurse through source directories
 include_directories(
   contrib


### PR DESCRIPTION
Visual Studio 2017 version 15.5 has [deprecated the std::tr1 namespace](https://docs.microsoft.com/en-us/cpp/cpp-conformance-improvements-2017#update_155), leading to significant warning spew. It'll also fail to compile if we set the C++17 flag. The other condition where we could require `<tr1/tuple>` would be on Android if using STLport, but we've never supported that config.

According to the [gtest docs](https://github.com/google/googletest/tree/master/googletest), setting the flag in the build flow is preferred over editing gtest.h directly.