### PR TITLE
Fix a warning in clang 5

### DIFF
--- a/src/autowiring/auto_id.h
+++ b/src/autowiring/auto_id.h
@@ -58,9 +58,13 @@ namespace autowiring {
       )
     {}
 
-#if defined(__clang__) && __clang_major__ >= 9
+#if defined(__clang__)
 #pragma clang diagnostic push
+#if __clang_major__ >= 9
 #pragma clang diagnostic ignored "-Wc++1z-compat-mangling"
+#elif __clang_major__ >= 5
+#pragma clang diagnostic ignored "-Wc++1z-compat"
+#endif
 #endif
     auto_id_block(
       int index,


### PR DESCRIPTION
-Wc++1z-compat-mangling doesn't seem to exist in the clang5 that ships with NDK 16b