### PR TITLE
Remove "Unknown compiler version" warnings on MSVC

### DIFF
--- a/contrib/autoboost/autoboost/config/compiler/visualc.hpp
+++ b/contrib/autoboost/autoboost/config/compiler/visualc.hpp
@@ -288,11 +288,4 @@
 #endif
 
 //
-// last known and checked version is 19.00.23026 (VC++ 2015 RTM):
-#if (_MSC_VER > 1900)
-#  if defined(AUTOBOOST_ASSERT_CONFIG)
-#     error "Unknown compiler version - please run the configure tests and report the results"
-#  else
-#     pragma message("Unknown compiler version - please run the configure tests and report the results")
-#  endif
-#endif
+// last known and checked version is VC++ 2017 Version 15.6.0 Preview 5.0 (1913)


### PR DESCRIPTION
Starting with MSVC 2017 we've been spamming the logs with this:
```
Unknown compiler version - please run the configure tests and report the results
```
which comes from boost (autoboost). However, this warning is unhelpful because autoboost does not contain boost's "configure tests".

We could raise the threshold version number (1913 to be current, or higher) but that would defer to problem. Better to follow `gcc.hpp` and `clang.hpp` which do not emit warnings for untested compiler versions. When we do hit a compiler error, we'll know.