### PR TITLE
Bump version number to 1.0.6

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -32,7 +32,7 @@ PROJECT_NAME           = Autowiring
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = "1.0.5"
+PROJECT_NUMBER         = "1.0.6"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer

--- a/publicDoxyfile.conf
+++ b/publicDoxyfile.conf
@@ -38,7 +38,7 @@ PROJECT_NAME           = Autowiring
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.0.5
+PROJECT_NUMBER         = 1.0.6
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/version.cmake
+++ b/version.cmake
@@ -1,1 +1,1 @@
-set(autowiring_VERSION 1.0.5)
+set(autowiring_VERSION 1.0.6)


### PR DESCRIPTION
Changes since 1.0.5:

#1037 Remove references to std::tr1
#1038 Update copyright year
#1040 Fix a compiler error on VS2017
#1041 Fix a warning in clang 5
#1043 Alignment make share fix
#1044 Add support for adjusting the thread scheduling policy
#1045 Fixes various issues with android and cross compiling toolchains
#1046 Fix MSVC signed/unsigned mismatch warning