### PR TITLE
Add support for adjusting the thread scheduling policy

### DIFF
--- a/src/autowiring/BasicThreadStateBlock.cpp
+++ b/src/autowiring/BasicThreadStateBlock.cpp
@@ -5,8 +5,9 @@
 
 using namespace autowiring;
 
-BasicThreadStateBlock::BasicThreadStateBlock(void) :
-  m_priority{ ThreadPriority::Default }
+BasicThreadStateBlock::BasicThreadStateBlock(ThreadPriority threadPriority, SchedulingPolicy schedPolicy) :
+  m_threadPriority{ threadPriority },
+  m_schedPolicy{ schedPolicy }
 {}
 
 BasicThreadStateBlock::~BasicThreadStateBlock(void)

--- a/src/autowiring/BasicThreadStateBlock.h
+++ b/src/autowiring/BasicThreadStateBlock.h
@@ -1,17 +1,13 @@
 // Copyright (C) 2012-2018 Leap Motion, Inc. All rights reserved.
 #pragma once
-#include MEMORY_HEADER
-#include MUTEX_HEADER
-#include THREAD_HEADER
-
-enum class ThreadPriority;
+#include "BasicThread.h"
 
 namespace autowiring {
 
 struct BasicThreadStateBlock:
   std::enable_shared_from_this<BasicThreadStateBlock>
 {
-  BasicThreadStateBlock(void);
+  BasicThreadStateBlock(ThreadPriority threadPriority, SchedulingPolicy schedPolicy);
   ~BasicThreadStateBlock(void);
 
   // Lock used to protect the actual thread
@@ -24,7 +20,8 @@ struct BasicThreadStateBlock:
   // The current thread, if running
   std::thread m_thisThread;
 
-  ThreadPriority m_priority;
+  ThreadPriority m_threadPriority;
+  SchedulingPolicy m_schedPolicy;
 
   // Completion condition, true when this thread is no longer running and has run at least once
   bool m_completed = false;

--- a/src/autowiring/CoreThread.cpp
+++ b/src/autowiring/CoreThread.cpp
@@ -8,6 +8,14 @@ CoreThread::CoreThread(const char* pName):
   BasicThread(pName)
 {}
 
+CoreThread::CoreThread(ThreadPriority threadPriority, const char* pName):
+  BasicThread(threadPriority, pName)
+{}
+
+CoreThread::CoreThread(ThreadPriority threadPriority, SchedulingPolicy schedPolicy, const char* pName):
+  BasicThread(threadPriority, schedPolicy, pName)
+{}
+
 CoreThread::~CoreThread(void){}
 
 void CoreThread::DoRunLoopCleanup(std::shared_ptr<CoreContext>&& ctxt, std::shared_ptr<CoreObject>&& refTracker) {

--- a/src/autowiring/CoreThread.h
+++ b/src/autowiring/CoreThread.h
@@ -34,6 +34,20 @@ public:
   /// The name assigned to a thread is visible in some debuggers.
   /// <param name="pName">An optional name for this thread.</param>
   CoreThread(const char* pName = nullptr);
+  /// Constructs a core thread object with priority and a name.
+  ///
+  /// The name assigned to a thread is visible in some debuggers.
+  /// <param name="threadPriority">A priority for this thread.</param>
+  /// <param name="pName">An optional name for this thread.</param>
+  CoreThread(ThreadPriority threadPriority, const char* pName = nullptr);
+  /// Constructs a core thread object with priority, scheduling policy,
+  /// and a name.
+  ///
+  /// The name assigned to a thread is visible in some debuggers.
+  /// <param name="threadPriority">A priority for this thread.</param>
+  /// <param name="schedPolicy">A scheduling policy for this thread.</param>
+  /// <param name="pName">An optional name for this thread.</param>
+  CoreThread(ThreadPriority threadPriority, SchedulingPolicy schedPolicy, const char* pName = nullptr);
   virtual ~CoreThread(void);
 
 protected:

--- a/src/autowiring/CoreThreadWin.cpp
+++ b/src/autowiring/CoreThreadWin.cpp
@@ -60,7 +60,7 @@ bool SetCapturePriority(void) {
   return true;
 }
 
-void BasicThread::SetThreadPriority(const std::thread::native_handle_type& handle, ThreadPriority threadPriority) {
+void BasicThread::SetThreadPriority(const std::thread::native_handle_type& handle, ThreadPriority threadPriority, SchedulingPolicy schedPolicy) {
   int nPriority;
   switch(threadPriority) {
   case ThreadPriority::Idle:


### PR DESCRIPTION
In order to properly get thread priorities working on Unix-like operating systems, a realtime scheduler needs to be used. This PR provides the ability to adjust the scheduler to be used when creating a new thread.