### PR TITLE
Fix MSVC signed/unsigned mismatch warning

### DIFF
--- a/src/autowiring/test/CoreJobTest.cpp
+++ b/src/autowiring/test/CoreJobTest.cpp
@@ -191,7 +191,7 @@ TEST_F(CoreJobTest, PendFromMultipleThreads) {
   for (size_t i = 0; i < threads.size(); i++) {
     threads[i] = std::thread([&] {
       ctxt->DelayUntilInitiated();
-      for (int j = 0; j < times; j++) {
+      for (size_t j = 0; j < times; j++) {
         *cj += [&counter] {
           counter++; // Should be updated exclusively in the CoreJob's thread
         };


### PR DESCRIPTION
This came up in a latest round of testing. Seems to have crept in with 1.0.5 when we cleaned up a whole bunch of race conditions and tests.