### PR TITLE
[Bug] Fix buffer-overflow in `SetThreadName`

### DIFF
--- a/src/autowiring/CoreThreadWin.cpp
+++ b/src/autowiring/CoreThreadWin.cpp
@@ -34,7 +34,7 @@ void SetThreadName(DWORD dwThreadID, LPCSTR szThreadName)
   __try
   {
     // Magic exception which informs the OS of this thread's name
-    RaiseException(0x406D1388, 0, sizeof(info)/sizeof(DWORD), (ULONG_PTR*)&info);
+    RaiseException(0x406D1388, 0, sizeof(info)/sizeof(ULONG_PTR), (ULONG_PTR*)&info);
   }
   __except(EXCEPTION_CONTINUE_EXECUTION)
   {


### PR DESCRIPTION
By running msvc's ASan on this project, we detected a buffer-overflow error in `RaiseException` call in `CoreThreadWin`'s `SetThreadName`.

See the relevant bit below

```C++
void SetThreadName(DWORD dwThreadID, LPCSTR szThreadName)
{
  THREADNAME_INFO info;
  info.dwType = 0x1000;
  info.szName = szThreadName;
  info.dwThreadID = dwThreadID;
  info.dwFlags = 0;

  __try
  {
    // Magic exception which informs the OS of this thread's name
    RaiseException(0x406D1388, 0, sizeof(info)/sizeof(DWORD), (ULONG_PTR*)&info);
  }
  __except(EXCEPTION_CONTINUE_EXECUTION)
  {
  }
}
```

This method follows the pattern outlined in [these docs](https://learn.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2015/debugger/how-to-set-a-thread-name-in-native-code?view=vs-2015&redirectedfrom=MSDN) with one difference, it is dividing `sizeof(info)` by `sizeof(DWORD)` instead of `sizeof(ULONG_PTR)`.

This difference is _fine_ for 32-bit architectures (1 pointer  = 1 DWORD, or 4 bytes), but not for 64 bit,  where 1 pointer is 2 DWORDS (8 bytes).

This PR aims to correct this minor arithmetic error, so it works across all architectures. Thanks!