### PR TITLE
Modify code to support C++17

### DIFF
--- a/contrib/autoboost/autoboost/operators.hpp
+++ b/contrib/autoboost/autoboost/operators.hpp
@@ -884,6 +884,21 @@ template <class T> struct operators<T, T>
 //  Iterator helper classes (contributed by Jeremy Siek) -------------------//
 //  (Input and output iterator helpers contributed by Daryle Walker) -------//
 //  (Changed to use combined operator classes by Daryle Walker) ------------//
+//  (Adapted to C++17 by Daniel Frey) --------------------------------------//
+template <class Category,
+          class T,
+          class Distance = std::ptrdiff_t,
+          class Pointer = T*,
+          class Reference = T&>
+struct iterator_helper
+{
+  typedef Category iterator_category;
+  typedef T value_type;
+  typedef Distance difference_type;
+  typedef Pointer pointer;
+  typedef Reference reference;
+};
+
 template <class T,
           class V,
           class D = std::ptrdiff_t,
@@ -891,13 +906,13 @@ template <class T,
           class R = V const &>
 struct input_iterator_helper
   : input_iteratable<T, P
-  , autoboost::iterator<std::input_iterator_tag, V, D, P, R
+  , autoboost::iterator_helper<std::input_iterator_tag, V, D, P, R
     > > {};
 
 template<class T>
 struct output_iterator_helper
   : output_iteratable<T
-  , autoboost::iterator<std::output_iterator_tag, void, void, void, void
+  , autoboost::iterator_helper<std::output_iterator_tag, void, void, void, void
   > >
 {
   T& operator*()  { return static_cast<T&>(*this); }
@@ -911,7 +926,7 @@ template <class T,
           class R = V&>
 struct forward_iterator_helper
   : forward_iteratable<T, P
-  , autoboost::iterator<std::forward_iterator_tag, V, D, P, R
+  , autoboost::iterator_helper<std::forward_iterator_tag, V, D, P, R
     > > {};
 
 template <class T,
@@ -921,7 +936,7 @@ template <class T,
           class R = V&>
 struct bidirectional_iterator_helper
   : bidirectional_iteratable<T, P
-  , autoboost::iterator<std::bidirectional_iterator_tag, V, D, P, R
+  , autoboost::iterator_helper<std::bidirectional_iterator_tag, V, D, P, R
     > > {};
 
 template <class T,
@@ -931,7 +946,7 @@ template <class T,
           class R = V&>
 struct random_access_iterator_helper
   : random_access_iteratable<T, P, D, R
-  , autoboost::iterator<std::random_access_iterator_tag, V, D, P, R
+  , autoboost::iterator_helper<std::random_access_iterator_tag, V, D, P, R
     > >
 {
   friend D requires_difference_operator(const T& x, const T& y) {

--- a/contrib/websocketpp/websocketpp/common/memory.hpp
+++ b/contrib/websocketpp/websocketpp/common/memory.hpp
@@ -65,7 +65,6 @@ namespace lib {
 #ifdef _WEBSOCKETPP_CPP11_MEMORY_
     using std::shared_ptr;
     using std::weak_ptr;
-    using std::auto_ptr;
     using std::enable_shared_from_this;
     using std::static_pointer_cast;
     using std::make_shared;
@@ -75,7 +74,6 @@ namespace lib {
 #else
     using autoboost::shared_ptr;
     using autoboost::weak_ptr;
-    using std::auto_ptr;
     using autoboost::enable_shared_from_this;
     using autoboost::static_pointer_cast;
     using autoboost::make_shared;

--- a/contrib/websocketpp/websocketpp/utilities.hpp
+++ b/contrib/websocketpp/websocketpp/utilities.hpp
@@ -72,10 +72,9 @@ private:
  * Based on code from
  * http://stackoverflow.com/questions/3152241/case-insensitive-stdstring-find
  */
-struct ci_less : std::binary_function<std::string, std::string, bool> {
+struct ci_less {
     // case-independent (ci) compare_less binary function
     struct nocase_compare
-      : public std::binary_function<unsigned char,unsigned char,bool>
     {
         bool operator() (unsigned char const & c1, unsigned char const & c2) const {
             return tolower (c1) < tolower (c2);

--- a/src/autowiring/test/ContextEnumeratorTest.cpp
+++ b/src/autowiring/test/ContextEnumeratorTest.cpp
@@ -2,6 +2,7 @@
 #include "stdafx.h"
 #include <autowiring/ContextEnumerator.h>
 #include <algorithm>
+#include <random>
 #include MEMORY_HEADER
 #include STL_UNORDERED_SET
 
@@ -110,7 +111,7 @@ TEST_F(ContextEnumeratorTest, VerifyComplexEnumeration) {
   // Verify global context structure
   auto enumerator = ContextEnumeratorT<NamedContext>(AutoGlobalContext());
   size_t globalCount = std::distance(enumerator.begin(), enumerator.end());
-  
+
   ASSERT_EQ(globalCount, 2UL) << "Expected exactly one context in the parent context, found " << globalCount;
 }
 
@@ -146,7 +147,9 @@ TEST_F(ContextEnumeratorTest, ComplexRemovalInterference) {
     children.push_back(AutoCreateContext());
 
   // Shuffle the collection to prevent the order here from being equivalent to the order in the context
-  std::random_shuffle(children.begin(), children.end());
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::shuffle(children.begin(), children.end(), gen);
 
   // These are the elements actually encountered in the enumeration, held here to prevent expiration in the
   // event that we enumerate a context which should have already been evicted
@@ -158,7 +161,7 @@ TEST_F(ContextEnumeratorTest, ComplexRemovalInterference) {
   // Go through the enumeration, the totals should line up by the time we're done:
   for(const auto& cur : CurrentContextEnumerator()) {
     enumerated.insert(cur);
-    
+
     // Pull off the last element:
     auto removed = children.back();
     children.pop_back();


### PR DESCRIPTION
With the release of C++17, several already deprecated STL functions have been removed. In order to support compilers that adhere strictly to the standard, this PR removes use of those old functions.