### PR TITLE
Include <stdexcept> in autowiring/auto_signal.h

### DIFF
--- a/src/autowiring/auto_signal.h
+++ b/src/autowiring/auto_signal.h
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <stdexcept>
 #include TYPE_TRAITS_HEADER
 
 /// <summary>


### PR DESCRIPTION
... to use `std::runtime_error`.

Fixes #1067.