### PR TITLE
Additional fix std::filesystem with /std:c++17

### DIFF
--- a/src/autowiring/C++11/filesystem.h
+++ b/src/autowiring/C++11/filesystem.h
@@ -18,7 +18,7 @@
 namespace awfsnamespace = autoboost::filesystem;
 #endif
 
-#if !defined(_MSC_VER) || _MSC_VER < 1914 || _MSVC_LANG < 201402L
+#if !defined(_MSC_VER) || _MSC_VER < 1914 || _MSVC_LANG < 201703L
 namespace std {
   namespace filesystem {
     using awfsnamespace::path;


### PR DESCRIPTION
The change in #1058 was incomplete as this constant is checked in two places. Fix it in the second one as well.

- [ ] Fixes #1059 i.e. actually fixes #1056 