### PR TITLE
Allow building with newer standards than C++11 on non-MSVC platforms

### DIFF
--- a/src/autowiring/C++11/memory.h
+++ b/src/autowiring/C++11/memory.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-// MSVC already implements make_unique
-#ifndef _MSC_VER
+// MSVC and C++14 already implements make_unique
+#if !defined(_MSC_VER) && (__cplusplus < 201402L)
   #include "make_unique.h"
 #endif


### PR DESCRIPTION
We were incorrectly including our own version of `make_unique.h` when building with C++14 or newer on non-MSVC platforms.