### PR TITLE
Fix C++17 check with /std:c++17

### DIFF
--- a/src/autowiring/C++11/filesystem.h
+++ b/src/autowiring/C++11/filesystem.h
@@ -4,7 +4,7 @@
 //C++17 Filesystem standard
 #if defined(_MSC_VER) && _MSC_VER >= 1900
   #include <filesystem>
-  #if _MSC_VER >= 1914 && _MSVC_LANG >= 201402L
+  #if _MSC_VER >= 1914 && _MSVC_LANG >= 201703L
     // VS 2017 15.7 Preview 2 or newer with /std:c++17
     namespace awfsnamespace = std::filesystem;
   #elif _MSC_VER >= 1910


### PR DESCRIPTION
It's not clear how this ended up incorrect in #1056. Possibly I pasted from the wrong place, or Preview 1.0 behaved differently. In any case this works on Visual Studio 2017 v15.7.0 Preview 2.0 and 3.0