### PR TITLE
Fix std::filesystem conflict with /std:c++17

### DIFF
--- a/src/autowiring/C++11/filesystem.h
+++ b/src/autowiring/C++11/filesystem.h
@@ -4,7 +4,7 @@
 //C++17 Filesystem standard
 #if defined(_MSC_VER) && _MSC_VER >= 1900
   #include <filesystem>
-  #if _MSC_VER >= 1914 && __cplusplus >= 201402L
+  #if _MSC_VER >= 1914 && _HAS_CXX17
     // VS 2017 15.7 Preview 2 or newer with /std:c++17
     namespace awfsnamespace = std::filesystem;
   #elif _MSC_VER >= 1910
@@ -18,7 +18,7 @@
 namespace awfsnamespace = autoboost::filesystem;
 #endif
 
-#if !defined(_MSC_VER) || _MSC_VER < 1914 || __cplusplus < 201402L
+#if !defined(_MSC_VER) || _MSC_VER < 1914 || !_HAS_CXX17
 namespace std {
   namespace filesystem {
     using awfsnamespace::path;

--- a/src/autowiring/C++11/filesystem.h
+++ b/src/autowiring/C++11/filesystem.h
@@ -4,7 +4,9 @@
 //C++17 Filesystem standard
 #if defined(_MSC_VER) && _MSC_VER >= 1900
   #include <filesystem>
-#if _MSC_VER >= 1910
+  #if _MSC_VER >= 1914
+    namespace awfsnamespace = std::filesystem;
+  #elif _MSC_VER >= 1910
     namespace awfsnamespace = std::experimental::filesystem;
   #else
     namespace awfsnamespace = std::tr2::sys;
@@ -15,6 +17,7 @@
 namespace awfsnamespace = autoboost::filesystem;
 #endif
 
+#if !defined(_MSC_VER) || _MSC_VER < 1914
 namespace std {
   namespace filesystem {
     using awfsnamespace::path;
@@ -33,3 +36,4 @@ namespace std {
     using awfsnamespace::temp_directory_path;
   }
 }
+#endif

--- a/src/autowiring/C++11/filesystem.h
+++ b/src/autowiring/C++11/filesystem.h
@@ -4,7 +4,7 @@
 //C++17 Filesystem standard
 #if defined(_MSC_VER) && _MSC_VER >= 1900
   #include <filesystem>
-  #if _MSC_VER >= 1914 && _HAS_CXX17
+  #if _MSC_VER >= 1914 && _MSVC_LANG >= 201402L
     // VS 2017 15.7 Preview 2 or newer with /std:c++17
     namespace awfsnamespace = std::filesystem;
   #elif _MSC_VER >= 1910
@@ -18,7 +18,7 @@
 namespace awfsnamespace = autoboost::filesystem;
 #endif
 
-#if !defined(_MSC_VER) || _MSC_VER < 1914 || !_HAS_CXX17
+#if !defined(_MSC_VER) || _MSC_VER < 1914 || _MSVC_LANG < 201402L
 namespace std {
   namespace filesystem {
     using awfsnamespace::path;

--- a/src/autowiring/C++11/filesystem.h
+++ b/src/autowiring/C++11/filesystem.h
@@ -4,7 +4,8 @@
 //C++17 Filesystem standard
 #if defined(_MSC_VER) && _MSC_VER >= 1900
   #include <filesystem>
-  #if _MSC_VER >= 1914
+  #if _MSC_VER >= 1914 && __cplusplus >= 201402L
+    // VS 2017 15.7 Preview 2 or newer with /std:c++17
     namespace awfsnamespace = std::filesystem;
   #elif _MSC_VER >= 1910
     namespace awfsnamespace = std::experimental::filesystem;
@@ -17,7 +18,7 @@
 namespace awfsnamespace = autoboost::filesystem;
 #endif
 
-#if !defined(_MSC_VER) || _MSC_VER < 1914
+#if !defined(_MSC_VER) || _MSC_VER < 1914 || __cplusplus < 201402L
 namespace std {
   namespace filesystem {
     using awfsnamespace::path;


### PR DESCRIPTION
Visual Studio 2017 15.7.0 Preview 2.0 adds support for std::filesystem when building in C++17 mode, leading to conflicts that this PR resolves.

Although we are currently looking to remove filesystem-related code from Autowiring, that is not trivial because LeapIPC currently depends on this functionality. If it didn't, LeapIPC would either have to link in Boost directly or drop its support for C++14 and older, something we may resort to at a later time.

- [ ] Fixes #1051